### PR TITLE
Add Zotero-style annotations and improve PDF annotation features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Agentero 是一个基于 Tauri 2 + React 19 的本地优先科研工作台。Vau
 - **Agent 权限**：设置 → Agent **全局权限模式**（受限默认 / 自动批准）；非 per-provider YOLO。逐项「每次询问」仍待。
 - 文件树：右键 / `⌥⌘R` 在 Finder 中显示（无双击）；右键 / `⌥⌘T` 在终端中打开（文件夹 = 自身 cwd，文件 = 父目录；系统默认终端）；多选（⌘/Shift）+ 拖拽移动；**删除**走回收站（`path_trash` → `.agentero/.trash/`，**无确认 / 无 Undo toast**）；侧栏 `Trash2` 打开中间栏回收站视图（恢复 / 永久删除 / 清空）。
 - 论文库：**Rescan**（`paper_rescan`）从 `papers/` + `metadata.json` 补齐盘上有、catalog 无的条目。
-- PDF：Vault **任意路径** `.pdf` → `blob:` 预览；论文单元本地优先 → 自动下载 → 远程回退；**页码导航 / 适应宽·整页 / 大纲 / ⌘F 查找**；真实 scale 渲染 + 平滑划词覆盖层；划词操作菜单（高亮 / 笔记 / 提问 / 翻译，见 `docs/development/pdf-ask.md`）。
+- PDF：Vault **任意路径** `.pdf` → `blob:` 预览；论文单元本地优先 → 自动下载 → 远程回退；**页码导航 / 适应宽·整页 / 大纲 / ⌘F 查找**；真实 scale 渲染 + 平滑划词覆盖层；划词操作菜单（高亮 / 批注 / 提问 / 翻译，见 `docs/development/pdf-ask.md`）。**批注** = 高亮 + 内联评论（`comment`），带 comment 的高亮显示页边批注针，右侧 **批注** 面板列出当前 PDF 的批注卡（跳转 / 编辑 / 删除），不写入 `NOTES.md`。
 - 图片：常见格式任意路径 `blob:` 中间栏预览。
 - **Markdown 内嵌图片**：粘贴 / 工具栏 → `{mdDir}/assets/` + `![](./assets/…)`；选中显示源码；删节点且无引用时 GC（`src/lib/markdown-image.ts`）。
 - **外部/Agent 改动自动重载**：Host `notify` → `vault:file-changed`（`watcher.rs` / `fs-watch.ts`）；打开中的 `.md`/`NOTES.md` 磁盘内容变化则重载（**覆盖本地未存改动**，内容相等抑制自写回声）；create/remove/rename 去抖刷新文件树。

--- a/docs/backend/data-model.md
+++ b/docs/backend/data-model.md
@@ -161,15 +161,16 @@ Vault 技能种子：Create Vault 写入 `.agents/skills/paper-reader/SKILL.md`�
 - 含锚点（page + 归一化 rects + quote）与 `messages[]`；**不**写入 PDF 二进制，**不**进 catalog 正文。
 - 触发：划词 / 框选 / 双击 / 悬停；发送过问题后锚点旁对话图标可回访。
 
-### `highlights/`（已落地：PDF 划词高亮）
+### `highlights/`（已落地：PDF 划词高亮 + 批注）
 
-划词后弹出的操作菜单（**高亮 / 笔记 / 提问 / 翻译**）中，「高亮」写入的持久化标注。与多轮问答 `asks/` 分离，是纯视觉标注（不含对话）。
+划词后弹出的操作菜单（**高亮 / 批注 / 提问 / 翻译**）中，「高亮」与「批注」写入的持久化标注。与多轮问答 `asks/` 分离；「批注」= `comment` 非空的高亮（高亮 + 内联评论），纯高亮则 `comment` 为空。
 
 - 路径：`papers/<id>/highlights/<id>.json`（pretty JSON，便于 Git diff）。
-- 字段：`version:1`、`id`、`paperPath`、`createdAt/updatedAt`、`page`、归一化 `rects[]`、`quote`、可选 `color`（预留调色板，缺省琥珀）。
-- 归一化坐标可在缩放/重开后重定位；页面上点击已有高亮出现「删除」浮层。
-- **不**污染原始 PDF、**不**进 catalog；坏文件读取时跳过。
-- 「笔记」操作把选中原文以块引用 `> …` 追加进该篇 `NOTES.md`（经编辑器实例写入，避免覆盖未存改动）；「翻译」复用 asks 弹层走 Agent 流式，不额外落盘。
+- 字段：`version:1`、`id`、`paperPath`、`createdAt/updatedAt`、`page`、归一化 `rects[]`、`quote`、可选 `color`（预留调色板，缺省琥珀）、**可选 `comment?: string`**（非空 ⇒ 批注；`version` 保持 `1`，向后兼容）。
+- 归一化坐标可在缩放/重开后重定位；页面上点击已有高亮出现「删除」浮层；`comment` 非空的高亮在页边渲染**批注针**，点击打开内联编辑器读/改评论。
+- 右侧「批注」面板列出**当前活动 PDF tab** 的批注卡（页码 + 引文 + 评论），点击跳转闪烁、可编辑 / 删除；由 `PdfViewerHandle` + `onHighlightsChange` 驱动。
+- **不**污染原始 PDF、**不**进 catalog、**不**写入 `NOTES.md`（旧「追加引文到 `NOTES.md`」行为已移除）；坏文件读取时跳过。
+- 「翻译」复用 asks 弹层走 Agent 流式，不额外落盘。
 
 格式示例:
 

--- a/docs/development/pdf-ask.md
+++ b/docs/development/pdf-ask.md
@@ -1,8 +1,8 @@
 # PDF 划词提问（Selection Ask）
 
-> 状态：**MVP 已落地（前端 + 文件 IO）**；划词现先弹**操作菜单**（高亮 / 笔记 / 提问 / 翻译），不再默认套用琥珀高亮。  
-> 范围：阅读 PDF 时选中文本 → 选区操作菜单 → 分派到高亮（JSON 落盘）/ 笔记（追加 `NOTES.md`）/ 提问（迷你对话框）/ 翻译（复用对话框走 Agent）。提问线程 JSON 落盘 + 页边圆片回访（飞书式边注）。  
-> 实现入口：`src/components/viewer/pdf-viewer.tsx`、`src/components/viewer/pdf-ask/`（含 `selection-menu.tsx`、`highlight-layer.tsx`）、`src/lib/pdf-ask/`、`src/lib/pdf-highlight/`。  
+> 状态：**MVP 已落地（前端 + 文件 IO）**；划词现先弹**操作菜单**（高亮 / 批注 / 提问 / 翻译），不再默认套用琥珀高亮。  
+> 范围：阅读 PDF 时选中文本 → 选区操作菜单 → 分派到高亮（JSON 落盘）/ 批注（高亮 + 内联评论）/ 提问（迷你对话框）/ 翻译（复用对话框走 Agent）。提问线程 JSON 落盘 + 页边圆片回访（飞书式边注）；**批注 = `comment` 非空的高亮**，页边批注针 + 右侧「批注」面板回访。  
+> 实现入口：`src/components/viewer/pdf-viewer.tsx`、`src/components/viewer/pdf-ask/`（含 `selection-menu.tsx`、`highlight-layer.tsx`、`annotation-editor.tsx`、`annotation-gutter.tsx`）、`src/components/viewer/annotations-panel.tsx`、`src/lib/pdf-ask/`、`src/lib/pdf-highlight/`。  
 > 相关：[`technical-plan.md`](technical-plan.md) §3.4 阅读器、[`../frontend/ui.md`](../frontend/ui.md)、[`../backend/data-model.md`](../backend/data-model.md)、[`../backend/api.md`](../backend/api.md) Agent 契约。
 
 ## 1. 产品目标
@@ -11,8 +11,8 @@
 
 | 交互 | 行为 |
 |---|---|
-| **划词** | 选中 PDF 文本后，在选区旁弹出**操作菜单**（高亮 / 笔记 / 提问 / 翻译）；不默认高亮，只保留浏览器原生选区 |
-| **操作菜单** | 高亮→JSON 落盘并渲染琥珀覆盖层；笔记→原文以 `> …` 追加进 `NOTES.md`（菜单内联「已加入」）；提问→打开迷你问答卡；翻译→建线程后复用问答卡走 Agent 流式 |
+| **划词** | 选中 PDF 文本后，在选区旁弹出**操作菜单**（高亮 / 批注 / 提问 / 翻译）；不默认高亮，只保留浏览器原生选区 |
+| **操作菜单** | 高亮→JSON 落盘并渲染琥珀覆盖层；批注→先建高亮，再在选区旁弹出**内联编辑器**（`annotation-editor.tsx`）写评论，保存后 `comment` 落盘（留空则退化为纯高亮），**不再追加 `NOTES.md`**；提问→打开迷你问答卡；翻译→建线程后复用问答卡走 Agent 流式 |
 | **双击** | 双击打开对话框，输入框预填页码（不选词、不高亮整页） |
 | **悬停停留** | 指针在某处静止超过阈值 \(T\)，弹出迷你问答卡 |
 | **键入提问** | 卡内输入问题并发送；**仅发送过问题的线程**保留对话图标 |
