### PR TITLE
fix: update catalog path on rename and detect TeX in lazy-loaded source/

### DIFF
--- a/src-tauri/src/features/catalog/papers.rs
+++ b/src-tauri/src/features/catalog/papers.rs
@@ -299,7 +299,16 @@ pub fn rebuild_from_disk(vault_root: &Path) -> Result<usize, AppError> {
     while let Some(dir) = stack.pop() {
         if dir.join("metadata.json").is_file() {
             // A paper folder is a leaf: re-import it and do not descend.
-            if let Some(record) = record_from_metadata(vault_root, &dir) {
+            if let Some(mut record) = record_from_metadata(vault_root, &dir) {
+                // When body_source is unknown, scan the local folder for TeX files
+                // so papers with TeX in lazy‑loaded source/ don't show a false
+                // "download TeX" indicator in the frontend.
+                if record.body_source.is_none() && has_local_tex_in_tree(&dir) {
+                    record.body_source = Some("latex".to_string());
+                    if record.body_quality.is_none() {
+                        record.body_quality = Some("high".to_string());
+                    }
+                }
                 if upsert_conn(&conn, &record).is_ok() {
                     count += 1;
                 }
@@ -316,6 +325,34 @@ pub fn rebuild_from_disk(vault_root: &Path) -> Result<usize, AppError> {
         }
     }
     Ok(count)
+}
+
+/// True when a paper folder (or its source/ subdirectory) contains at least one
+/// .tex or .ltx file. Scans the filesystem directly, so it works for lazy‑loaded
+/// directories that the file tree skips.
+fn has_local_tex_in_tree(dir: &Path) -> bool {
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(current) = stack.pop() {
+        if !current.is_dir() {
+            continue;
+        }
+        if let Ok(entries) = fs::read_dir(&current) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    if stack.len() < 64 {
+                        stack.push(path);
+                    }
+                } else if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+                    let lower = ext.to_ascii_lowercase();
+                    if lower == "tex" || lower == "ltx" {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
 }
 
 /// Read a paper folder's `metadata.json`, re-injecting the folder path (which

--- a/src-tauri/src/features/import/mod.rs
+++ b/src-tauri/src/features/import/mod.rs
@@ -483,6 +483,21 @@ pub async fn download_paper_assets_with_progress(
     )
     .await?;
 
+    // When TeX was downloaded into source/, record body_source = "latex" in catalog
+    // so the frontend doesn't show "download TeX" even though source/ is lazy‑loaded.
+    if result.tex {
+        if let Ok(Some(mut row)) = papers::get_by_path(&vault, &path_rel) {
+            let changed = row.body_source.as_deref() != Some("latex");
+            if changed {
+                row.body_source = Some("latex".to_string());
+                row.body_quality = Some("high".to_string());
+                row.updated_at =
+                    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+                let _ = papers::upsert_paper(&vault, &row);
+            }
+        }
+    }
+
     // After download: no TeX + has PDF → liteparse PAPER.md
     let parse = crate::features::import::pdf_parse::maybe_generate_paper_md_after_download(
         &vault, &path_rel, &paper_dir,

--- a/src-tauri/src/features/vault/commands.rs
+++ b/src-tauri/src/features/vault/commands.rs
@@ -1,5 +1,6 @@
 use crate::core::error::{map_err, ApiResult, AppError};
 use crate::core::log_util::{trunc, OpTimer};
+use crate::features::catalog::papers as catalog_papers;
 use crate::features::vault::tree::VaultTreeNode;
 use crate::features::vault::{self, tree, CreateVaultResult};
 use crate::features::wiki::models::{
@@ -183,7 +184,11 @@ pub fn wiki_move(
         &args.from_rel,
         &args.to_rel,
         &args.dirty_paths,
-        || Ok(()),
+        || {
+            catalog_papers::move_under_path(&vault, &args.from_rel, &args.to_rel)
+                .map(|_| ())
+                .map_err(|error| error.to_string())
+        },
     ) {
         Ok(result) => ApiResult::ok(result),
         Err(error) => map_err(AppError::message(error.to_string())),

--- a/src/components/sidebar/file-tree.tsx
+++ b/src/components/sidebar/file-tree.tsx
@@ -1552,11 +1552,11 @@ export const FileTree = memo(
 		);
 
 		const renderPaperRow = (node: FileNode): ReactNode => {
-			const downloadReasons = paperAssetDownloadReasons(node);
-			const showDownload =
-				Boolean(onDownloadPaperAssets) && downloadReasons.length > 0;
 			const rel = relPathForNode(node.path);
 			const meta = paperMetaByRelPath?.get(rel) ?? null;
+			const downloadReasons = paperAssetDownloadReasons(node, meta);
+			const showDownload =
+				Boolean(onDownloadPaperAssets) && downloadReasons.length > 0;
 			const label = formatPaperTreeLabel(paperTreeLabelMode, meta, node.name);
 			const showRead =
 				Boolean(onReadPaper) && !showDownload && paperNeedsRead(node, meta);

--- a/src/lib/paper/assets.ts
+++ b/src/lib/paper/assets.ts
@@ -64,30 +64,42 @@ export type PaperDownloadReason = "noPdf" | "noBody";
  *
  * Click: download PDF to paper folder root; arXiv TeX into `source/`; if no TeX → liteparse PAPER.md.
  * Note: `source/` is only required for TeX archives — PDF alone does not require `source/`.
+ *
+ * `meta` is optional catalog metadata. When present, its `body_source` field
+ * overrides the file-tree scan: `source/` is lazy‑loaded so TeX files inside it
+ * are never visible to `paperHasLocalTex`.
  */
 export function paperAssetDownloadReasons(
 	node: TreeWalkNode,
+	meta?: { body_source?: string } | null,
 ): PaperDownloadReason[] {
 	const reasons: PaperDownloadReason[] = [];
 	if (!paperHasLocalPdf(node)) reasons.push("noPdf");
-	// Body: TeX wins; only flag when neither TeX nor PAPER.md exists
-	if (!paperHasLocalTex(node) && !paperHasLocalPaperMd(node)) {
+	// Body: trust catalog body_source when set (source/ is lazy‑loaded).
+	const bodyKnown = meta?.body_source != null && meta.body_source !== "";
+	if (!bodyKnown && !paperHasLocalTex(node) && !paperHasLocalPaperMd(node)) {
 		reasons.push("noBody");
 	}
 	return reasons;
 }
 
 /** Show file-tree Download when PDF / source / readable body is incomplete. */
-export function paperNeedsAssetDownload(node: TreeWalkNode): boolean {
-	return paperAssetDownloadReasons(node).length > 0;
+export function paperNeedsAssetDownload(
+	node: TreeWalkNode,
+	meta?: { body_source?: string } | null,
+): boolean {
+	return paperAssetDownloadReasons(node, meta).length > 0;
 }
 
 /**
  * Local assets are complete enough for reading / paper-reader:
  * PDF present, and TeX or PAPER.md as readable body.
  */
-export function paperAssetsComplete(node: TreeWalkNode): boolean {
-	return paperAssetDownloadReasons(node).length === 0;
+export function paperAssetsComplete(
+	node: TreeWalkNode,
+	meta?: { body_source?: string } | null,
+): boolean {
+	return paperAssetDownloadReasons(node, meta).length === 0;
 }
 
 /**
@@ -95,8 +107,8 @@ export function paperAssetsComplete(node: TreeWalkNode): boolean {
  */
 export function paperNeedsRead(
 	node: TreeWalkNode,
-	meta: { is_read?: boolean } | null | undefined,
+	meta: { is_read?: boolean; body_source?: string } | null | undefined,
 ): boolean {
-	if (!paperAssetsComplete(node)) return false;
+	if (!paperAssetsComplete(node, meta)) return false;
 	return !(meta?.is_read === true);
 }


### PR DESCRIPTION
针对 #107 问题的PR所作的修改

问题：
重命名论文时 wiki_move 未更新 catalog 的 path 字段，导致 is_read、body_source 等元数据丢失，论文显示为未精读。
同时 source/ 目录在文件树中lazy-loaded，paperHasLocalTex 扫描不到里面的 .tex 文件，导致已下载 TeX的论文仍显示"下载 TeX"按钮

修复：
wiki_move 的 commit 闭包中加入 papers::move_under_path
利用 body_source ， TeX 下载成功后设置 body_source="latex"
rebuild_from_disk 扫描 TeX 文件并回填 body_source
前端 paperAssetDownloadReasons 优先信任 catalog 的 body_source