@@ -188,12 +188,18 @@ interface PdfAskMessage {
 
 ```text
 src/components/viewer/
-  pdf-viewer.tsx              # 现有；挂载交互层与 gutter
+  pdf-viewer.tsx              # 现有；挂载交互层与 gutter；暴露命令式 `PdfViewerHandle`
+                             #   （getHighlights / scrollToHighlight / editComment / deleteHighlight）
+                             #   + `onHighlightsChange` 回调，App.tsx 按 tab 保存 handle + highlights 驱动面板
+  annotations-panel.tsx       # 右侧「批注」tab：列出**当前活动 PDF tab** 的批注卡（页码 + 引文 + 评论）；
+                             #   点击卡片滚动到原文并闪烁；卡片可编辑 / 删除
   pdf-ask/
     ask-layer.tsx             # 捕获 selection / dblclick / dwell
     ask-popover.tsx           # 迷你对话框（消息 + 输入）
     ask-gutter.tsx            # 右侧圆片列表
     ask-highlight.tsx         # 选区/已锚定高亮 overlay（可选）
+    annotation-editor.tsx     # 内联评论编辑器（选区旁 popover；新建/读取/编辑批注）
+    annotation-gutter.tsx     # 页边**批注针**（仅 comment 非空的高亮）；点击打开内联编辑器
     use-pdf-geometry.ts       # DOMRect ↔ 归一化坐标
     use-pdf-ask-store.ts      # 当前 paper 的 threads 加载/保存
 src/lib/pdf-ask/
@@ -270,7 +276,8 @@ src/lib/pdf-ask/
 | **M3 ACP 接入** | 真流式回答；多轮；结束写盘 | 与 Agent 面板共用 provider 配置 | ✅ |
 | **M4 双击 / 悬停** | 触发完善；阈值暂固定（约 700ms） | 防误触可接受 | ✅ |
 | **M5 增强** | 导出 highlight；本地 PDF 文本层；无文本层降级 UI | 扫描件有明确空状态 | ⏳ |
-| **M6 选区菜单** | 划词弹菜单：高亮（`highlights/*.json`）/ 笔记（追加 `NOTES.md`）/ 提问 / 翻译；去掉默认琥珀高亮 | 四项可用；高亮重开对齐并可删除；笔记不覆盖未存改动 | ✅ |
+| **M6 选区菜单** | 划词弹菜单：高亮（`highlights/*.json`）/ 批注 / 提问 / 翻译；去掉默认琥珀高亮 | 四项可用；高亮重开对齐并可删除 | ✅ |
+| **M7 批注（Zotero 式）** | 「批注」= 建高亮 + 内联编辑器写 `comment`；页边批注针；右侧「批注」面板（活动 PDF tab）列卡、跳转闪烁、编辑/删除；**不写 `NOTES.md`** | 新建/编辑/面板跳转/删除闭环；`comment` 落盘且 `version` 兼容 | ✅ |
 
 ## 10. 风险与降级
 
@@ -285,8 +292,9 @@ src/lib/pdf-ask/
 
 ## 11. 测试要点
 
-- 单元：归一化坐标往返、`schema` 校验、index 重建。
+- 单元：归一化坐标往返、`schema` 校验（含可选 `comment`）、index 重建。
 - 组件：selection → open popover；write → gutter 出现；click → 消息恢复。
+- 批注：批注→内联编辑器写 `comment` 落盘并出现页边批注针；右侧「批注」面板列卡、点击跳转并闪烁、编辑 / 删除闭环。
 - 集成：mock `agent:stream` 完成一轮后文件存在且可再读。
 - 手工：长 PDF 滚动、窗口缩放、中英混排选区、双栏论文（rects 多段）。
 

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -393,8 +393,8 @@
 
 - ~~Zotero/BibTeX 批量导入~~ ✅ 一键从本地 Zotero 迁移（直读 `zotero.sqlite` + `storage/`，可选拷 PDF；见 [`../backend/identifier-lookup.md`](../backend/identifier-lookup.md) §16）；BibTeX/RIS 文件仍走 Library 导入。
 - 浏览器插件，一键收集网页和论文。
-- ~~**PDF 划词提问** MVP~~ ✅（划词弹操作菜单：高亮 / 笔记 / 提问 / 翻译 → `asks/*.json` + `highlights/*.json`；**平滑蓝色选区覆盖层**（非默认琥珀高亮）；见 [`pdf-ask.md`](pdf-ask.md)）。仍待：导出 `highlights.md`、无文本层降级、TextLayer 增强。
-- 完整 PDF 高亮、批注、摘录同步（`highlights.md`；可与划词提问互导）。
+- ~~**PDF 划词提问** MVP~~ ✅（划词弹操作菜单：高亮 / 批注 / 提问 / 翻译 → `asks/*.json` + `highlights/*.json`；**平滑蓝色选区覆盖层**（非默认琥珀高亮）；见 [`pdf-ask.md`](pdf-ask.md)）。仍待：导出 `highlights.md`、无文本层降级、TextLayer 增强。
+- ~~阅读器内 PDF 高亮 + 批注~~ ✅（就地批注 = 高亮 + 内联评论 + 页边批注针 + 右侧「批注」面板）。仍待：`highlights.md` 摘录同步 / 导出到 `NOTES.md`（暂不做）、与划词提问互导。
 - 远程 PDF 链接、任意网页入库（DOI 魔棒路径可部分覆盖）。
 - 多 Agent 并行读论文和综合评估。
 - ~~论文引用关系自动抽取~~ → 升格为 **V0.7**（引用图 + hover Info + Agent 工作流）。
@@ -499,8 +499,9 @@ Codex 的原生 thread runtime 是 provider 专属实现，不应把其命令、
 
 - [x] 从本地 Zotero 迁移（`zotero_scan` / `zotero_migrate`：直读 sqlite、可选拷 PDF、按 collection 建子文件夹、笔记 HTML→MD、PDF 批注文本、逐条选择 / 进度）；批注原位高亮渲染仍待。
 - [ ] 浏览器插件与网页 importer。
-- [x] PDF 划词提问 MVP（见 [`pdf-ask.md`](pdf-ask.md)：划词操作菜单 高亮/笔记/提问/翻译；`asks/*.json` 线程 + `highlights/*.json` 高亮 + 锚点图标 + ACP；M5 增强仍待）。
-- [ ] PDF/HTML 标注系统（`highlights.md`）。
+- [x] PDF 划词提问 MVP（见 [`pdf-ask.md`](pdf-ask.md)：划词操作菜单 高亮/批注/提问/翻译；`asks/*.json` 线程 + `highlights/*.json` 高亮 + 锚点图标 + ACP；M5 增强仍待）。
+- [x] PDF 标注系统（Zotero 式）：阅读器内就地批注（高亮 + 内联评论 `comment`）+ 页边批注针 + 右侧「批注」面板（活动 PDF tab；跳转闪烁 / 编辑 / 删除）；标注落 `highlights/*.json`，**不**写 `NOTES.md`。**导出到 `NOTES.md` 暂不做**（可能的后续）。
+- [ ] PDF/HTML 统一标注系统与 `highlights.md` 互导（HTML iframe 标注仍待）。
 - [ ] 多 Agent 并行综述与评估。
 - [ ] 作者 / 机构 / 会议关系图谱；更深的 prior–derivative 引用布局。
 - [ ] 复杂分屏（>2 格）与命名工作区会话。

--- a/docs/development/todo.md
+++ b/docs/development/todo.md
@@ -58,7 +58,7 @@
    - [x] 页码导航：底部 pill + 跳转输入；`PageDown/PageUp` / `Home/End`。
    - [x] 大纲（书签）左侧浮层；文档内查找 `⌘/Ctrl+F` + 命中高亮（`pdf-find.ts`）。
    - [x] 平滑划词覆盖层（Zotero 风格；隐藏原生 `::selection` 行间缝隙）。
-   - [x] 划词操作菜单 MVP：高亮 / 笔记 / 提问 / 翻译（见 3. PDF 划词提问）。
+   - [x] 划词操作菜单 MVP：高亮 / 批注 / 提问 / 翻译（见 3. PDF 划词提问）。
    - [x] 本地 PDF 直接预览（优先本地 → 无本地时 `paper_download_assets` → 失败再远程 `pdf_url`）。
 
 2f. **Markdown 内嵌图片** ✅
@@ -200,12 +200,14 @@
    - [x] M3：接入 ACP `agent_run_once` 流式多轮；结束会话落盘。
    - [x] M4：双击 / 悬停停留触发 + 防误触（阈值暂固定 700ms）。
    - [ ] M5（可选）：导出为 `highlights.md`；无文本层降级；本地 PDF TextLayer。
-   - [x] M6：划词操作菜单（高亮 / 笔记 / 提问 / 翻译）；高亮落盘 `papers/<id>/highlights/<id>.json` + 覆盖层 + 点击删除；笔记追加 `NOTES.md`（经编辑器实例，防覆盖）；翻译复用问答卡走 Agent；去掉默认琥珀高亮，仅原生选区。
+   - [x] M6：划词操作菜单（高亮 / 批注 / 提问 / 翻译）；高亮落盘 `papers/<id>/highlights/<id>.json` + 覆盖层 + 点击删除；翻译复用问答卡走 Agent；去掉默认琥珀高亮，仅原生选区。
+   - [x] M7：Zotero 式批注 —「批注」= 建高亮 + 内联编辑器（`annotation-editor.tsx`）写可选 `comment`；页边批注针（`annotation-gutter.tsx`）；右侧「批注」面板（`annotations-panel.tsx`，活动 PDF tab）列卡、跳转闪烁、编辑 / 删除，经 `PdfViewerHandle` + `onHighlightsChange` 驱动；**不写 `NOTES.md`**（旧追加行为已移除）。
 
 4. **PDF / HTML 标注系统**
    - 参考 Hypothesis 风格的边注、评论、锚点。
-   - 标注正文进入 `highlights.md`，坐标/锚点缓存可重建。
-   - PDF.js / HTML iframe 都需要统一标注模型。
+   - [x] PDF 就地批注已落地（高亮 + `comment` + 页边针 + 右侧面板）；标注落 `highlights/*.json`。
+   - [ ] 标注正文进入 `highlights.md` / 导出到 `NOTES.md`（**暂不做**，可能的后续），坐标/锚点缓存可重建。
+   - [ ] PDF.js / HTML iframe 统一标注模型（HTML iframe 标注仍待）。
    - 与划词提问（asks JSON）边界清晰，可互导。
 
 5. **更大范围导入**

--- a/docs/superpowers/plans/2026-07-17-pdf-annotations.md
+++ b/docs/superpowers/plans/2026-07-17-pdf-annotations.md
@@ -1,0 +1,1162 @@
+# PDF 批注（Zotero 式）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 PDF 划词的「加入笔记」替换为 Zotero 式批注——对选中段落写备注，存进现有高亮 JSON（新增 `comment` 字段），并通过页边图标 + 右侧「批注」面板呈现，可跳转/编辑/删除，完全不写入 NOTES.md。
+
+**Architecture:** 批注 = `comment` 非空的高亮，复用 `papers/<id>/highlights/<id>.json` 存储与既有渲染层。Phase 1 在 `pdf-viewer.tsx` 内完成创建、内联备注编辑器、页边图标、点击高亮的编辑/删除菜单（自成可用闭环）。Phase 2 把高亮列表与命令句柄提升到 `App.tsx`，新增右侧「批注」tab 面板，点卡片经 per-tab `PdfViewerHandle` 跳转/编辑/删除。
+
+**Tech Stack:** React 19 + TypeScript、Tauri plugin-fs、react-pdf/pdfjs-dist、react-i18next、Vitest（lib 层单测）、Biome（lint/format）。
+
+**Design spec:** `docs/superpowers/specs/2026-07-17-pdf-annotations-design.md`
+
+**Conventions:**
+- 每个 task 完成后 `pnpm run fix:ts`（Biome，pre-commit 也会跑），确保通过再 commit。
+- lib 层用 Vitest TDD；UI 层用 `pnpm tauri dev` 手动验证（无组件测试基建）。
+- 提交信息用 Conventional Commits，一次提交一件事。
+
+---
+
+## Phase 1 — 数据模型与 viewer 内批注
+
+### Task 1: 高亮数据模型新增 `comment` 字段
+
+**Files:**
+- Modify: `src/lib/pdf-highlight/types.ts`
+- Modify: `src/lib/pdf-highlight/schema.ts:30-41`
+- Modify: `src/lib/pdf-highlight/io.ts:33-54`
+- Create: `test/pdf-highlight.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+Create `test/pdf-highlight.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { createHighlight } from "@/lib/pdf-highlight/io";
+import { parsePdfHighlight } from "@/lib/pdf-highlight/schema";
+
+const base = {
+	version: 1,
+	id: "h1",
+	paperPath: "papers/1706.03762",
+	createdAt: "2026-01-01T00:00:00.000Z",
+	updatedAt: "2026-01-01T00:00:00.000Z",
+	page: 2,
+	rects: [{ x: 0.1, y: 0.2, w: 0.3, h: 0.05 }],
+	quote: "attention is all you need",
+};
+
+describe("pdf-highlight schema", () => {
+	it("parses a highlight without comment (backward compatible)", () => {
+		const h = parsePdfHighlight(base);
+		expect(h).not.toBeNull();
+		expect(h?.comment).toBeUndefined();
+	});
+
+	it("keeps a string comment", () => {
+		const h = parsePdfHighlight({ ...base, comment: "这是动机" });
+		expect(h?.comment).toBe("这是动机");
+	});
+
+	it("drops a non-string comment", () => {
+		const h = parsePdfHighlight({ ...base, comment: 42 });
+		expect(h).not.toBeNull();
+		expect(h?.comment).toBeUndefined();
+	});
+
+	it("createHighlight carries an optional comment", () => {
+		const h = createHighlight({
+			paperPath: "papers/x",
+			page: 1,
+			rects: [{ x: 0, y: 0, w: 0.1, h: 0.1 }],
+			quote: "q",
+			comment: "note",
+		});
+		expect(h.comment).toBe("note");
+		const plain = createHighlight({
+			paperPath: "papers/x",
+			page: 1,
+			rects: [{ x: 0, y: 0, w: 0.1, h: 0.1 }],
+			quote: "q",
+		});
+		expect(plain.comment).toBeUndefined();
+	});
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `pnpm exec vitest run test/pdf-highlight.test.ts`
+Expected: FAIL（`createHighlight` 不接受 `comment`；`parsePdfHighlight` 不返回 `comment`）。
+
+- [ ] **Step 3: 实现——types.ts 增加字段**
+
+In `src/lib/pdf-highlight/types.ts`, add the field after `color?`:
+
+```ts
+	/** Reserved for future color palette; defaults to amber when absent */
+	color?: string;
+	/** Zotero-style annotation note; non-empty means this highlight is an annotation */
+	comment?: string;
+};
+```
+
+- [ ] **Step 4: 实现——schema.ts 放行可选 comment**
+
+In `src/lib/pdf-highlight/schema.ts`, after the `if (typeof raw.color === "string") highlight.color = raw.color;` line (currently L40), add:
+
+```ts
+	if (typeof raw.color === "string") highlight.color = raw.color;
+	if (typeof raw.comment === "string" && raw.comment.trim()) {
+		highlight.comment = raw.comment;
+	}
+	return highlight;
+```
+
+- [ ] **Step 5: 实现——io.ts createHighlight 接受 comment**
+
+In `src/lib/pdf-highlight/io.ts`, extend the `createHighlight` input type and body. Change the input signature (L33-40) to add `comment?: string;`, and after `if (input.color) highlight.color = input.color;` (L52) add:
+
+```ts
+		if (input.color) highlight.color = input.color;
+		if (input.comment?.trim()) highlight.comment = input.comment;
+		return highlight;
+```
+
+Add `comment?: string;` to the input object type alongside `color?: string;`.
+
+- [ ] **Step 6: 运行测试确认通过**
+
+Run: `pnpm exec vitest run test/pdf-highlight.test.ts`
+Expected: PASS（4 项）。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/pdf-highlight/types.ts src/lib/pdf-highlight/schema.ts src/lib/pdf-highlight/io.ts test/pdf-highlight.test.ts
+git commit -m "feat(pdf): add optional comment field to highlight model"
+```
+
+---
+
+### Task 2: i18n 文案——「笔记」改「批注」+ 新词条
+
+**Files:**
+- Modify: `src/i18n/locales/en/viewer.json`
+- Modify: `src/i18n/locales/zh-CN/viewer.json`
+
+- [ ] **Step 1: 更新 en/viewer.json 的 `selection` 块**
+
+Replace the `selection` object with:
+
+```json
+	"selection": {
+		"menuLabel": "Selection actions",
+		"highlight": "Highlight",
+		"note": "Annotate",
+		"ask": "Ask",
+		"translate": "Translate",
+		"noteAdded": "Added to notes",
+		"removeHighlight": "Remove highlight",
+		"editComment": "Edit note",
+		"translateAction": "Translate this passage"
+	},
+```
+
+- [ ] **Step 2: 新增 `annotations` 块到 en/viewer.json**
+
+After the `pdfAsk` object (before `selection`), add:
+
+```json
+	"annotations": {
+		"title": "Annotations",
+		"empty": "No annotations yet. Select text in the PDF and choose Annotate.",
+		"placeholder": "Write a note…",
+		"save": "Save",
+		"cancel": "Cancel",
+		"delete": "Delete",
+		"editorLabel": "Annotation note",
+		"pinAria": "Open annotation: {{preview}}",
+		"panelAria": "Annotations for this paper"
+	},
+```
+
+- [ ] **Step 3: 同步 zh-CN/viewer.json 的 `selection` 块**
+
+```json
+	"selection": {
+		"menuLabel": "选区操作",
+		"highlight": "高亮",
+		"note": "批注",
+		"ask": "提问",
+		"translate": "翻译",
+		"noteAdded": "已加入笔记",
+		"removeHighlight": "删除高亮",
+		"editComment": "编辑批注",
+		"translateAction": "翻译这段文字"
+	},
+```
+
+- [ ] **Step 4: 新增 `annotations` 块到 zh-CN/viewer.json**
+
+```json
+	"annotations": {
+		"title": "批注",
+		"empty": "还没有批注。在 PDF 中选中文本并点「批注」。",
+		"placeholder": "写点备注…",
+		"save": "保存",
+		"cancel": "取消",
+		"delete": "删除",
+		"editorLabel": "批注备注",
+		"pinAria": "打开批注：{{preview}}",
+		"panelAria": "本论文的批注"
+	},
+```
+
+- [ ] **Step 5: 校验 JSON + commit**
+
+Run: `pnpm run fix:ts` (Biome 会格式化/校验 JSON)
+Expected: 无错误。
+
+```bash
+git add src/i18n/locales/en/viewer.json src/i18n/locales/zh-CN/viewer.json
+git commit -m "i18n(viewer): rename note action to annotate and add annotation strings"
+```
+
+---
+
+### Task 3: 内联批注编辑器组件
+
+**Files:**
+- Create: `src/components/viewer/pdf-ask/annotation-editor.tsx`
+
+- [ ] **Step 1: 创建组件**
+
+Create `src/components/viewer/pdf-ask/annotation-editor.tsx`:
+
+```tsx
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type AnnotationEditorProps = {
+	/** Screen point near the highlight (from popoverScreenPoint) */
+	screen: { x: number; y: number };
+	/** The highlighted passage, shown read-only */
+	quote: string;
+	/** Existing note text when editing; empty for a fresh annotation */
+	initialComment?: string;
+	/** Save the (possibly empty) note; empty means "no comment / plain highlight" */
+	onSave: (text: string) => void;
+	/** Delete the whole highlight */
+	onDelete: () => void;
+	/** Dismiss without saving */
+	onClose: () => void;
+};
+
+const BOX_W = 260;
+
+/** Floating note editor anchored next to a highlight. */
+export function AnnotationEditor({
+	screen,
+	quote,
+	initialComment,
+	onSave,
+	onDelete,
+	onClose,
+}: AnnotationEditorProps) {
+	const { t } = useTranslation("viewer");
+	const [text, setText] = useState(initialComment ?? "");
+	const ref = useRef<HTMLTextAreaElement>(null);
+
+	useEffect(() => {
+		ref.current?.focus();
+	}, []);
+
+	const vw = typeof window !== "undefined" ? window.innerWidth : 1200;
+	const vh = typeof window !== "undefined" ? window.innerHeight : 800;
+	let left = screen.x;
+	left = Math.min(Math.max(12, left), vw - BOX_W - 12);
+	let top = screen.y;
+	top = Math.min(Math.max(12, top), vh - 180);
+
+	return (
+		<div
+			className={cn(
+				"fixed z-50 flex w-[260px] flex-col gap-2 rounded-xl border border-border/80 bg-background p-3 shadow-2xl ring-1 ring-black/5 dark:ring-white/10",
+			)}
+			style={{ left, top }}
+			role="dialog"
+			aria-label={t("annotations.editorLabel")}
+			onMouseDown={(e) => e.stopPropagation()}
+		>
+			<blockquote className="max-h-16 overflow-y-auto border-amber-400 border-l-2 pl-2 text-muted-foreground text-xs">
+				{quote}
+			</blockquote>
+			<textarea
+				ref={ref}
+				className="min-h-16 w-full resize-none rounded-md border border-border/80 bg-transparent p-2 text-sm outline-none focus:ring-1 focus:ring-ring"
+				placeholder={t("annotations.placeholder")}
+				value={text}
+				onChange={(e) => setText(e.target.value)}
+				onKeyDown={(e) => {
+					if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+						e.preventDefault();
+						onSave(text);
+					}
+					if (e.key === "Escape") {
+						e.preventDefault();
+						onClose();
+					}
+				}}
+			/>
+			<div className="flex items-center justify-between">
+				<Button
+					type="button"
+					variant="ghost"
+					size="sm"
+					className="text-destructive hover:text-destructive"
+					onClick={onDelete}
+				>
+					{t("annotations.delete")}
+				</Button>
+				<div className="flex items-center gap-1">
+					<Button type="button" variant="ghost" size="sm" onClick={onClose}>
+						{t("annotations.cancel")}
+					</Button>
+					<Button type="button" size="sm" onClick={() => onSave(text)}>
+						{t("annotations.save")}
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}
+```
+
+- [ ] **Step 2: 校验类型 + commit**
+
+Run: `pnpm run fix:ts`
+Expected: 无错误（若 `Button` 无 `size="sm"` 变体，改用现有变体，检查 `src/components/ui/button.tsx`）。
+
+```bash
+git add src/components/viewer/pdf-ask/annotation-editor.tsx
+git commit -m "feat(pdf): add inline annotation note editor component"
+```
+
+---
+
+### Task 4: 页边批注图标组件
+
+**Files:**
+- Create: `src/components/viewer/pdf-ask/annotation-gutter.tsx`
+
+- [ ] **Step 1: 创建组件**
+
+Create `src/components/viewer/pdf-ask/annotation-gutter.tsx`（复用 `ask-gutter.tsx` 的 `layoutPins` 碰撞思路，改用批注图标与 amber 配色）：
+
+```tsx
+import { MessageSquareText } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { cn } from "@/lib/utils";
+
+export type AnnotationPin = {
+	id: string;
+	/** 0–1 page-normalized anchor (top-right of the highlight) */
+	x: number;
+	y: number;
+	preview: string;
+};
+
+type AnnotationGutterProps = {
+	/** Pins for this page only */
+	items: AnnotationPin[];
+	activeId: string | null;
+	onOpen: (id: string) => void;
+};
+
+const PILL = 20;
+const GAP = 4;
+
+function layoutPins(
+	items: AnnotationPin[],
+	pageW: number,
+	pageH: number,
+): Array<{ id: string; leftPct: number; topPct: number }> {
+	const sorted = [...items].sort((a, b) => a.y - b.y || a.x - b.x);
+	const placed: Array<{ id: string; x: number; y: number }> = [];
+	for (const it of sorted) {
+		let x = it.x;
+		let y = it.y;
+		let guard = 0;
+		while (guard < 12) {
+			let hit = false;
+			for (const p of placed) {
+				const dx = (x - p.x) * pageW;
+				const dy = (y - p.y) * pageH;
+				if (Math.hypot(dx, dy) < PILL + GAP) {
+					y += (PILL + GAP) / (pageH || 1);
+					hit = true;
+					break;
+				}
+			}
+			if (!hit) break;
+			guard += 1;
+		}
+		y = Math.min(0.98, Math.max(0.02, y));
+		x = Math.min(0.98, Math.max(0.02, x));
+		placed.push({ id: it.id, x, y });
+	}
+	return placed.map((p) => ({ id: p.id, leftPct: p.x * 100, topPct: p.y * 100 }));
+}
+
+/** Note icons next to annotated highlights; click opens the note editor. */
+export function AnnotationGutter({
+	items,
+	activeId,
+	onOpen,
+}: AnnotationGutterProps) {
+	const { t } = useTranslation("viewer");
+	if (!items.length) return null;
+	const laid = layoutPins(items, 600, 800);
+	const byId = new Map(items.map((it) => [it.id, it]));
+
+	return (
+		<div className="pointer-events-none absolute inset-0 z-[9]" aria-hidden={false}>
+			{laid.map((pos) => {
+				const item = byId.get(pos.id);
+				if (!item) return null;
+				return (
+					<button
+						key={item.id}
+						type="button"
+						className={cn(
+							"pointer-events-auto absolute flex size-6 -translate-y-1/2 items-center justify-center rounded-md border border-amber-600/40 bg-background text-amber-600 shadow-sm transition-transform hover:scale-110 dark:text-amber-400",
+							activeId === item.id && "ring-2 ring-ring ring-offset-1",
+						)}
+						style={{ left: `${pos.leftPct}%`, top: `${pos.topPct}%` }}
+						aria-label={t("annotations.pinAria", { preview: item.preview })}
+						onClick={(e) => {
+							e.stopPropagation();
+							onOpen(item.id);
+						}}
+					>
+						<MessageSquareText className="size-3.5" strokeWidth={2} />
+					</button>
+				);
+			})}
+		</div>
+	);
+}
+```
+
+> 注：批注 pin 锚点用高亮首个 rect 的右上（`x + w`, `y`），与提问气泡（选区中点）通常不重叠；若同页碰撞由各自 `layoutPins` 分别避让，MVP 接受偶发相邻。
+
+- [ ] **Step 2: 校验 + commit**
+
+Run: `pnpm run fix:ts`
+Expected: 无错误（确认 `lucide-react` 有 `MessageSquareText`；若无则用 `StickyNote`）。
+
+```bash
+git add src/components/viewer/pdf-ask/annotation-gutter.tsx
+git commit -m "feat(pdf): add annotation gutter pin component"
+```
+
+---
+
+### Task 5: viewer 接入批注创建 + 编辑器 + 页边图标
+
+**Files:**
+- Modify: `src/components/viewer/pdf-viewer.tsx`（imports、state、handlers、render）
+
+- [ ] **Step 1: 补充 imports**
+
+In `src/components/viewer/pdf-viewer.tsx`, ensure the geometry helpers are imported. Find the import block that includes `clientPointInPage` (around L47) and make sure it also imports `findPageElByNumber` and `popoverScreenPoint` from `@/lib/pdf-ask/geometry`. Add the two component imports near the other `pdf-ask` component imports:
+
+```tsx
+import { AnnotationEditor } from "@/components/viewer/pdf-ask/annotation-editor";
+import {
+	AnnotationGutter,
+	type AnnotationPin,
+} from "@/components/viewer/pdf-ask/annotation-gutter";
+```
+
+- [ ] **Step 2: 新增 state（在 `highlightMenu` state 之后，约 L227）**
+
+```tsx
+	/** Inline note editor for an annotation, anchored to a highlight */
+	const [commentEditor, setCommentEditor] = useState<{
+		id: string;
+		screen: { x: number; y: number };
+	} | null>(null);
+	/** Transient focus flash after jump-to-highlight from the panel */
+	const [activeHighlightId, setActiveHighlightId] = useState<string | null>(
+		null,
+	);
+```
+
+- [ ] **Step 3: 在切换论文的 reset effect 里清理新 state（约 L627-629）**
+
+After `setHighlightMenu(null);` inside the `useEffect` that resets on `paperAbsPath` change, add:
+
+```tsx
+		setHighlightMenu(null);
+		setCommentEditor(null);
+		setActiveHighlightId(null);
+```
+
+- [ ] **Step 4: 新增 helper——打开编辑器**
+
+Add near the menu handlers (before `handleMenuHighlight`, ~L1116):
+
+```tsx
+	const openCommentEditorFor = useCallback((id: string) => {
+		const host = contentRef.current;
+		const hl = highlightsRef.current.find((h) => h.id === id);
+		if (!host || !hl) return;
+		const pageEl = findPageElByNumber(host, hl.page);
+		const screen = popoverScreenPoint(pageEl, hl.rects);
+		if (screen) {
+			setHighlightMenu(null);
+			setCommentEditor({ id, screen });
+		}
+	}, []);
+
+	const saveComment = useCallback(
+		(id: string, text: string) => {
+			const comment = text.trim();
+			setHighlights((prev) =>
+				prev.map((h) =>
+					h.id === id
+						? { ...h, comment: comment || undefined }
+						: h,
+				),
+			);
+			setCommentEditor(null);
+			if (paperAbsPath) {
+				const hl = highlightsRef.current.find((h) => h.id === id);
+				if (hl) {
+					void writePdfHighlight(paperAbsPath, {
+						...hl,
+						comment: comment || undefined,
+					}).catch(() => undefined);
+				}
+			}
+		},
+		[paperAbsPath],
+	);
+```
+
+- [ ] **Step 5: 替换 `handleMenuNote` 为 `handleMenuAnnotate`（L1142-1146）**
+
+Replace:
+
+```tsx
+	const handleMenuNote = useCallback(() => {
+		const quote = selectionMenu?.anchor.quote?.trim();
+		if (quote) onAddNote?.(quote);
+		// SelectionMenu shows its own confirmation, then calls onClose.
+	}, [selectionMenu, onAddNote]);
+```
+
+with:
+
+```tsx
+	const handleMenuAnnotate = useCallback(() => {
+		const sm = selectionMenu;
+		if (!sm) return;
+		setSelectionMenu(null);
+		const quote = sm.anchor.quote?.trim();
+		if (!quote || !sm.anchor.rects.length) return;
+		const paperPath = paperRelPath || paperAbsPath || "paper";
+		const hl = createHighlight({
+			paperPath,
+			page: sm.anchor.page,
+			rects: mergeRectsByLine(
+				sm.anchor.rects.filter((r) => r.w > 0 && r.h > 0),
+			),
+			quote,
+		});
+		setHighlights((prev) => [hl, ...prev]);
+		window.getSelection()?.removeAllRanges();
+		if (paperAbsPath) {
+			void writePdfHighlight(paperAbsPath, hl).catch(() => undefined);
+		}
+		const host = contentRef.current;
+		const pageEl = host ? findPageElByNumber(host, hl.page) : null;
+		const screen = popoverScreenPoint(pageEl, hl.rects);
+		if (screen) setCommentEditor({ id: hl.id, screen });
+	}, [selectionMenu, paperAbsPath, paperRelPath]);
+```
+
+- [ ] **Step 6: SelectionMenu 的 `onNote` 改指向 `handleMenuAnnotate`（L1638）**
+
+In the `<SelectionMenu ... />` JSX, change `onNote={handleMenuNote}` to `onNote={handleMenuAnnotate}`.
+
+- [ ] **Step 7: SelectionMenu 组件去掉「已加入笔记」确认，直接触发**
+
+In `src/components/viewer/pdf-ask/selection-menu.tsx`: replace the `handleNote` callback (L58-66) so it calls `onNote()` then `onClose()` immediately (no `noted` confirmation state), and remove the `noted` branch (L78-83) so the four buttons always render. Concretely:
+- Delete the `noted` state, `timerRef`, and the `Check` import usage.
+- Replace `handleNote` with:
+
+```tsx
+	const handleNote = useCallback(() => {
+		onNote();
+		onClose();
+	}, [onNote, onClose]);
+```
+
+- Remove the `{noted ? (...) : (` wrapper so the `TooltipProvider` block renders unconditionally.
+
+（保留 `onClick={handleNote}` 在批注按钮上；`selection.note` 现渲染为「批注」。`noteAdded` 词条可留作历史，不再引用。）
+
+- [ ] **Step 8: 派生每页批注 pin，并渲染 AnnotationGutter（render，约 L1447 与 L1516-1524 附近）**
+
+Where `pageHighlights` is computed (L1447), add below it:
+
+```tsx
+										const pageAnnotations: AnnotationPin[] = pageHighlights
+											.filter((h) => h.comment?.trim())
+											.map((h) => {
+												const r = h.rects[0] ?? { x: 0, y: 0, w: 0, h: 0 };
+												return {
+													id: h.id,
+													x: r.x + r.w,
+													y: r.y,
+													preview: h.comment ?? "",
+												};
+											});
+```
+
+Then inside the `<div data-pdf-ask-ui="">` that wraps `<AskGutter .../>` (L1516-1524), add the annotation gutter alongside it:
+
+```tsx
+									<div data-pdf-ask-ui="">
+										<AskGutter
+											items={pageSummaries}
+											activeId={activeThreadId}
+											onOpen={handleOpenPill}
+											onEnter={cancelHoverHide}
+											onLeave={scheduleHoverHide}
+										/>
+										<AnnotationGutter
+											items={pageAnnotations}
+											activeId={commentEditor?.id ?? activeHighlightId}
+											onOpen={openCommentEditorFor}
+										/>
+									</div>
+```
+
+- [ ] **Step 9: HighlightLayer activeId 合并 flash（L1476-1479）**
+
+Change `activeId={highlightMenu?.id ?? null}` to:
+
+```tsx
+												activeId={
+													highlightMenu?.id ??
+													commentEditor?.id ??
+													activeHighlightId
+												}
+```
+
+- [ ] **Step 10: 渲染 AnnotationEditor（在 SelectionMenu JSX 之后，highlightMenu 之前，约 L1644）**
+
+```tsx
+			{commentEditor
+				? (() => {
+						const hl = highlights.find((h) => h.id === commentEditor.id);
+						if (!hl) return null;
+						return (
+							<div data-pdf-ask-ui="">
+								<AnnotationEditor
+									screen={commentEditor.screen}
+									quote={hl.quote}
+									initialComment={hl.comment}
+									onSave={(text) => saveComment(hl.id, text)}
+									onDelete={() => removeHighlight(hl.id)}
+									onClose={() => setCommentEditor(null)}
+								/>
+							</div>
+						);
+					})()
+				: null}
+```
+
+- [ ] **Step 11: 关闭 menus 的 effect 也关闭 commentEditor（约 L1160-1182）**
+
+The `useEffect` that dismisses menus on outside pointerdown/Escape/scroll currently guards on `if (!selectionMenu && !highlightMenu) return;` and `closeAll` sets both to null. Leave `commentEditor` OUT of `closeAll` (the editor should not close on scroll/outside-click while typing; it closes via its own Save/Cancel/Escape). No change needed here, but verify the editor's own `onMouseDown stopPropagation` + `data-pdf-ask-ui` prevents the outside-pointerdown handler from closing sibling menus incorrectly.
+
+- [ ] **Step 12: 手动验证 Phase-1 创建/编辑/图标**
+
+Run: `pnpm tauri dev`（若端口被占用，说明无法浏览器验证并跳到 lint/commit）
+验证：
+1. 打开一篇 PDF，选中一段 → 菜单显示「批注」。
+2. 点「批注」→ 出现高亮 + 内联备注框（聚焦）。输入文字 → ⌘/Ctrl+Enter 或点保存 → 框关闭，页边出现批注图标。
+3. 点页边图标 → 重新打开备注框可编辑；点删除 → 高亮与图标消失。
+4. 关闭并重开该 PDF tab → 批注与备注仍在（JSON 持久化）。
+5. 纯「高亮」按钮仍工作，无备注框、无页边图标。
+6. 打开该论文的 `NOTES.md` 确认未被批注流程改动。
+
+- [ ] **Step 13: lint + commit**
+
+Run: `pnpm run fix:ts`
+Expected: 无错误。
+
+```bash
+git add src/components/viewer/pdf-viewer.tsx src/components/viewer/pdf-ask/selection-menu.tsx
+git commit -m "feat(pdf): create/edit annotations inline with gutter pins"
+```
+
+---
+
+### Task 6: 移除 PDF→NOTES.md 的引文追加链路
+
+**Files:**
+- Modify: `src/components/viewer/pdf-viewer.tsx`（去掉 `onAddNote` prop）
+- Modify: `src/components/layout/tab-center.tsx:126`（去掉 `onAddPdfNote` 透传）
+- Modify: `src/App.tsx`（删除 `handleAddPdfNote` 及其 prop 传递）
+
+- [ ] **Step 1: 移除 viewer 的 `onAddNote` prop**
+
+In `src/components/viewer/pdf-viewer.tsx`:
+- Delete the `onAddNote?: (quote: string) => void;` line from `PdfViewerProps` (L114-115) and its comment.
+- Remove `onAddNote,` from the destructured props (L167).
+
+- [ ] **Step 2: 移除 tab-center 的 onAddNote 使用**
+
+In `src/components/layout/tab-center.tsx`, delete `onAddNote={(quote) => onAddPdfNote(tab, quote)}` (L126). Then remove the now-unused `onAddPdfNote` from this component's props type and its parameter list (search `onAddPdfNote` in the file; remove the prop declaration and any pass-through). If `onAddPdfNote` was required by a parent-facing props type in this file, delete that field.
+
+- [ ] **Step 3: 移除 App.tsx 的 handleAddPdfNote 与传递**
+
+In `src/App.tsx`:
+- Delete the `handleAddPdfNote` useCallback (L425-453).
+- Delete the `onAddPdfNote={handleAddPdfNote}` prop passed to the center/tab component (L2220).
+- If `notesEditorHandles` (L412) and `MarkdownEditorHandle.appendMarkdown` are now unused anywhere else, leave `notesEditorHandles` if still used for reseed elsewhere; only remove `appendMarkdown` usage. Verify with a search: `grep appendMarkdown` — if the only caller was `handleAddPdfNote`, remove the `appendMarkdown` method from `MarkdownEditorHandle` and its implementation in `src/components/editor/markdown-editor.tsx:150-171`. If still referenced elsewhere, keep it.
+
+- [ ] **Step 4: 验证 + 手动 smoke**
+
+Run: `pnpm run fix:ts`
+Expected: 无 TS/lint 错误、无 “unused” 报错。
+
+Run: `pnpm tauri dev` — 划词「批注」仍工作；确认没有任何路径再写 NOTES.md。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/viewer/pdf-viewer.tsx src/components/layout/tab-center.tsx src/App.tsx src/components/editor/markdown-editor.tsx
+git commit -m "refactor(pdf): drop the selection-to-NOTES.md append path"
+```
+
+---
+
+## Phase 2 — 右侧批注面板
+
+### Task 7: viewer 暴露句柄与高亮变更回调
+
+**Files:**
+- Modify: `src/components/viewer/pdf-viewer.tsx`
+
+- [ ] **Step 1: 定义并导出 `PdfViewerHandle` 类型**
+
+Add near `PdfViewerProps` in `src/components/viewer/pdf-viewer.tsx`:
+
+```tsx
+export type PdfViewerHandle = {
+	getHighlights: () => PdfHighlight[];
+	scrollToHighlight: (id: string) => void;
+	editComment: (id: string) => void;
+	deleteHighlight: (id: string) => void;
+};
+```
+
+Add two optional props to `PdfViewerProps`:
+
+```tsx
+	/** Register/unregister an imperative handle for the annotations panel */
+	onHandle?: (handle: PdfViewerHandle | null) => void;
+	/** Called whenever the highlight list changes (for the annotations panel) */
+	onHighlightsChange?: (highlights: PdfHighlight[]) => void;
+```
+
+Add `onHandle,` and `onHighlightsChange,` to the destructured props.
+
+- [ ] **Step 2: 实现 `scrollToHighlight`（放在 `openCommentEditorFor` 附近）**
+
+```tsx
+	const scrollToHighlight = useCallback((id: string) => {
+		const host = contentRef.current;
+		const hl = highlightsRef.current.find((h) => h.id === id);
+		if (!host || !hl) return;
+		const pageEl = findPageElByNumber(host, hl.page);
+		pageEl?.scrollIntoView({ behavior: "smooth", block: "center" });
+		setActiveHighlightId(id);
+		window.setTimeout(() => {
+			setActiveHighlightId((cur) => (cur === id ? null : cur));
+		}, 1600);
+	}, []);
+```
+
+- [ ] **Step 3: 上报高亮变更**
+
+Add an effect after the highlights state/ref setup:
+
+```tsx
+	useEffect(() => {
+		onHighlightsChange?.(highlights);
+	}, [highlights, onHighlightsChange]);
+```
+
+- [ ] **Step 4: 注册/注销句柄**
+
+Add an effect:
+
+```tsx
+	useEffect(() => {
+		if (!onHandle) return;
+		onHandle({
+			getHighlights: () => highlightsRef.current,
+			scrollToHighlight,
+			editComment: openCommentEditorFor,
+			deleteHighlight: removeHighlight,
+		});
+		return () => onHandle(null);
+	}, [onHandle, scrollToHighlight, openCommentEditorFor, removeHighlight]);
+```
+
+- [ ] **Step 5: 验证 + commit**
+
+Run: `pnpm run fix:ts`
+Expected: 无错误。
+
+```bash
+git add src/components/viewer/pdf-viewer.tsx
+git commit -m "feat(pdf): expose viewer handle and highlight-change callback"
+```
+
+---
+
+### Task 8: 批注面板组件
+
+**Files:**
+- Create: `src/components/viewer/annotations-panel.tsx`
+
+- [ ] **Step 1: 创建组件**
+
+Create `src/components/viewer/annotations-panel.tsx`:
+
+```tsx
+import { MessageSquareText, Pencil, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type AnnotationRow = {
+	id: string;
+	page: number;
+	quote: string;
+	comment: string;
+};
+
+type AnnotationsPanelProps = {
+	items: AnnotationRow[];
+	onJump: (id: string) => void;
+	onEdit: (id: string) => void;
+	onDelete: (id: string) => void;
+	className?: string;
+};
+
+/** Right-sidebar list of the active paper's annotations. */
+export function AnnotationsPanel({
+	items,
+	onJump,
+	onEdit,
+	onDelete,
+	className,
+}: AnnotationsPanelProps) {
+	const { t } = useTranslation("viewer");
+
+	return (
+		<div
+			className={cn("flex h-full min-h-0 flex-col overflow-hidden", className)}
+			aria-label={t("annotations.panelAria")}
+		>
+			<div className="flex items-center gap-2 border-b px-3 py-2 text-muted-foreground text-xs">
+				<MessageSquareText className="size-3.5" />
+				{t("annotations.title")}
+			</div>
+			{items.length === 0 ? (
+				<p className="px-3 py-6 text-center text-muted-foreground text-xs">
+					{t("annotations.empty")}
+				</p>
+			) : (
+				<ul className="min-h-0 flex-1 overflow-y-auto p-2">
+					{items.map((a) => (
+						<li key={a.id} className="mb-2">
+							<div className="group rounded-lg border border-border/70 p-2 hover:border-border">
+								<button
+									type="button"
+									className="block w-full text-left"
+									onClick={() => onJump(a.id)}
+								>
+									<span className="text-[10px] text-muted-foreground uppercase">
+										p.{a.page}
+									</span>
+									<blockquote className="mt-0.5 line-clamp-2 border-amber-400 border-l-2 pl-2 text-muted-foreground text-xs">
+										{a.quote}
+									</blockquote>
+									<p className="mt-1 whitespace-pre-wrap text-foreground text-sm">
+										{a.comment}
+									</p>
+								</button>
+								<div className="mt-1 flex justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+									<Button
+										type="button"
+										variant="ghost"
+										size="icon-xs"
+										aria-label={t("selection.editComment")}
+										onClick={() => onEdit(a.id)}
+									>
+										<Pencil className="size-3.5" />
+									</Button>
+									<Button
+										type="button"
+										variant="ghost"
+										size="icon-xs"
+										aria-label={t("annotations.delete")}
+										onClick={() => onDelete(a.id)}
+									>
+										<Trash2 className="size-3.5" />
+									</Button>
+								</div>
+							</div>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}
+```
+
+- [ ] **Step 2: 验证 + commit**
+
+Run: `pnpm run fix:ts`
+Expected: 无错误（确认 `Button` 有 `size="icon-xs"`，workspace-header 已在用）。
+
+```bash
+git add src/components/viewer/annotations-panel.tsx
+git commit -m "feat(pdf): add annotations side panel component"
+```
+
+---
+
+### Task 9: App 接线——per-tab 句柄、高亮态、右栏 tab
+
+**Files:**
+- Modify: `src/App.tsx`
+- Modify: `src/components/layout/tab-center.tsx`
+- Modify: `src/components/layout/workspace-header.tsx`
+
+- [ ] **Step 1: App 扩展右栏 tab 类型与状态**
+
+In `src/App.tsx`:
+- Change `useState<"agent" | "backlinks">("agent")` (L192) to `useState<"agent" | "backlinks" | "annotations">("agent")`.
+- Change `openRightTab` param type (L580) to `(tab: "agent" | "backlinks" | "annotations")`.
+
+- [ ] **Step 2: App 新增 per-tab 句柄与高亮态**
+
+Add near `notesEditorHandles` (L412):
+
+```tsx
+	/** PDF viewer imperative handles by tab id (for the annotations panel). */
+	const pdfViewerHandles = useRef(new Map<string, PdfViewerHandle>());
+	/** Latest highlights per PDF tab id, for the annotations panel. */
+	const [pdfHighlightsByTab, setPdfHighlightsByTab] = useState<
+		Record<string, PdfHighlight[]>
+	>({});
+```
+
+Import the types at top of `App.tsx`:
+
+```tsx
+import type { PdfViewerHandle } from "@/components/viewer/pdf-viewer";
+import type { PdfHighlight } from "@/lib/pdf-highlight/types";
+import type { AnnotationRow } from "@/components/viewer/annotations-panel";
+```
+
+- [ ] **Step 3: App 派生活动 tab 的批注行 + 面板动作**
+
+Add (after `pdfHighlightsByTab` declaration; assumes `activeTabId` exists — confirm the active-tab id variable name and adjust):
+
+```tsx
+	const activeAnnotations = useMemo<AnnotationRow[]>(() => {
+		const list = activeTabId ? pdfHighlightsByTab[activeTabId] : undefined;
+		if (!list) return [];
+		return list
+			.filter((h) => h.comment?.trim())
+			.map((h) => ({
+				id: h.id,
+				page: h.page,
+				quote: h.quote,
+				comment: h.comment ?? "",
+			}))
+			.sort((a, b) => a.page - b.page);
+	}, [activeTabId, pdfHighlightsByTab]);
+
+	const annotationAction = useCallback(
+		(fn: (h: PdfViewerHandle) => void) => {
+			if (!activeTabId) return;
+			const h = pdfViewerHandles.current.get(activeTabId);
+			if (h) fn(h);
+		},
+		[activeTabId],
+	);
+```
+
+> `useMemo`/`useCallback`/`useRef` 已在文件中使用；确认 `activeTabId` 就是当前活动 tab id 的变量名（若不同，替换为实际名字）。
+
+- [ ] **Step 4: App 传高亮回调与句柄给 center**
+
+At the center/tab component usage where `onAddPdfNote` used to be (near L2220 now removed), pass registration callbacks down. Add props on the `<TabCenter .../>` (or equivalent) call:
+
+```tsx
+							registerPdfHandle={(tabId, handle) => {
+								if (handle) pdfViewerHandles.current.set(tabId, handle);
+								else pdfViewerHandles.current.delete(tabId);
+							}}
+							onPdfHighlightsChange={(tabId, list) =>
+								setPdfHighlightsByTab((prev) => ({ ...prev, [tabId]: list }))
+							}
+```
+
+- [ ] **Step 5: tab-center 透传到 PdfViewer**
+
+In `src/components/layout/tab-center.tsx`:
+- Add to its props type: `registerPdfHandle: (tabId: string, handle: PdfViewerHandle | null) => void;` and `onPdfHighlightsChange: (tabId: string, list: PdfHighlight[]) => void;` (import the two types).
+- In the `tab.mode === "pdf"` branch (L114-129), pass:
+
+```tsx
+					onHandle={(h) => registerPdfHandle(tab.id, h)}
+					onHighlightsChange={(list) => onPdfHighlightsChange(tab.id, list)}
+```
+
+- [ ] **Step 6: workspace-header 新增「批注」toggle 按钮**
+
+In `src/components/layout/workspace-header.tsx`:
+- Change `onOpenRightTab` prop type (L43) to `(tab: "agent" | "backlinks" | "annotations") => void`; same for the `rightSidebarTab` prop type if it's typed as a union.
+- Import an icon: add `MessageSquareText` to the `lucide-react` import.
+- After the backlinks `<Tooltip>` block (ends L231), add:
+
+```tsx
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<Button
+													type="button"
+													variant="ghost"
+													size="icon-xs"
+													aria-label={t("titlebar.annotationsPanel")}
+													aria-pressed={rightSidebarTab === "annotations"}
+													className={cn(
+														rightSidebarTab === "annotations" &&
+															"bg-muted text-foreground",
+													)}
+													onClick={() => onOpenRightTab("annotations")}
+												>
+													<MessageSquareText className="size-3.5" />
+												</Button>
+											</TooltipTrigger>
+											<TooltipContent side="bottom">
+												{t("annotations.title", { ns: "viewer" })}
+											</TooltipContent>
+										</Tooltip>
+```
+
+Add i18n key `titlebar.annotationsPanel` to the header's namespace (find where `titlebar.backlinksPanel` lives — likely `common`/`app` namespace en+zh) with values `"Annotations"` / `"批注"`.
+
+- [ ] **Step 7: App 渲染批注面板分支**
+
+In the right-sidebar `ResizablePanel` (after the `backlinks` branch, before `</ResizablePanel>` at L2409), add:
+
+```tsx
+								{rightSidebarOpen &&
+								!agentZenMode &&
+								rightSidebarTab === "annotations" ? (
+									<AnnotationsPanel
+										items={activeAnnotations}
+										onJump={(id) =>
+											annotationAction((h) => h.scrollToHighlight(id))
+										}
+										onEdit={(id) => annotationAction((h) => h.editComment(id))}
+										onDelete={(id) =>
+											annotationAction((h) => h.deleteHighlight(id))
+										}
+									/>
+								) : null}
+```
+
+Import `AnnotationsPanel` at top of `App.tsx`.
+
+- [ ] **Step 8: 手动验证 Phase-2**
+
+Run: `pnpm tauri dev`
+验证：
+1. 打开 PDF 并创建 ≥2 条批注 → 标题栏出现「批注」图标 → 打开右栏「批注」tab，列出卡片（页码 + 引文 + 备注）。
+2. 点卡片 → PDF 平滑滚动到该处并高亮闪烁 ~1.6s。
+3. 卡片「编辑」→ viewer 内联备注框打开；改动保存后面板同步更新。
+4. 卡片「删除」→ 高亮、页边图标、卡片同时消失。
+5. 打开第二个 PDF tab，批注面板随活动 tab 切换内容；无 PDF tab 时显示空状态。
+
+- [ ] **Step 9: lint + commit**
+
+Run: `pnpm run fix:ts`
+Expected: 无错误。
+
+```bash
+git add src/App.tsx src/components/layout/tab-center.tsx src/components/layout/workspace-header.tsx
+git commit -m "feat(pdf): add annotations right-sidebar tab wired to the active PDF"
+```
+
+---
+
+### Task 10: 文档同步
+
+**Files:**
+- Modify: `docs/development/pdf-ask.md`
+- Modify: `docs/backend/data-model.md`
+- Modify: `docs/development/roadmap.md`
+- Modify: `docs/development/todo.md`
+- Modify: `AGENTS.md`（若批注语义值得在总览提及）
+
+- [ ] **Step 1: 更新 pdf-ask.md**
+
+在交互矩阵与数据模型章节：把「note = append NOTES.md」改为「annotate = 高亮 + `comment`（存 `highlights/<id>.json`），完全不写 NOTES.md」；在模块清单加入 `annotation-editor.tsx`、`annotation-gutter.tsx`、`annotations-panel.tsx`、`PdfViewerHandle`；在测试清单加入「创建批注 / 编辑备注 / 面板跳转 / 删除同步」。
+
+- [ ] **Step 2: 更新 data-model.md**
+
+在高亮 schema 处加 `comment?: string` 字段说明（非空即批注），并注明右侧面板由活动 PDF tab 驱动、不入 catalog。
+
+- [ ] **Step 3: 更新 roadmap.md / todo.md**
+
+勾选/更新「PDF 标注系统」相关条目为已落地（in-viewer + 侧栏面板；导出到 NOTES.md 列为后续可选）。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add docs/development/pdf-ask.md docs/backend/data-model.md docs/development/roadmap.md docs/development/todo.md AGENTS.md
+git commit -m "docs(pdf): document Zotero-style annotation feature"
+```
+
+---
+
+## Self-Review 记录
+
+- **Spec 覆盖**：数据模型→Task 1；按钮改名/交互→Task 2/5;内联编辑器→Task 3/5;页边图标→Task 4/5;移除 NOTES.md 链路→Task 6;句柄与回调→Task 7;右侧面板→Task 8/9;i18n→Task 2 + Task 9 Step6;文档→Task 10。全部有对应 task。
+- **Placeholder 扫描**：无 TBD/TODO；每个改代码步骤均含实际代码或精确锚点。
+- **类型一致性**：`PdfViewerHandle`（getHighlights/scrollToHighlight/editComment/deleteHighlight）在 Task 7 定义、Task 9 使用一致；`AnnotationPin`（Task 4）与 viewer 派生（Task 5 Step8）字段一致；`AnnotationRow`（Task 8）与 App 派生（Task 9 Step3）一致；`comment` 字段贯穿 Task 1/5/7/8/9 命名一致。
+- **执行者需现场确认的变量名**：`activeTabId`（活动 tab id）、center 组件在 App 中的实际标签名与 props、`Button` 的 size 变体、`lucide-react` 是否有 `MessageSquareText`、`titlebar.*` 所在 i18n 命名空间。这些在对应步骤已标注“确认/替换为实际名字”。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,11 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+	type AnnotationRow,
+	AnnotationsPanel,
+} from "@/components/viewer/annotations-panel";
+import type { PdfViewerHandle } from "@/components/viewer/pdf-viewer";
 import { ViewModeToggle } from "@/components/viewer/view-mode-toggle";
 import { useAppShortcuts } from "@/hooks/use-app-shortcuts";
 import { useNativeMenuEvents } from "@/hooks/use-native-menu-events";
@@ -81,6 +86,7 @@ import {
 	TRASH_VIRTUAL_PATH,
 	trashPaths,
 } from "@/lib/papers-api";
+import type { PdfHighlight } from "@/lib/pdf-highlight/types";
 import { openInTerminal, revealInFileManager } from "@/lib/reveal";
 import { type AppSettings, loadSettings, saveSettings } from "@/lib/settings";
 import {
@@ -186,9 +192,9 @@ export default function App() {
 	 * Collapsed by default; top-bar icons open a tab.
 	 */
 	const [rightSidebarOpen, setRightSidebarOpen] = useState(false);
-	const [rightSidebarTab, setRightSidebarTab] = useState<"agent" | "backlinks">(
-		"agent",
-	);
+	const [rightSidebarTab, setRightSidebarTab] = useState<
+		"agent" | "backlinks" | "annotations"
+	>("agent");
 	/**
 	 * Agent zen / quest mode: hide vault chrome, full-width Agent chat
 	 * (Cursor Agents Window / VS Code zen — distraction-free single surface).
@@ -372,6 +378,36 @@ export default function App() {
 	const activeTabIdRef = useRef(activeTabId);
 	activeTabIdRef.current = activeTabId;
 
+	/** PDF viewer imperative handles by tab id (for the annotations panel). */
+	const pdfViewerHandles = useRef(new Map<string, PdfViewerHandle>());
+	/** Latest highlights per PDF tab id, for the annotations panel. */
+	const [pdfHighlightsByTab, setPdfHighlightsByTab] = useState<
+		Record<string, PdfHighlight[]>
+	>({});
+
+	const activeAnnotations = useMemo<AnnotationRow[]>(() => {
+		const list = activeTabId ? pdfHighlightsByTab[activeTabId] : undefined;
+		if (!list) return [];
+		return list
+			.filter((h) => h.comment?.trim())
+			.map((h) => ({
+				id: h.id,
+				page: h.page,
+				quote: h.quote,
+				comment: h.comment ?? "",
+			}))
+			.sort((a, b) => a.page - b.page);
+	}, [activeTabId, pdfHighlightsByTab]);
+
+	const annotationAction = useCallback(
+		(fn: (h: PdfViewerHandle) => void) => {
+			if (!activeTabId) return;
+			const h = pdfViewerHandles.current.get(activeTabId);
+			if (h) fn(h);
+		},
+		[activeTabId],
+	);
+
 	/** Cycle the active tab by delta (wraps). */
 	const cycleActiveTab = useCallback((delta: number) => {
 		setActiveTabId((cur) => cycleActiveTabId(tabsRef.current, cur, delta));
@@ -540,7 +576,7 @@ export default function App() {
 
 	/** Open right sidebar on a tab (or switch tab if already open). */
 	const openRightTab = useCallback(
-		(tab: "agent" | "backlinks") => {
+		(tab: "agent" | "backlinks" | "annotations") => {
 			setRightSidebarTab(tab);
 			if (tab === "agent") setAgentPanelMounted(true);
 			if (!rightSidebarOpen) {
@@ -2180,6 +2216,17 @@ export default function App() {
 														if (vaultPath) void refreshTree(vaultPath);
 													}}
 													onTabPatch={updateTab}
+													registerPdfHandle={(tabId, handle) => {
+														if (handle)
+															pdfViewerHandles.current.set(tabId, handle);
+														else pdfViewerHandles.current.delete(tabId);
+													}}
+													onPdfHighlightsChange={(tabId, list) =>
+														setPdfHighlightsByTab((prev) => ({
+															...prev,
+															[tabId]: list,
+														}))
+													}
 												/>
 											</div>
 										))}
@@ -2364,6 +2411,20 @@ export default function App() {
 										wikiIndexRevision={wikiIndexRevision}
 									/>
 								</div>
+							) : null}
+							{rightSidebarOpen &&
+							!agentZenMode &&
+							rightSidebarTab === "annotations" ? (
+								<AnnotationsPanel
+									items={activeAnnotations}
+									onJump={(id) =>
+										annotationAction((h) => h.scrollToHighlight(id))
+									}
+									onEdit={(id) => annotationAction((h) => h.editComment(id))}
+									onDelete={(id) =>
+										annotationAction((h) => h.deleteHighlight(id))
+									}
+								/>
 							) : null}
 						</ResizablePanel>
 					</ResizableGroup>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -344,6 +344,12 @@ export default function App() {
 			setActiveTabId(activeId);
 			return tabs;
 		});
+		setPdfHighlightsByTab((prev) => {
+			if (!(id in prev)) return prev;
+			const next = { ...prev };
+			delete next[id];
+			return next;
+		});
 	}, []);
 
 	/** Close every tab whose path is at or under the given path. */
@@ -357,6 +363,17 @@ export default function App() {
 			if (!removed.length) return prev;
 			for (const t of removed) revokeTabPdfSource(t);
 			setActiveTabId(activeId);
+			setPdfHighlightsByTab((prevHl) => {
+				let changed = false;
+				const next = { ...prevHl };
+				for (const t of removed) {
+					if (t.id in next) {
+						delete next[t.id];
+						changed = true;
+					}
+				}
+				return changed ? next : prevHl;
+			});
 			return tabs;
 		});
 	}, []);
@@ -406,6 +423,20 @@ export default function App() {
 			if (h) fn(h);
 		},
 		[activeTabId],
+	);
+
+	const registerPdfHandle = useCallback(
+		(tabId: string, handle: PdfViewerHandle | null) => {
+			if (handle) pdfViewerHandles.current.set(tabId, handle);
+			else pdfViewerHandles.current.delete(tabId);
+		},
+		[],
+	);
+	const handlePdfHighlightsChange = useCallback(
+		(tabId: string, list: PdfHighlight[]) => {
+			setPdfHighlightsByTab((prev) => ({ ...prev, [tabId]: list }));
+		},
+		[],
 	);
 
 	/** Cycle the active tab by delta (wraps). */
@@ -2216,17 +2247,8 @@ export default function App() {
 														if (vaultPath) void refreshTree(vaultPath);
 													}}
 													onTabPatch={updateTab}
-													registerPdfHandle={(tabId, handle) => {
-														if (handle)
-															pdfViewerHandles.current.set(tabId, handle);
-														else pdfViewerHandles.current.delete(tabId);
-													}}
-													onPdfHighlightsChange={(tabId, list) =>
-														setPdfHighlightsByTab((prev) => ({
-															...prev,
-															[tabId]: list,
-														}))
-													}
+													registerPdfHandle={registerPdfHandle}
+													onPdfHighlightsChange={handlePdfHighlightsChange}
 												/>
 											</div>
 										))}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,10 +11,7 @@ import { useTheme } from "next-themes";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { usePanelRef } from "react-resizable-panels";
-import {
-	MarkdownEditor,
-	type MarkdownEditorHandle,
-} from "@/components/editor/markdown-editor";
+import { MarkdownEditor } from "@/components/editor/markdown-editor";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { ZoteroIcon } from "@/components/icons/zotero-icon";
 import { AgentPanel } from "@/components/layout/agent-panel";
@@ -408,9 +405,6 @@ export default function App() {
 		})();
 	}, [closeTab]);
 
-	/** NOTES editor imperative handles by tab id (for PDF "add note"). */
-	const notesEditorHandles = useRef(new Map<string, MarkdownEditorHandle>());
-
 	/** Reseed an open paper tab's NOTES after the reader / download writes it. */
 	const refreshTabNotes = useCallback((paperDir: string, content: string) => {
 		setTabs((prev) => reseedNotesTab(prev, paperDir, content));
@@ -420,37 +414,6 @@ export default function App() {
 	const refreshTabMarkdown = useCallback((absPath: string, content: string) => {
 		setTabs((prev) => reseedMarkdownTab(prev, absPath, content));
 	}, []);
-
-	/** Append a selected PDF passage to a paper's NOTES.md as a blockquote. */
-	const handleAddPdfNote = useCallback(
-		async (tab: DocTab, quote: string) => {
-			const q = quote.replace(/\s+/g, " ").trim();
-			if (!q || !tab.notesPath) return;
-			// Preferred: route through the mounted editor (single writer, no clobber)
-			const handle = notesEditorHandles.current.get(tab.id);
-			if (handle) {
-				handle.appendMarkdown(`> ${q}`);
-				return;
-			}
-			// Fallback: editor not mounted → append on disk and reseed
-			const paperDir = tab.notesPath.replace(/[\\/]NOTES\.md$/i, "");
-			try {
-				let current = "";
-				try {
-					current = await readVaultFile(tab.notesPath);
-				} catch {
-					// missing NOTES.md → start fresh
-				}
-				const base = current.replace(/\s+$/, "");
-				const next = `${base}${base ? "\n\n" : ""}> ${q}\n`;
-				await writeVaultFile(tab.notesPath, next);
-				refreshTabNotes(paperDir, next);
-			} catch (e) {
-				notifyError(e instanceof Error ? e.message : String(e));
-			}
-		},
-		[refreshTabNotes],
-	);
 
 	// Restore the previous window's open tabs once on mount (per-window session).
 	// biome-ignore lint/correctness/useExhaustiveDependencies: mount-only restore
@@ -2217,7 +2180,6 @@ export default function App() {
 														if (vaultPath) void refreshTree(vaultPath);
 													}}
 													onTabPatch={updateTab}
-													onAddPdfNote={handleAddPdfNote}
 												/>
 											</div>
 										))}
@@ -2296,10 +2258,6 @@ export default function App() {
 												>
 													<MarkdownEditor
 														key={`notes-${tab.id}-${tab.notesKey}`}
-														ref={(h) => {
-															if (h) notesEditorHandles.current.set(tab.id, h);
-															else notesEditorHandles.current.delete(tab.id);
-														}}
 														className="agentero-scroll h-full min-h-0"
 														initialMarkdown={tab.notesSeed}
 														filePath={tab.notesPath}

--- a/src/components/editor/markdown-editor.tsx
+++ b/src/components/editor/markdown-editor.tsx
@@ -5,11 +5,9 @@ import { MarkdownPlugin } from "@platejs/markdown";
 import { ImagePlugin } from "@platejs/media/react";
 import { Plate, usePlateEditor } from "platejs/react";
 import {
-	forwardRef,
 	type KeyboardEvent,
 	useCallback,
 	useEffect,
-	useImperativeHandle,
 	useMemo,
 	useRef,
 } from "react";
@@ -50,32 +48,20 @@ export type MarkdownEditorProps = {
 	onAssetsChanged?: () => void;
 };
 
-/** Imperative handle for appending content without clobbering unsaved edits. */
-export type MarkdownEditorHandle = {
-	/** Append a Markdown fragment to the end of the document and persist. */
-	appendMarkdown: (markdown: string) => void;
-};
-
 const CHANGE_DEBOUNCE_MS = 500;
 
-export const MarkdownEditor = forwardRef<
-	MarkdownEditorHandle,
-	MarkdownEditorProps
->(function MarkdownEditor(
-	{
-		initialMarkdown,
-		filePath,
-		readOnly,
-		placeholder,
-		className,
-		fontSize,
-		showToolbar,
-		onPersist,
-		onDirtyChange,
-		onAssetsChanged,
-	},
-	ref,
-) {
+export function MarkdownEditor({
+	initialMarkdown,
+	filePath,
+	readOnly,
+	placeholder,
+	className,
+	fontSize,
+	showToolbar,
+	onPersist,
+	onDirtyChange,
+	onAssetsChanged,
+}: MarkdownEditorProps) {
 	const frontmatterRef = useRef("");
 	const savedRef = useRef(initialMarkdown);
 	const readyRef = useRef(false);
@@ -146,29 +132,6 @@ export const MarkdownEditor = forwardRef<
 	// Latest persist closure, for the unmount flush (captures this file's path).
 	const persistRef = useRef(persist);
 	persistRef.current = persist;
-
-	useImperativeHandle(
-		ref,
-		() => ({
-			appendMarkdown: (markdown: string) => {
-				if (readOnly) return;
-				const fragment = markdown.trim();
-				if (!fragment) return;
-				const nodes = editor
-					.getApi(MarkdownPlugin)
-					.markdown.deserialize(fragment);
-				if (!Array.isArray(nodes) || !nodes.length) return;
-				editor.tf.insertNodes(nodes, { at: [editor.children.length] });
-				if (timerRef.current) {
-					clearTimeout(timerRef.current);
-					timerRef.current = null;
-				}
-				onDirtyChange?.(false);
-				persistRef.current();
-			},
-		}),
-		[editor, readOnly, onDirtyChange],
-	);
 
 	// Mark ready after the initial normalization pass so opening a file never saves.
 	// Seed image URL counts so we only GC assets removed after open.
@@ -249,4 +212,4 @@ export const MarkdownEditor = forwardRef<
 			</Plate>
 		</MarkdownDocProvider>
 	);
-});
+}

--- a/src/components/layout/tab-center.tsx
+++ b/src/components/layout/tab-center.tsx
@@ -3,8 +3,12 @@ import { PapersLibrary } from "@/components/layout/papers-library";
 import { RecycleBinView } from "@/components/layout/recycle-bin-view";
 import { HtmlViewer } from "@/components/viewer/html-viewer";
 import { ImageViewer } from "@/components/viewer/image-viewer";
-import { PdfViewer } from "@/components/viewer/pdf-viewer";
+import {
+	PdfViewer,
+	type PdfViewerHandle,
+} from "@/components/viewer/pdf-viewer";
 import type { PaperMetadata } from "@/lib/paper-metadata";
+import type { PdfHighlight } from "@/lib/pdf-highlight/types";
 import { type DocTab, tabIsPaperNotes } from "@/lib/tabs";
 import { isMarkdownPath, paperRelFromNotes } from "@/lib/vault";
 
@@ -30,6 +34,8 @@ type TabCenterProps = {
 	onPersistFile: (path: string, md: string) => void;
 	onEditorAssetsChanged: () => void;
 	onTabPatch: (id: string, patch: Partial<DocTab>) => void;
+	registerPdfHandle: (tabId: string, handle: PdfViewerHandle | null) => void;
+	onPdfHighlightsChange: (tabId: string, list: PdfHighlight[]) => void;
 };
 
 /** Center-pane view for a single open tab (library, trash, editor, PDF, image, HTML). */
@@ -53,6 +59,8 @@ export function TabCenter({
 	onPersistFile,
 	onEditorAssetsChanged,
 	onTabPatch,
+	registerPdfHandle,
+	onPdfHighlightsChange,
 }: TabCenterProps) {
 	if (tab.kind === "library") {
 		return (
@@ -122,6 +130,8 @@ export function TabCenter({
 					}
 					vaultPath={vaultPath}
 					className="h-full w-full"
+					onHandle={(h) => registerPdfHandle(tab.id, h)}
+					onHighlightsChange={(list) => onPdfHighlightsChange(tab.id, list)}
 				/>
 			</div>
 		);

--- a/src/components/layout/tab-center.tsx
+++ b/src/components/layout/tab-center.tsx
@@ -30,7 +30,6 @@ type TabCenterProps = {
 	onPersistFile: (path: string, md: string) => void;
 	onEditorAssetsChanged: () => void;
 	onTabPatch: (id: string, patch: Partial<DocTab>) => void;
-	onAddPdfNote: (tab: DocTab, quote: string) => void;
 };
 
 /** Center-pane view for a single open tab (library, trash, editor, PDF, image, HTML). */
@@ -54,7 +53,6 @@ export function TabCenter({
 	onPersistFile,
 	onEditorAssetsChanged,
 	onTabPatch,
-	onAddPdfNote,
 }: TabCenterProps) {
 	if (tab.kind === "library") {
 		return (
@@ -123,7 +121,6 @@ export function TabCenter({
 						tab.paperMeta?.path ?? paperRelFromNotes(tab.notesPath, vaultPath)
 					}
 					vaultPath={vaultPath}
-					onAddNote={(quote) => onAddPdfNote(tab, quote)}
 					className="h-full w-full"
 				/>
 			</div>

--- a/src/components/layout/workspace-header.tsx
+++ b/src/components/layout/workspace-header.tsx
@@ -1,4 +1,12 @@
-import { Bot, Focus, Link2, PanelLeft, PanelRight, X } from "lucide-react";
+import {
+	Bot,
+	Focus,
+	Link2,
+	MessageSquareText,
+	PanelLeft,
+	PanelRight,
+	X,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { DocumentTabBar } from "@/components/layout/document-tab-bar";
 import { LayoutMenu } from "@/components/layout/layout-menu";
@@ -30,7 +38,7 @@ type WorkspaceHeaderProps = {
 	notesEligible: boolean;
 	showNotes: boolean;
 	rightSidebarOpen: boolean;
-	rightSidebarTab: "agent" | "backlinks";
+	rightSidebarTab: "agent" | "backlinks" | "annotations";
 	onExitAgentZen: () => void;
 	onToggleSidebar: () => void;
 	onSelectTab: (id: string) => void;
@@ -40,7 +48,7 @@ type WorkspaceHeaderProps = {
 	onToggleRightSidebar: () => void;
 	onToggleAgentZen: () => void;
 	onEnterAgentZen: () => void;
-	onOpenRightTab: (tab: "agent" | "backlinks") => void;
+	onOpenRightTab: (tab: "agent" | "backlinks" | "annotations") => void;
 };
 
 /** Title-bar row: window chrome, sidebar toggles, document tabs, layout + agent controls. */
@@ -227,6 +235,27 @@ export function WorkspaceHeader({
 										</TooltipTrigger>
 										<TooltipContent side="bottom">
 											{t("labels.backlinks")}
+										</TooltipContent>
+									</Tooltip>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<Button
+												type="button"
+												variant="ghost"
+												size="icon-xs"
+												aria-label={t("titlebar.annotationsPanel")}
+												aria-pressed={rightSidebarTab === "annotations"}
+												className={cn(
+													rightSidebarTab === "annotations" &&
+														"bg-muted text-foreground",
+												)}
+												onClick={() => onOpenRightTab("annotations")}
+											>
+												<MessageSquareText className="size-3.5" />
+											</Button>
+										</TooltipTrigger>
+										<TooltipContent side="bottom">
+											{t("annotations.title", { ns: "viewer" })}
 										</TooltipContent>
 									</Tooltip>
 								</>

--- a/src/components/viewer/annotations-panel.tsx
+++ b/src/components/viewer/annotations-panel.tsx
@@ -35,7 +35,7 @@ export function AnnotationsPanel({
 			aria-label={t("annotations.panelAria")}
 		>
 			<div className="flex items-center gap-2 border-b px-3 py-2 text-muted-foreground text-xs">
-				<MessageSquareText className="size-3.5" />
+				<MessageSquareText className="size-3.5" aria-hidden />
 				{t("annotations.title")}
 			</div>
 			{items.length === 0 ? (
@@ -47,10 +47,18 @@ export function AnnotationsPanel({
 					{items.map((a) => (
 						<li key={a.id} className="mb-2">
 							<div className="group rounded-lg border border-border/70 p-2 hover:border-border">
-								<button
-									type="button"
-									className="block w-full text-left"
+								{/* biome-ignore lint/a11y/useSemanticElements: a native <button> cannot wrap the blockquote/p flow content, so a div with role/button semantics is used */}
+								<div
+									role="button"
+									tabIndex={0}
+									className="block w-full cursor-pointer text-left"
 									onClick={() => onJump(a.id)}
+									onKeyDown={(e) => {
+										if (e.key === "Enter" || e.key === " ") {
+											e.preventDefault();
+											onJump(a.id);
+										}
+									}}
 								>
 									<span className="text-[10px] text-muted-foreground uppercase">
 										p.{a.page}
@@ -61,7 +69,7 @@ export function AnnotationsPanel({
 									<p className="mt-1 whitespace-pre-wrap text-foreground text-sm">
 										{a.comment}
 									</p>
-								</button>
+								</div>
 								<div className="mt-1 flex justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100">
 									<Button
 										type="button"

--- a/src/components/viewer/annotations-panel.tsx
+++ b/src/components/viewer/annotations-panel.tsx
@@ -1,0 +1,92 @@
+import { MessageSquareText, Pencil, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type AnnotationRow = {
+	id: string;
+	page: number;
+	quote: string;
+	comment: string;
+};
+
+type AnnotationsPanelProps = {
+	items: AnnotationRow[];
+	onJump: (id: string) => void;
+	onEdit: (id: string) => void;
+	onDelete: (id: string) => void;
+	className?: string;
+};
+
+/** Right-sidebar list of the active paper's annotations. */
+export function AnnotationsPanel({
+	items,
+	onJump,
+	onEdit,
+	onDelete,
+	className,
+}: AnnotationsPanelProps) {
+	const { t } = useTranslation("viewer");
+
+	return (
+		<section
+			className={cn("flex h-full min-h-0 flex-col overflow-hidden", className)}
+			aria-label={t("annotations.panelAria")}
+		>
+			<div className="flex items-center gap-2 border-b px-3 py-2 text-muted-foreground text-xs">
+				<MessageSquareText className="size-3.5" />
+				{t("annotations.title")}
+			</div>
+			{items.length === 0 ? (
+				<p className="px-3 py-6 text-center text-muted-foreground text-xs">
+					{t("annotations.empty")}
+				</p>
+			) : (
+				<ul className="min-h-0 flex-1 overflow-y-auto p-2">
+					{items.map((a) => (
+						<li key={a.id} className="mb-2">
+							<div className="group rounded-lg border border-border/70 p-2 hover:border-border">
+								<button
+									type="button"
+									className="block w-full text-left"
+									onClick={() => onJump(a.id)}
+								>
+									<span className="text-[10px] text-muted-foreground uppercase">
+										p.{a.page}
+									</span>
+									<blockquote className="mt-0.5 line-clamp-2 border-amber-400 border-l-2 pl-2 text-muted-foreground text-xs">
+										{a.quote}
+									</blockquote>
+									<p className="mt-1 whitespace-pre-wrap text-foreground text-sm">
+										{a.comment}
+									</p>
+								</button>
+								<div className="mt-1 flex justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+									<Button
+										type="button"
+										variant="ghost"
+										size="icon-xs"
+										aria-label={t("selection.editComment")}
+										onClick={() => onEdit(a.id)}
+									>
+										<Pencil className="size-3.5" />
+									</Button>
+									<Button
+										type="button"
+										variant="ghost"
+										size="icon-xs"
+										aria-label={t("annotations.delete")}
+										onClick={() => onDelete(a.id)}
+									>
+										<Trash2 className="size-3.5" />
+									</Button>
+								</div>
+							</div>
+						</li>
+					))}
+				</ul>
+			)}
+		</section>
+	);
+}

--- a/src/components/viewer/pdf-ask/annotation-editor.tsx
+++ b/src/components/viewer/pdf-ask/annotation-editor.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type AnnotationEditorProps = {
+	/** Screen point near the highlight (from popoverScreenPoint) */
+	screen: { x: number; y: number };
+	/** The highlighted passage, shown read-only */
+	quote: string;
+	/** Existing note text when editing; empty for a fresh annotation */
+	initialComment?: string;
+	/** Save the (possibly empty) note; empty means "no comment / plain highlight" */
+	onSave: (text: string) => void;
+	/** Delete the whole highlight */
+	onDelete: () => void;
+	/** Dismiss without saving */
+	onClose: () => void;
+};
+
+const BOX_W = 260;
+
+/** Floating note editor anchored next to a highlight. */
+export function AnnotationEditor({
+	screen,
+	quote,
+	initialComment,
+	onSave,
+	onDelete,
+	onClose,
+}: AnnotationEditorProps) {
+	const { t } = useTranslation("viewer");
+	const [text, setText] = useState(initialComment ?? "");
+	const ref = useRef<HTMLTextAreaElement>(null);
+
+	useEffect(() => {
+		ref.current?.focus();
+	}, []);
+
+	const vw = typeof window !== "undefined" ? window.innerWidth : 1200;
+	const vh = typeof window !== "undefined" ? window.innerHeight : 800;
+	let left = screen.x;
+	left = Math.min(Math.max(12, left), vw - BOX_W - 12);
+	let top = screen.y;
+	top = Math.min(Math.max(12, top), vh - 180);
+
+	return (
+		<div
+			className={cn(
+				"fixed z-50 flex w-[260px] flex-col gap-2 rounded-xl border border-border/80 bg-background p-3 shadow-2xl ring-1 ring-black/5 dark:ring-white/10",
+			)}
+			style={{ left, top }}
+			role="dialog"
+			aria-label={t("annotations.editorLabel")}
+			onMouseDown={(e) => e.stopPropagation()}
+		>
+			<blockquote className="max-h-16 overflow-y-auto border-amber-400 border-l-2 pl-2 text-muted-foreground text-xs">
+				{quote}
+			</blockquote>
+			<textarea
+				ref={ref}
+				className="min-h-16 w-full resize-none rounded-md border border-border/80 bg-transparent p-2 text-sm outline-none focus:ring-1 focus:ring-ring"
+				placeholder={t("annotations.placeholder")}
+				value={text}
+				onChange={(e) => setText(e.target.value)}
+				onKeyDown={(e) => {
+					if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+						e.preventDefault();
+						onSave(text);
+					}
+					if (e.key === "Escape") {
+						e.preventDefault();
+						onClose();
+					}
+				}}
+			/>
+			<div className="flex items-center justify-between">
+				<Button
+					type="button"
+					variant="ghost"
+					size="sm"
+					className="text-destructive hover:text-destructive"
+					onClick={onDelete}
+				>
+					{t("annotations.delete")}
+				</Button>
+				<div className="flex items-center gap-1">
+					<Button type="button" variant="ghost" size="sm" onClick={onClose}>
+						{t("annotations.cancel")}
+					</Button>
+					<Button type="button" size="sm" onClick={() => onSave(text)}>
+						{t("annotations.save")}
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/viewer/pdf-ask/annotation-gutter.tsx
+++ b/src/components/viewer/pdf-ask/annotation-gutter.tsx
@@ -1,0 +1,100 @@
+import { MessageSquareText } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { cn } from "@/lib/utils";
+
+export type AnnotationPin = {
+	id: string;
+	/** 0–1 page-normalized anchor (top-right of the highlight) */
+	x: number;
+	y: number;
+	preview: string;
+};
+
+type AnnotationGutterProps = {
+	/** Pins for this page only */
+	items: AnnotationPin[];
+	activeId: string | null;
+	onOpen: (id: string) => void;
+};
+
+const PILL = 20;
+const GAP = 4;
+
+function layoutPins(
+	items: AnnotationPin[],
+	pageW: number,
+	pageH: number,
+): Array<{ id: string; leftPct: number; topPct: number }> {
+	const sorted = [...items].sort((a, b) => a.y - b.y || a.x - b.x);
+	const placed: Array<{ id: string; x: number; y: number }> = [];
+	for (const it of sorted) {
+		let x = it.x;
+		let y = it.y;
+		let guard = 0;
+		while (guard < 12) {
+			let hit = false;
+			for (const p of placed) {
+				const dx = (x - p.x) * pageW;
+				const dy = (y - p.y) * pageH;
+				if (Math.hypot(dx, dy) < PILL + GAP) {
+					y += (PILL + GAP) / (pageH || 1);
+					hit = true;
+					break;
+				}
+			}
+			if (!hit) break;
+			guard += 1;
+		}
+		y = Math.min(0.98, Math.max(0.02, y));
+		x = Math.min(0.98, Math.max(0.02, x));
+		placed.push({ id: it.id, x, y });
+	}
+	return placed.map((p) => ({
+		id: p.id,
+		leftPct: p.x * 100,
+		topPct: p.y * 100,
+	}));
+}
+
+/** Note icons next to annotated highlights; click opens the note editor. */
+export function AnnotationGutter({
+	items,
+	activeId,
+	onOpen,
+}: AnnotationGutterProps) {
+	const { t } = useTranslation("viewer");
+	if (!items.length) return null;
+	const laid = layoutPins(items, 600, 800);
+	const byId = new Map(items.map((it) => [it.id, it]));
+
+	return (
+		<div
+			className="pointer-events-none absolute inset-0 z-[9]"
+			aria-hidden={false}
+		>
+			{laid.map((pos) => {
+				const item = byId.get(pos.id);
+				if (!item) return null;
+				return (
+					<button
+						key={item.id}
+						type="button"
+						className={cn(
+							"pointer-events-auto absolute flex size-6 -translate-y-1/2 items-center justify-center rounded-md border border-amber-600/40 bg-background text-amber-600 shadow-sm transition-transform hover:scale-110 dark:text-amber-400",
+							activeId === item.id && "ring-2 ring-ring ring-offset-1",
+						)}
+						style={{ left: `${pos.leftPct}%`, top: `${pos.topPct}%` }}
+						aria-label={t("annotations.pinAria", { preview: item.preview })}
+						onClick={(e) => {
+							e.stopPropagation();
+							onOpen(item.id);
+						}}
+					>
+						<MessageSquareText className="size-3.5" strokeWidth={2} />
+					</button>
+				);
+			})}
+		</div>
+	);
+}

--- a/src/components/viewer/pdf-ask/selection-menu.tsx
+++ b/src/components/viewer/pdf-ask/selection-menu.tsx
@@ -1,11 +1,10 @@
 import {
-	Check,
 	Highlighter,
 	Languages,
 	MessageSquare,
 	NotebookPen,
 } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
@@ -44,8 +43,6 @@ export function SelectionMenu({
 	onClose,
 }: SelectionMenuProps) {
 	const { t } = useTranslation("viewer");
-	const [noted, setNoted] = useState(false);
-	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	const vw = typeof window !== "undefined" ? window.innerWidth : 1200;
 	const vh = typeof window !== "undefined" ? window.innerHeight : 800;
@@ -57,12 +54,7 @@ export function SelectionMenu({
 
 	const handleNote = useCallback(() => {
 		onNote();
-		setNoted(true);
-		if (timerRef.current) clearTimeout(timerRef.current);
-		timerRef.current = setTimeout(() => {
-			timerRef.current = null;
-			onClose();
-		}, 1000);
+		onClose();
 	}, [onNote, onClose]);
 
 	return (
@@ -75,75 +67,64 @@ export function SelectionMenu({
 			aria-label={t("selection.menuLabel")}
 			onMouseDown={(e) => e.stopPropagation()}
 		>
-			{noted ? (
-				<span className="flex items-center gap-1.5 px-2 text-emerald-600 text-xs dark:text-emerald-400">
-					<Check className="size-3.5" />
-					{t("selection.noteAdded")}
-				</span>
-			) : (
-				<TooltipProvider delayDuration={200}>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon-sm"
-								aria-label={t("selection.highlight")}
-								onClick={onHighlight}
-							>
-								<Highlighter className="size-4" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent side="top">
-							{t("selection.highlight")}
-						</TooltipContent>
-					</Tooltip>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon-sm"
-								aria-label={t("selection.note")}
-								onClick={handleNote}
-							>
-								<NotebookPen className="size-4" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent side="top">{t("selection.note")}</TooltipContent>
-					</Tooltip>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon-sm"
-								aria-label={t("selection.ask")}
-								onClick={onAsk}
-							>
-								<MessageSquare className="size-4" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent side="top">{t("selection.ask")}</TooltipContent>
-					</Tooltip>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon-sm"
-								aria-label={t("selection.translate")}
-								onClick={onTranslate}
-							>
-								<Languages className="size-4" />
-							</Button>
-						</TooltipTrigger>
-						<TooltipContent side="top">
-							{t("selection.translate")}
-						</TooltipContent>
-					</Tooltip>
-				</TooltipProvider>
-			)}
+			<TooltipProvider delayDuration={200}>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon-sm"
+							aria-label={t("selection.highlight")}
+							onClick={onHighlight}
+						>
+							<Highlighter className="size-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent side="top">{t("selection.highlight")}</TooltipContent>
+				</Tooltip>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon-sm"
+							aria-label={t("selection.note")}
+							onClick={handleNote}
+						>
+							<NotebookPen className="size-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent side="top">{t("selection.note")}</TooltipContent>
+				</Tooltip>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon-sm"
+							aria-label={t("selection.ask")}
+							onClick={onAsk}
+						>
+							<MessageSquare className="size-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent side="top">{t("selection.ask")}</TooltipContent>
+				</Tooltip>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon-sm"
+							aria-label={t("selection.translate")}
+							onClick={onTranslate}
+						>
+							<Languages className="size-4" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent side="top">{t("selection.translate")}</TooltipContent>
+				</Tooltip>
+			</TooltipProvider>
 		</div>
 	);
 }

--- a/src/components/viewer/pdf-viewer.tsx
+++ b/src/components/viewer/pdf-viewer.tsx
@@ -103,6 +103,13 @@ function clampZoom(z: number): number {
 	return Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, rounded));
 }
 
+export type PdfViewerHandle = {
+	getHighlights: () => PdfHighlight[];
+	scrollToHighlight: (id: string) => void;
+	editComment: (id: string) => void;
+	deleteHighlight: (id: string) => void;
+};
+
 type PdfViewerProps = {
 	/**
 	 * PDF.js file source: local `blob:` (bytes via fs) or remote https.
@@ -117,6 +124,10 @@ type PdfViewerProps = {
 	/** Current vault root for ACP cwd */
 	vaultPath?: string | null;
 	className?: string;
+	/** Register/unregister an imperative handle for the annotations panel */
+	onHandle?: (handle: PdfViewerHandle | null) => void;
+	/** Called whenever the highlight list changes (for the annotations panel) */
+	onHighlightsChange?: (highlights: PdfHighlight[]) => void;
 };
 
 type PdfOutlineNode = {
@@ -168,6 +179,8 @@ export function PdfViewer({
 	paperRelPath = null,
 	vaultPath = null,
 	className,
+	onHandle,
+	onHighlightsChange,
 }: PdfViewerProps) {
 	const { t } = useTranslation("viewer");
 	const hostRef = useRef<HTMLDivElement>(null);
@@ -1098,7 +1111,7 @@ export function PdfViewer({
 		[upsertThread, openThread, cancelHoverHide],
 	);
 
-	// --- Selection action menu (highlight / note / ask / translate) ---
+	// --- Selection action menu (highlight / annotate / ask / translate) ---
 
 	const handleMenuAsk = useCallback(() => {
 		const sm = selectionMenu;
@@ -1126,6 +1139,18 @@ export function PdfViewer({
 			buildPdfTranslatePrompt(quote, sm.anchor.page, targetLang),
 		);
 	}, [selectionMenu, paperAbsPath, paperRelPath, openThread, sendToThread, t]);
+
+	const scrollToHighlight = useCallback((id: string) => {
+		const host = contentRef.current;
+		const hl = highlightsRef.current.find((h) => h.id === id);
+		if (!host || !hl) return;
+		const pageEl = findPageElByNumber(host, hl.page);
+		pageEl?.scrollIntoView({ behavior: "smooth", block: "center" });
+		setActiveHighlightId(id);
+		window.setTimeout(() => {
+			setActiveHighlightId((cur) => (cur === id ? null : cur));
+		}, 1600);
+	}, []);
 
 	const openCommentEditorFor = useCallback((id: string) => {
 		const host = contentRef.current;
@@ -1222,6 +1247,21 @@ export function PdfViewer({
 		},
 		[paperAbsPath],
 	);
+
+	useEffect(() => {
+		onHighlightsChange?.(highlights);
+	}, [highlights, onHighlightsChange]);
+
+	useEffect(() => {
+		if (!onHandle) return;
+		onHandle({
+			getHighlights: () => highlightsRef.current,
+			scrollToHighlight,
+			editComment: openCommentEditorFor,
+			deleteHighlight: removeHighlight,
+		});
+		return () => onHandle(null);
+	}, [onHandle, scrollToHighlight, openCommentEditorFor, removeHighlight]);
 
 	// Dismiss menus on outside pointerdown / Escape / scroll
 	useEffect(() => {

--- a/src/components/viewer/pdf-viewer.tsx
+++ b/src/components/viewer/pdf-viewer.tsx
@@ -251,6 +251,10 @@ export function PdfViewer({
 	);
 	const highlightsRef = useRef(highlights);
 	highlightsRef.current = highlights;
+	const onHandleRef = useRef(onHandle);
+	onHandleRef.current = onHandle;
+	const onHighlightsChangeRef = useRef(onHighlightsChange);
+	onHighlightsChangeRef.current = onHighlightsChange;
 
 	const activeSessionRef = useRef<string | null>(null);
 	const suppressSelectionUntilRef = useRef(0);
@@ -1249,19 +1253,18 @@ export function PdfViewer({
 	);
 
 	useEffect(() => {
-		onHighlightsChange?.(highlights);
-	}, [highlights, onHighlightsChange]);
+		onHighlightsChangeRef.current?.(highlights);
+	}, [highlights]);
 
 	useEffect(() => {
-		if (!onHandle) return;
-		onHandle({
+		onHandleRef.current?.({
 			getHighlights: () => highlightsRef.current,
 			scrollToHighlight,
 			editComment: openCommentEditorFor,
 			deleteHighlight: removeHighlight,
 		});
-		return () => onHandle(null);
-	}, [onHandle, scrollToHighlight, openCommentEditorFor, removeHighlight]);
+		return () => onHandleRef.current?.(null);
+	}, [scrollToHighlight, openCommentEditorFor, removeHighlight]);
 
 	// Dismiss menus on outside pointerdown / Escape / scroll
 	useEffect(() => {

--- a/src/components/viewer/pdf-viewer.tsx
+++ b/src/components/viewer/pdf-viewer.tsx
@@ -28,6 +28,11 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { AnnotationEditor } from "@/components/viewer/pdf-ask/annotation-editor";
+import {
+	AnnotationGutter,
+	type AnnotationPin,
+} from "@/components/viewer/pdf-ask/annotation-gutter";
 import { AskGutter } from "@/components/viewer/pdf-ask/ask-gutter";
 import { AskPopover } from "@/components/viewer/pdf-ask/ask-popover";
 import { HighlightLayer } from "@/components/viewer/pdf-ask/highlight-layer";
@@ -164,7 +169,6 @@ export function PdfViewer({
 	paperAbsPath = null,
 	paperRelPath = null,
 	vaultPath = null,
-	onAddNote,
 	className,
 }: PdfViewerProps) {
 	const { t } = useTranslation("viewer");
@@ -225,6 +229,15 @@ export function PdfViewer({
 		id: string;
 		screen: { x: number; y: number };
 	} | null>(null);
+	/** Inline note editor for an annotation, anchored to a highlight */
+	const [commentEditor, setCommentEditor] = useState<{
+		id: string;
+		screen: { x: number; y: number };
+	} | null>(null);
+	/** Transient focus flash after jump-to-highlight from the panel */
+	const [activeHighlightId, setActiveHighlightId] = useState<string | null>(
+		null,
+	);
 	const highlightsRef = useRef(highlights);
 	highlightsRef.current = highlights;
 
@@ -627,6 +640,8 @@ export function PdfViewer({
 		setHighlights([]);
 		setSelectionMenu(null);
 		setHighlightMenu(null);
+		setCommentEditor(null);
+		setActiveHighlightId(null);
 		activeSessionRef.current = null;
 
 		if (!paperAbsPath) return;
@@ -1114,6 +1129,40 @@ export function PdfViewer({
 		);
 	}, [selectionMenu, paperAbsPath, paperRelPath, openThread, sendToThread, t]);
 
+	const openCommentEditorFor = useCallback((id: string) => {
+		const host = contentRef.current;
+		const hl = highlightsRef.current.find((h) => h.id === id);
+		if (!host || !hl) return;
+		const pageEl = findPageElByNumber(host, hl.page);
+		const screen = popoverScreenPoint(pageEl, hl.rects);
+		if (screen) {
+			setHighlightMenu(null);
+			setCommentEditor({ id, screen });
+		}
+	}, []);
+
+	const saveComment = useCallback(
+		(id: string, text: string) => {
+			const comment = text.trim();
+			setHighlights((prev) =>
+				prev.map((h) =>
+					h.id === id ? { ...h, comment: comment || undefined } : h,
+				),
+			);
+			setCommentEditor(null);
+			if (paperAbsPath) {
+				const hl = highlightsRef.current.find((h) => h.id === id);
+				if (hl) {
+					void writePdfHighlight(paperAbsPath, {
+						...hl,
+						comment: comment || undefined,
+					}).catch(() => undefined);
+				}
+			}
+		},
+		[paperAbsPath],
+	);
+
 	const handleMenuHighlight = useCallback(() => {
 		const sm = selectionMenu;
 		if (!sm) return;
@@ -1139,11 +1188,31 @@ export function PdfViewer({
 		}
 	}, [selectionMenu, paperAbsPath, paperRelPath]);
 
-	const handleMenuNote = useCallback(() => {
-		const quote = selectionMenu?.anchor.quote?.trim();
-		if (quote) onAddNote?.(quote);
-		// SelectionMenu shows its own confirmation, then calls onClose.
-	}, [selectionMenu, onAddNote]);
+	const handleMenuAnnotate = useCallback(() => {
+		const sm = selectionMenu;
+		if (!sm) return;
+		setSelectionMenu(null);
+		const quote = sm.anchor.quote?.trim();
+		if (!quote || !sm.anchor.rects.length) return;
+		const paperPath = paperRelPath || paperAbsPath || "paper";
+		const hl = createHighlight({
+			paperPath,
+			page: sm.anchor.page,
+			rects: mergeRectsByLine(
+				sm.anchor.rects.filter((r) => r.w > 0 && r.h > 0),
+			),
+			quote,
+		});
+		setHighlights((prev) => [hl, ...prev]);
+		window.getSelection()?.removeAllRanges();
+		if (paperAbsPath) {
+			void writePdfHighlight(paperAbsPath, hl).catch(() => undefined);
+		}
+		const host = contentRef.current;
+		const pageEl = host ? findPageElByNumber(host, hl.page) : null;
+		const screen = popoverScreenPoint(pageEl, hl.rects);
+		if (screen) setCommentEditor({ id: hl.id, screen });
+	}, [selectionMenu, paperAbsPath, paperRelPath]);
 
 	const removeHighlight = useCallback(
 		(id: string) => {
@@ -1447,6 +1516,22 @@ export function PdfViewer({
 										const pageHighlights = highlights.filter(
 											(h) => h.page === pageNumber,
 										);
+										const pageAnnotations: AnnotationPin[] = pageHighlights
+											.filter((h) => h.comment?.trim())
+											.map((h) => {
+												const r = h.rects[0] ?? {
+													x: 0,
+													y: 0,
+													w: 0,
+													h: 0,
+												};
+												return {
+													id: h.id,
+													x: r.x + r.w,
+													y: r.y,
+													preview: h.comment ?? "",
+												};
+											});
 										return (
 											<div
 												key={`${fileUrl}-p${pageNumber}`}
@@ -1475,7 +1560,11 @@ export function PdfViewer({
 												{/* Persisted highlights (visual only; removal via click hit-test) */}
 												<HighlightLayer
 													items={pageHighlights}
-													activeId={highlightMenu?.id ?? null}
+													activeId={
+														highlightMenu?.id ??
+														commentEditor?.id ??
+														activeHighlightId
+													}
 												/>
 												{findHighlight?.page === pageNumber ? (
 													<div className="pointer-events-none absolute inset-0 z-[7]">
@@ -1520,6 +1609,11 @@ export function PdfViewer({
 														onOpen={handleOpenPill}
 														onEnter={cancelHoverHide}
 														onLeave={scheduleHoverHide}
+													/>
+													<AnnotationGutter
+														items={pageAnnotations}
+														activeId={commentEditor?.id ?? activeHighlightId}
+														onOpen={openCommentEditorFor}
 													/>
 												</div>
 											</div>
@@ -1635,13 +1729,32 @@ export function PdfViewer({
 					<SelectionMenu
 						screen={selectionMenu.screen}
 						onHighlight={handleMenuHighlight}
-						onNote={handleMenuNote}
+						onNote={handleMenuAnnotate}
 						onAsk={handleMenuAsk}
 						onTranslate={handleMenuTranslate}
 						onClose={() => setSelectionMenu(null)}
 					/>
 				</div>
 			) : null}
+
+			{commentEditor
+				? (() => {
+						const hl = highlights.find((h) => h.id === commentEditor.id);
+						if (!hl) return null;
+						return (
+							<div data-pdf-ask-ui="">
+								<AnnotationEditor
+									screen={commentEditor.screen}
+									quote={hl.quote}
+									initialComment={hl.comment}
+									onSave={(text) => saveComment(hl.id, text)}
+									onDelete={() => removeHighlight(hl.id)}
+									onClose={() => setCommentEditor(null)}
+								/>
+							</div>
+						);
+					})()
+				: null}
 
 			{highlightMenu ? (
 				<div data-pdf-ask-ui="">

--- a/src/components/viewer/pdf-viewer.tsx
+++ b/src/components/viewer/pdf-viewer.tsx
@@ -116,8 +116,6 @@ type PdfViewerProps = {
 	paperRelPath?: string | null;
 	/** Current vault root for ACP cwd */
 	vaultPath?: string | null;
-	/** Append a quoted passage to the paper's NOTES.md (handled by parent) */
-	onAddNote?: (quote: string) => void;
 	className?: string;
 };
 

--- a/src/i18n/locales/en/app.json
+++ b/src/i18n/locales/en/app.json
@@ -12,6 +12,7 @@
 		"hideSidebarHint": "Hide sidebar ({{shortcut}})",
 		"agentPanel": "Agent panel",
 		"backlinksPanel": "Backlinks panel",
+		"annotationsPanel": "Annotations",
 		"showRightSidebar": "Show right sidebar",
 		"hideRightSidebar": "Hide right sidebar",
 		"showRightSidebarHint": "Show right sidebar ({{shortcut}})",

--- a/src/i18n/locales/en/viewer.json
+++ b/src/i18n/locales/en/viewer.json
@@ -37,14 +37,26 @@
 		"pillAria": "Open ask: {{preview}}",
 		"pillFallback": "Ask thread"
 	},
+	"annotations": {
+		"title": "Annotations",
+		"empty": "No annotations yet. Select text in the PDF and choose Annotate.",
+		"placeholder": "Write a note…",
+		"save": "Save",
+		"cancel": "Cancel",
+		"delete": "Delete",
+		"editorLabel": "Annotation note",
+		"pinAria": "Open annotation: {{preview}}",
+		"panelAria": "Annotations for this paper"
+	},
 	"selection": {
 		"menuLabel": "Selection actions",
 		"highlight": "Highlight",
-		"note": "Add to notes",
+		"note": "Annotate",
 		"ask": "Ask",
 		"translate": "Translate",
 		"noteAdded": "Added to notes",
 		"removeHighlight": "Remove highlight",
+		"editComment": "Edit note",
 		"translateAction": "Translate this passage"
 	},
 	"html": {

--- a/src/i18n/locales/zh-CN/app.json
+++ b/src/i18n/locales/zh-CN/app.json
@@ -12,6 +12,7 @@
 		"hideSidebarHint": "隐藏侧边栏 ({{shortcut}})",
 		"agentPanel": "Agent 面板",
 		"backlinksPanel": "反向链接面板",
+		"annotationsPanel": "批注",
 		"showRightSidebar": "显示右侧边栏",
 		"hideRightSidebar": "隐藏右侧边栏",
 		"showRightSidebarHint": "显示右侧边栏 ({{shortcut}})",

--- a/src/i18n/locales/zh-CN/viewer.json
+++ b/src/i18n/locales/zh-CN/viewer.json
@@ -37,14 +37,26 @@
 		"pillAria": "打开提问：{{preview}}",
 		"pillFallback": "提问线程"
 	},
+	"annotations": {
+		"title": "批注",
+		"empty": "还没有批注。在 PDF 中选中文本并点「批注」。",
+		"placeholder": "写点备注…",
+		"save": "保存",
+		"cancel": "取消",
+		"delete": "删除",
+		"editorLabel": "批注备注",
+		"pinAria": "打开批注：{{preview}}",
+		"panelAria": "本论文的批注"
+	},
 	"selection": {
 		"menuLabel": "选区操作",
 		"highlight": "高亮",
-		"note": "加入笔记",
+		"note": "批注",
 		"ask": "提问",
 		"translate": "翻译",
 		"noteAdded": "已加入笔记",
 		"removeHighlight": "删除高亮",
+		"editComment": "编辑批注",
 		"translateAction": "翻译这段文字"
 	},
 	"html": {

--- a/src/lib/pdf-highlight/io.ts
+++ b/src/lib/pdf-highlight/io.ts
@@ -51,7 +51,7 @@ export function createHighlight(input: {
 		quote: input.quote,
 	};
 	if (input.color) highlight.color = input.color;
-	if (input.comment?.trim()) highlight.comment = input.comment;
+	if (input.comment?.trim()) highlight.comment = input.comment.trim();
 	return highlight;
 }
 

--- a/src/lib/pdf-highlight/io.ts
+++ b/src/lib/pdf-highlight/io.ts
@@ -36,6 +36,7 @@ export function createHighlight(input: {
 	rects: PdfHighlightRect[];
 	quote: string;
 	color?: string;
+	comment?: string;
 	id?: string;
 }): PdfHighlight {
 	const now = new Date().toISOString();
@@ -50,6 +51,7 @@ export function createHighlight(input: {
 		quote: input.quote,
 	};
 	if (input.color) highlight.color = input.color;
+	if (input.comment?.trim()) highlight.comment = input.comment;
 	return highlight;
 }
 

--- a/src/lib/pdf-highlight/schema.ts
+++ b/src/lib/pdf-highlight/schema.ts
@@ -39,7 +39,7 @@ export function parsePdfHighlight(raw: unknown): PdfHighlight | null {
 	};
 	if (typeof raw.color === "string") highlight.color = raw.color;
 	if (typeof raw.comment === "string" && raw.comment.trim()) {
-		highlight.comment = raw.comment;
+		highlight.comment = raw.comment.trim();
 	}
 	return highlight;
 }

--- a/src/lib/pdf-highlight/schema.ts
+++ b/src/lib/pdf-highlight/schema.ts
@@ -38,5 +38,8 @@ export function parsePdfHighlight(raw: unknown): PdfHighlight | null {
 		quote: raw.quote,
 	};
 	if (typeof raw.color === "string") highlight.color = raw.color;
+	if (typeof raw.comment === "string" && raw.comment.trim()) {
+		highlight.comment = raw.comment;
+	}
 	return highlight;
 }

--- a/src/lib/pdf-highlight/types.ts
+++ b/src/lib/pdf-highlight/types.ts
@@ -23,4 +23,6 @@ export type PdfHighlight = {
 	quote: string;
 	/** Reserved for future color palette; defaults to amber when absent */
 	color?: string;
+	/** Zotero-style annotation note; non-empty means this highlight is an annotation */
+	comment?: string;
 };

--- a/test/pdf-highlight.test.ts
+++ b/test/pdf-highlight.test.ts
@@ -32,6 +32,15 @@ describe("pdf-highlight schema", () => {
 		expect(h?.comment).toBeUndefined();
 	});
 
+	it("drops or trims whitespace comments", () => {
+		expect(
+			parsePdfHighlight({ ...base, comment: "   " })?.comment,
+		).toBeUndefined();
+		expect(parsePdfHighlight({ ...base, comment: "  hi  " })?.comment).toBe(
+			"hi",
+		);
+	});
+
 	it("createHighlight carries an optional comment", () => {
 		const h = createHighlight({
 			paperPath: "papers/x",

--- a/test/pdf-highlight.test.ts
+++ b/test/pdf-highlight.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { createHighlight } from "@/lib/pdf-highlight/io";
+import { parsePdfHighlight } from "@/lib/pdf-highlight/schema";
+
+const base = {
+	version: 1,
+	id: "h1",
+	paperPath: "papers/1706.03762",
+	createdAt: "2026-01-01T00:00:00.000Z",
+	updatedAt: "2026-01-01T00:00:00.000Z",
+	page: 2,
+	rects: [{ x: 0.1, y: 0.2, w: 0.3, h: 0.05 }],
+	quote: "attention is all you need",
+};
+
+describe("pdf-highlight schema", () => {
+	it("parses a highlight without comment (backward compatible)", () => {
+		const h = parsePdfHighlight(base);
+		expect(h).not.toBeNull();
+		expect(h?.comment).toBeUndefined();
+	});
+
+	it("keeps a string comment", () => {
+		const h = parsePdfHighlight({ ...base, comment: "这是动机" });
+		expect(h?.comment).toBe("这是动机");
+	});
+
+	it("drops a non-string comment", () => {
+		const h = parsePdfHighlight({ ...base, comment: 42 });
+		expect(h).not.toBeNull();
+		expect(h?.comment).toBeUndefined();
+	});
+
+	it("createHighlight carries an optional comment", () => {
+		const h = createHighlight({
+			paperPath: "papers/x",
+			page: 1,
+			rects: [{ x: 0, y: 0, w: 0.1, h: 0.1 }],
+			quote: "q",
+			comment: "note",
+		});
+		expect(h.comment).toBe("note");
+		const plain = createHighlight({
+			paperPath: "papers/x",
+			page: 1,
+			rects: [{ x: 0, y: 0, w: 0.1, h: 0.1 }],
+			quote: "q",
+		});
+		expect(plain.comment).toBeUndefined();
+	});
+});


### PR DESCRIPTION
This pull request adds a comprehensive PDF annotation (批注) system to the app, modeled after Zotero-style inline annotations. It introduces the ability to add comments to PDF highlights, renders annotation pins in the page gutter, and provides a right sidebar panel to view, edit, and manage all annotations for the active PDF tab. The changes also remove the previous "add to NOTES.md" behavior for PDF notes, making annotations self-contained and more powerful. Documentation and UI have been updated throughout to reflect these new features.

**PDF 批注系统 (Annotation system):**
- PDF highlights now support an optional `comment` field (`comment?: string`). Non-empty comments are treated as annotations ("批注"), displayed with pins in the page margin and listed in the new right sidebar "Annotations" panel. [[1]](diffhunk://#diff-bd70b8e42a45c587a8ee0e1eb6bb38302efdb6a0d4d0c4eec2cd7461eb756d3fL164-R173) [[2]](diffhunk://#diff-f81f58b3340f113c5207de20179792a705c31761a9f052afecd088f9ce0067d3L3-R5) [[3]](diffhunk://#diff-f81f58b3340f113c5207de20179792a705c31761a9f052afecd088f9ce0067d3L14-R15) [[4]](diffhunk://#diff-f81f58b3340f113c5207de20179792a705c31761a9f052afecd088f9ce0067d3L191-R202) [[5]](diffhunk://#diff-f81f58b3340f113c5207de20179792a705c31761a9f052afecd088f9ce0067d3L273-R280) [[6]](diffhunk://#diff-f81f58b3340f113c5207de20179792a705c31761a9f052afecd088f9ce0067d3L288-R297)
- The annotation workflow includes creating highlights, adding inline comments via a popover editor, rendering pins for annotated highlights, and supporting jump-to, edit, and delete actions from the sidebar panel. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R49-R53) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R89) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L192-R197) [[4]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R398-R441) [[5]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L2220-R2251) [[6]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R2437-R2450)

**App UI and state management:**
- Adds a new "annotations" tab to the right sidebar, with state management for per-tab PDF highlights and imperative PDF viewer handles to support annotation actions from the sidebar. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L192-R197) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R347-R352) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R366-R376) [[4]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R398-R441) [[5]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L580-R610)
- Integrates annotation panel actions (jump, edit, delete) with the PDF viewer via imperative handles, ensuring a seamless annotation management experience.

**Documentation and terminology updates:**
- Updates all documentation, UI strings, and menus to use "批注" (annotation) instead of the previous "笔记" (note) in the context of PDF highlights. The "add to NOTES.md" feature is removed for annotations, clarifying that annotations are now managed within the PDF annotation system and not exported to NOTES.md. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L28-R28) [[2]](diffhunk://#diff-f81f58b3340f113c5207de20179792a705c31761a9f052afecd088f9ce0067d3L3-R5) [[3]](diffhunk://#diff-f81f58b3340f113c5207de20179792a705c31761a9f052afecd088f9ce0067d3L14-R15) [[4]](diffhunk://#diff-1e8cc84eb38f5303ab16a6a42642734c17c96da2558c055b2406d71bdde6a4f5L61-R61) [[5]](diffhunk://#diff-1e8cc84eb38f5303ab16a6a42642734c17c96da2558c055b2406d71bdde6a4f5L203-R210) [[6]](diffhunk://#diff-ec84baa7418ec58350d59604efedf52dbe3290126c6e273621ad1ab0f3b7abd5L396-R397) [[7]](diffhunk://#diff-ec84baa7418ec58350d59604efedf52dbe3290126c6e273621ad1ab0f3b7abd5L502-R504)

**Code cleanup and refactoring:**
- Removes obsolete code for adding PDF notes to NOTES.md, and cleans up editor handle logic now that annotations are managed separately. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L14-R14) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L411-L413) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L424-L454) [[4]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L2299-L2302)

**Testing and roadmap:**
- Updates test plans and the development roadmap to reflect the new annotation system, its features, and future plans for export/sync with `highlights.md` and HTML annotation support. [[1]](diffhunk://#diff-f81f58b3340f113c5207de20179792a705c31761a9f052afecd088f9ce0067d3L288-R297) [[2]](diffhunk://#diff-1e8cc84eb38f5303ab16a6a42642734c17c96da2558c055b2406d71bdde6a4f5L203-R210) [[3]](diffhunk://#diff-ec84baa7418ec58350d59604efedf52dbe3290126c6e273621ad1ab0f3b7abd5L396-R397) [[4]](diffhunk://#diff-ec84baa7418ec58350d59604efedf52dbe3290126c6e273621ad1ab0f3b7abd5L502-R504)

These changes collectively deliver a robust, user-friendly PDF annotation experience, laying the foundation for future enhancements like annotation export and cross-format support.