### PR TITLE
refactor: 视觉批注裁剪改存 mark 资产，PDF 工作区按需恢复

### DIFF
--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -276,6 +276,7 @@ Agent：`agent_run_once` / `agent_warm` 在 vault 为 `remote:…` 时经 SSH `b
 - **行为**
   - 创建 label 为 `agentero-<uuid>` 的 Webview 窗口，URL 带 `?fresh=1`（不自动恢复上次 Vault）。
   - 窗口尺寸 / macOS overlay 标题栏与主窗口一致。
+  - 窗口初始隐藏，由全局 page-load hook 在页面加载完成后显示；首个 React commit 前显示静态启动壳。
   - Capability 覆盖 `main` 与 `agentero-*`（见 `src-tauri/capabilities/default.json`）。
   - 菜单点击由 Host 直接调用，不经过前端 event 往返（Host 内用 `tauri::async_runtime::spawn` 调用）。
   - **必须是 `async` command**：同步 command 在主线程、且处于调用方 webview 的 IPC 回调内执行，Windows 上从那里 build webview 会卡死（wry 进入嵌套消息循环等 WebView2 controller 回调，而该回调要等当前处理器返回），新窗口表现为空白且无法关闭。
@@ -297,6 +298,7 @@ Agent：`agent_run_once` / `agent_warm` 在 vault 为 `remote:…` 时经 SSH `b
 - **行为**
   - 若 label 为 `settings` 的窗口已存在，则将其聚焦并返回；否则新建。
   - URL 带 `?window=settings&section=...&vault_path=...`，由 `src/main.tsx` 分支渲染轻量 Settings 页面（不加载完整 `App`）。
+  - 新窗口初始隐藏，由全局 page-load hook 在页面加载完成后显示；首个 React commit 前显示静态启动壳。
   - macOS 使用 Overlay 标题栏与原生交通灯；Windows / Linux 使用系统原生窗口边框（OS 自绘标题栏与 caption 按钮）。
   - 窗口关闭时 Host 向所有窗口 `emit("settings_window_closed", ())`，便于主窗口同步 Settings 打开状态（实现 `⌘,` _toggle_）；建窗失败时也会 emit 一次，避免 toggle 卡在“已打开”。
   - 与 `window_new` 同理，**必须是 `async` command**。

--- a/docs/backend/data-model.md
+++ b/docs/backend/data-model.md
@@ -30,7 +30,7 @@ Vault/
 papers/<id>/
 ├── NOTES.md          # 人/Agent 笔记
 ├── <id>.pdf          # 可选
-├── marks/            # 高亮/批注/提问/翻译 JSON
+├── marks/            # 高亮/批注/提问/翻译 JSON 与 mark 自有资产
 ├── source/           # TeX 等（可懒加载）
 │   └── agentero-cite.json  # 参考文献 sidecar（可重建，见 api.md paper_refs_parse）
 ├── PAPER.md          # 无 TeX 时 liteparse 正文
@@ -42,7 +42,18 @@ papers/<id>/
 
 - 高亮/批注：`annotations.json`（含 `comment` 的为批注）
 - 提问/翻译：`<id>.json`（`kind`）
+- 视觉批注：`<id>.json`（`kind: agent-trace`）保存位置、会话与 `image.path`；裁剪图片位于 `assets/<id>.png`
 - 不写 PDF 二进制，不强制写入 NOTES
+
+```text
+marks/
+├── annotations.json
+├── <id>.json
+└── assets/
+    └── <agent-trace-id>.png
+```
+
+`marks/assets/` 由 mark 拥有，删除视觉批注时同步删除对应图片。列表与轮询只解析 JSON；悬浮预览、打开 Agent 或 Wiki 嵌入需要图片时才读取二进制。该目录与 Paper 单元根部供 `NOTES.md` 引用的 `assets/` 分开。
 
 ## Markdown 内嵌图
 

--- a/docs/backend/logging.md
+++ b/docs/backend/logging.md
@@ -8,5 +8,5 @@
 
 - 与用户 Toast / `ApiResult` **分层**：日志不替代错误 UX。
 - 关键操作记录 op start/end。
-- 前端启动：`main.tsx` 在 `op start/end frontend_boot` 之间输出 `boot stage=<阶段> ms=<累计>`（logger / settings / theme / i18n / 模块加载）。计时基准是 `performance.now()`，即从页面导航开始，因此包含 HTML 与入口模块本身的加载；多窗口时用末尾的 `window=main|settings` 区分。
+- 前端启动：`main.tsx` 在 `op start/end frontend_boot` 之间输出 `boot stage=<阶段> ms=<累计>`（entry / settings / theme / i18n / 模块加载）。计时基准是 `performance.now()`，即从页面导航开始，因此包含 HTML 与入口模块本身的加载；多窗口时用末尾的 `window=main|settings` 区分。dev 环境的 Webview console 日志桥接异步附加，不阻塞启动链。
 - 日志目录由插件约定（Windows 为 `%LOCALAPPDATA%\<identifier>\logs\agentero.log`）；设置内「打开日志文件夹」若未做则仍可用系统日志路径排查。

--- a/docs/frontend/pdf.md
+++ b/docs/frontend/pdf.md
@@ -33,13 +33,14 @@
 | 提问 | `marks/<id>.json`（kind ask） | 迷你问答；页边针 |
 | 加入对话 | 不落盘 | 选区固定为 Agent composer 文本 chip，见 [agent.md](agent.md) |
 | 翻译 | `marks/<id>.json`（kind translate） | [translate.md](translate.md) |
-| 视觉批注 | `marks/<id>.json`（kind `agent-trace`）；`providerSessionId` 为源会话；`messages[]` 本地多轮 transcript（续聊也会落盘） | 框选 → **Enter** → composer；**⌘↵** → 浮层。多轮续聊走 ACP 同一 session（load/resume），同时 `beginTraceContinue` + complete 更新 mark。打开 Agent 与 pin 共享 `providerSessionId` / `visualTraceId` |
+| 视觉批注 | `marks/<id>.json`（kind `agent-trace`）保存会话与 `image.path`；裁剪图位于 `marks/assets/<id>.png`；`providerSessionId` 为源会话；`messages[]` 本地多轮 transcript（续聊也会落盘） | 框选 → **Enter** → composer；**⌘↵** → 浮层。多轮续聊走 ACP 同一 session（load/resume），同时 `beginTraceContinue` + complete 更新 mark。打开 Agent 与 pin 共享 `providerSessionId` / `visualTraceId` |
 
 - 不改 PDF 二进制；不自动写入 `NOTES.md`。
 - 提问 Agent 可与面板默认 Agent 分开配置。
 - 坐标归一化；多段 rect 支持双栏。
 - 旧版 visual Ask（`kind: ask` + `visualKind`）仍可读、可打开。
 - 一次提交可包含多条视觉批注：prompt 按 `## Annotation N` 分点，图片顺序与 annotation 对齐。
+- 视觉裁剪不以 base64 写入 mark JSON；活动 PDF 的 marks 轮询只读取 metadata，悬浮卡片、打开 Agent 与 Wiki 嵌入按需读取图片。图片缺失时仍保留位置、批注和多轮 transcript。
 - **写进笔记**：批注面板复制 / `[[@id]]` / `![[…@id]]`，见 [wiki.md](wiki.md) 编辑器 `@` 说明。
 
 ## 代码
@@ -52,7 +53,7 @@
 | `src/components/viewer/pdf-ask/visual-annotation-editor.tsx` | 框选后批注编辑器 |
 | `src/components/viewer/pdf-citation-preview.tsx` | 文中引用悬浮预览 |
 | `src/lib/agent/visual-context-store.ts` | Agent composer 视觉批注草稿 |
-| `src/lib/pdf/agent-trace/` | agent-trace 契约 / IO / prompt / Open-in-Agent 重建 / 会话回跳 pending |
+| `src/lib/pdf/agent-trace/` | agent-trace 契约 / mark 资产 IO / prompt / Open-in-Agent 重建 / 会话回跳 pending |
 | `src/lib/pdf/highlight/` | 高亮 / 批注 |
 | `src/lib/pdf/ask/` | 划词提问 |
 | `src/lib/pdf/region.ts` | 区域坐标归一化与 PDF rect 转换 |

--- a/docs/frontend/pdf.md
+++ b/docs/frontend/pdf.md
@@ -9,6 +9,8 @@
 
 任意 Vault 路径 `.pdf` 可 `blob:` 预览；论文单元：本地优先 → 自动下载 → 远程 `pdf_url` 回退。HTML 用远程 `html_url` iframe（不注入主 DOM）。
 
+PDFium engine 由窗口共享并在主线程运行。Engine 宿主位于 React StrictMode 外，异步初始化即使在完成前被卸载也会主动销毁结果，避免 dev reload 遗留孤儿 WASM engine。工作区只挂载当前可见与最近使用的至多两个 PDF viewer；恢复的隐藏 PDF 标签按需 hydrate，退出保留集合的本地 PDF 字节会释放并在再次激活时重新读取。
+
 ## 阅读能力
 
 | 能力 | 说明 |

--- a/docs/frontend/shell.md
+++ b/docs/frontend/shell.md
@@ -15,6 +15,7 @@
 - 无 Vault：最近路径 MRU、打开 / 创建 / 从 Zotero 迁移。
 - `⌘N` → Host `window_new`（`?fresh=1`）；Vault 与 dock 布局按窗口 session 隔离。
 - 当前窗口 Vault：`sessionStorage`；MRU / 上次路径：`localStorage`。
+- 桌面窗口在 Webview 页面加载完成后显示；React 首次提交前由 `index.html` 的零依赖启动壳占位，避免冷启动和 dev 模块加载期间出现空白窗口。
 
 ## 全局 Toast
 

--- a/docs/frontend/workspace.md
+++ b/docs/frontend/workspace.md
@@ -21,6 +21,8 @@
 
 布局只存 dockview `toJSON()`；path/mode 在 panel params。
 
+启动恢复只 hydrate 每个 Dockview group 当前可见的 panel；隐藏标签在首次切换到前台时再读取资源。PDFium 保留当前可见与最近使用的至多两个 PDF viewer，本地 PDF `ArrayBuffer` 离开保留集合后释放，避免多标签工作区重启时并发加载全部 PDF 并长期占用 WebContent 内存。
+
 ## 面板类型
 
 Library · Trash · PDF · HTML · 图片 · Markdown · 论文 NOTES。

--- a/index.html
+++ b/index.html
@@ -4,10 +4,70 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Agentero</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+
+      html,
+      body,
+      #root {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+      }
+
+      body {
+        background: #fafafa;
+      }
+
+      #boot-shell {
+        display: grid;
+        width: 100%;
+        height: 100%;
+        place-items: center;
+      }
+
+      #boot-spinner {
+        width: 24px;
+        height: 24px;
+        border: 2px solid #d4d4d8;
+        border-top-color: #52525b;
+        border-radius: 9999px;
+        animation: boot-spin 800ms linear infinite;
+      }
+
+      @keyframes boot-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #09090b;
+        }
+
+        #boot-spinner {
+          border-color: #3f3f46;
+          border-top-color: #d4d4d8;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        #boot-spinner {
+          animation: none;
+        }
+      }
+    </style>
   </head>
 
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div id="boot-shell" aria-hidden="true">
+        <div id="boot-spinner"></div>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -68,15 +68,17 @@ pub fn run() {
 
     builder = handlers::attach_handlers(builder);
 
-    builder = builder.setup(|app| {
-        // Window chrome / show is desktop-only; mobile windows are managed by the
-        // embedder and do not expose these APIs.
-        #[cfg(not(target_os = "ios"))]
-        {
-            if let Some(win) = app.get_webview_window("main") {
-                let _ = win.show();
+    #[cfg(not(target_os = "ios"))]
+    {
+        builder = builder.on_page_load(|webview, payload| {
+            if matches!(payload.event(), tauri::webview::PageLoadEvent::Finished) {
+                // The HTML boot shell is ready now; reveal it while React hydrates.
+                let _ = webview.window().show();
             }
-        }
+        });
+    }
+
+    builder = builder.setup(|app| {
         // Native menu is macOS-only; the renderer re-syncs the locale on mount.
         #[cfg(target_os = "macos")]
         {

--- a/src-tauri/src/features/window/commands.rs
+++ b/src-tauri/src/features/window/commands.rs
@@ -46,6 +46,7 @@ pub async fn window_new(app: AppHandle) -> Result<(), String> {
             .title("Agentero")
             .inner_size(1280.0, 800.0)
             .min_inner_size(800.0, 520.0)
+            .visible(false)
             .resizable(true);
 
     #[cfg(target_os = "macos")]
@@ -117,6 +118,7 @@ pub async fn settings_window_open(
             .title("Settings")
             .inner_size(720.0, 560.0)
             .min_inner_size(640.0, 480.0)
+            .visible(false)
             .resizable(true);
 
     #[cfg(target_os = "macos")]

--- a/src/components/editor/wiki-annotation-embed.tsx
+++ b/src/components/editor/wiki-annotation-embed.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import { MessageResponse } from "@/components/ai-elements/message";
 import { cn } from "@/lib/core/utils";
+import { visualTraceImageAssetRelPath } from "@/lib/pdf/agent-trace/image";
 import {
 	type AnnotationRef,
 	annotationAnchorY,
@@ -81,7 +82,9 @@ function loadAnnotationState(
 	if (pending) return pending;
 
 	const paperAbs = paperAbsFromWikiTarget(vaultPath, targetPath);
-	const request = lookupAnnotationRef(paperAbs, annotationId)
+	const request = lookupAnnotationRef(paperAbs, annotationId, {
+		includeImage: true,
+	})
 		.then(
 			(ref): AnnotationLoadState =>
 				ref ? { kind: "ready", ref } : { kind: "missing" },
@@ -113,6 +116,10 @@ export function annotationEmbedWatchPaths(
 		joinVaultPath(
 			joinVaultPath(paperAbs, MARKS_FOLDER),
 			`${annotationId}.json`,
+		),
+		joinVaultPath(
+			joinVaultPath(paperAbs, MARKS_FOLDER),
+			visualTraceImageAssetRelPath(annotationId, "image/png"),
 		),
 	];
 }

--- a/src/components/editor/wiki-link-suggestion.tsx
+++ b/src/components/editor/wiki-link-suggestion.tsx
@@ -452,7 +452,9 @@ export function WikiLinkSuggestion({
 			const parentEntry = editor.api.parent(selection.anchor.path);
 			const stableLinkPath =
 				parentEntry && isWikiLinkNode(parentEntry[0]) ? parentEntry[1] : null;
-			controllerRef.current = null;
+			// Do not null controllerRef here. The layout effect only binds once
+			// (stable identity); clearing it permanently kills ↑/↓/Enter until
+			// remount. Closed menus are ignored via draftRef.current === null.
 			editor.tf.delete({ at: { anchor: start, focus: end } });
 			if (stableLinkPath) {
 				const parsed = parseWikiLinkMarkdown(markdown);
@@ -528,7 +530,7 @@ export function WikiLinkSuggestion({
 			);
 			return true;
 		},
-		[controllerRef, draft, editor, onClose, onContinue, request],
+		[draft, editor, onClose, onContinue, request],
 	);
 
 	const selectedIndexRef = useRef(selectedIndex);

--- a/src/components/viewer/embed/engine-provider.tsx
+++ b/src/components/viewer/embed/engine-provider.tsx
@@ -1,7 +1,12 @@
-import { usePdfiumEngine } from "@embedpdf/engines/react";
-import type { PdfEngine } from "@embedpdf/models";
+import { ignore, type PdfEngine } from "@embedpdf/models";
 import pdfiumWasmUrl from "@embedpdf/pdfium/pdfium.wasm?url";
-import { createContext, type ReactNode, useContext } from "react";
+import {
+	createContext,
+	type ReactNode,
+	useContext,
+	useEffect,
+	useState,
+} from "react";
 
 export type PdfEngineContextValue = {
 	engine: PdfEngine | null;
@@ -14,6 +19,55 @@ const PdfEngineContext = createContext<PdfEngineContextValue>({
 	isLoading: true,
 	error: null,
 });
+
+function disposePdfEngine(engine: PdfEngine): void {
+	const destroy = () => {
+		engine.destroy?.().wait(ignore, ignore);
+	};
+	engine.closeAllDocuments().wait(destroy, destroy);
+}
+
+function useAgenteroPdfEngine(): PdfEngineContextValue {
+	const [state, setState] = useState<PdfEngineContextValue>({
+		engine: null,
+		isLoading: true,
+		error: null,
+	});
+
+	useEffect(() => {
+		let cancelled = false;
+		let current: PdfEngine | null = null;
+
+		void import("@embedpdf/engines/pdfium-direct-engine")
+			.then(({ createPdfiumEngine }) =>
+				createPdfiumEngine(pdfiumWasmUrl, { fontFallback: null }),
+			)
+			.then((engine) => {
+				if (cancelled) {
+					disposePdfEngine(engine);
+					return;
+				}
+				current = engine;
+				setState({ engine, isLoading: false, error: null });
+			})
+			.catch((error: unknown) => {
+				if (cancelled) return;
+				setState({
+					engine: null,
+					isLoading: false,
+					error: error instanceof Error ? error : new Error(String(error)),
+				});
+			});
+
+		return () => {
+			cancelled = true;
+			if (current) disposePdfEngine(current);
+			current = null;
+		};
+	}, []);
+
+	return state;
+}
 
 /**
  * Creates the PDFium (WASM) engine once for the whole workspace window and
@@ -28,11 +82,7 @@ const PdfEngineContext = createContext<PdfEngineContextValue>({
  * wasm via the Vite `?url` asset) is used on every platform.
  */
 export function PdfEngineHost({ children }: { children: ReactNode }) {
-	const { engine, isLoading, error } = usePdfiumEngine({
-		wasmUrl: pdfiumWasmUrl,
-		worker: false,
-		fontFallback: null,
-	});
+	const { engine, isLoading, error } = useAgenteroPdfEngine();
 	return (
 		<PdfEngineContext.Provider value={{ engine, isLoading, error }}>
 			{children}

--- a/src/components/viewer/embed/pdf-viewer.tsx
+++ b/src/components/viewer/embed/pdf-viewer.tsx
@@ -164,6 +164,7 @@ import {
 	tracePin,
 	tracePreview,
 } from "@/lib/pdf/agent-trace";
+import { loadPdfVisualTraceImage } from "@/lib/pdf/agent-trace/image";
 import {
 	createEmptyThread,
 	deletePdfAskThread,
@@ -1808,7 +1809,7 @@ function PdfViewerInner({
 	}, [deleteVisualTraceById, hideActiveCard]);
 
 	const openVisualTraceSession = useCallback(
-		(trace: PdfVisualSessionTrace) => {
+		async (trace: PdfVisualSessionTrace) => {
 			// Same session as the pin modal — activate it in the shared store.
 			setAgentPanelMounted(true);
 			const store = agentSessionStore.getState();
@@ -1823,6 +1824,10 @@ function PdfViewerInner({
 			} else {
 				// Seed from mark once so sidebar opens the same transcript.
 				const messages = traceMessages(trace);
+				const image = await loadPdfVisualTraceImage(
+					paperAbsPath ?? "",
+					trace.image,
+				);
 				const title =
 					messages.find((m) => m.role === "user")?.content.trim() ||
 					trace.comment.trim() ||
@@ -1841,7 +1846,7 @@ function PdfViewerInner({
 						page: trace.page,
 						comment: trace.comment,
 						paperPath: trace.paperPath,
-						image: trace.image,
+						...(image ? { image } : {}),
 						messages: messages.map((m) => ({ ...m })),
 						status: trace.status,
 					},
@@ -1858,7 +1863,7 @@ function PdfViewerInner({
 		const card = activeCardRef.current;
 		if (card?.kind !== "agent-trace") return;
 		const tr = visualTracesRef.current.find((item) => item.id === card.id);
-		if (tr) openVisualTraceSession(tr);
+		if (tr) void openVisualTraceSession(tr);
 	}, [openVisualTraceSession]);
 
 	const handleStopVisualSession = useCallback(() => {
@@ -3187,6 +3192,7 @@ function PdfViewerInner({
 							{activeVisualTrace && cardScreen ? (
 								<VisualTraceCard
 									trace={activeVisualTrace}
+									paperAbsPath={paperAbsPath ?? undefined}
 									screen={cardScreen}
 									streaming={visualStreaming}
 									error={visualError}

--- a/src/components/viewer/pdf-ask/visual-trace-card.tsx
+++ b/src/components/viewer/pdf-ask/visual-trace-card.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/lib/agent/chat-state";
 import { stripPromptEnvelopeForDisplay } from "@/lib/agent/prompt-display";
 import { cn } from "@/lib/core/utils";
+import { loadPdfVisualTraceImage } from "@/lib/pdf/agent-trace/image";
 import { traceMessages, tracePreview } from "@/lib/pdf/agent-trace/schema";
 import type { PdfVisualSessionTrace } from "@/lib/pdf/agent-trace/types";
 
@@ -45,6 +46,7 @@ const EXPANDED = { width: 360, height: 440 } as const;
 
 type VisualTraceCardProps = {
 	trace: PdfVisualSessionTrace;
+	paperAbsPath?: string;
 	screen: { x: number; y: number };
 	streaming?: boolean;
 	error?: string | null;
@@ -174,16 +176,17 @@ type ModalTraceMessage = {
 /** Crop chip for the first user turn when store lines omit visualAnnotations. */
 function chipFromTrace(
 	trace: PdfVisualSessionTrace,
+	image: Awaited<ReturnType<typeof loadPdfVisualTraceImage>>,
 ): ChatVisualAnnotation | null {
-	if (!trace.image?.data) return null;
+	if (!image?.data) return null;
 	return {
 		id: trace.id,
 		page: trace.page,
 		comment: trace.comment,
 		paperPath: trace.paperPath,
 		image: {
-			data: trace.image.data,
-			mimeType: trace.image.mimeType || "image/png",
+			data: image.data,
+			mimeType: image.mimeType || "image/png",
 		},
 	};
 }
@@ -224,8 +227,9 @@ function chatLinesToTraceMessages(lines: ChatLine[]): ModalTraceMessage[] {
 function withTraceCropChip(
 	messages: ModalTraceMessage[],
 	trace: PdfVisualSessionTrace,
+	image: Awaited<ReturnType<typeof loadPdfVisualTraceImage>>,
 ): ModalTraceMessage[] {
-	const chip = chipFromTrace(trace);
+	const chip = chipFromTrace(trace, image);
 	if (!chip) return messages;
 	let attached = false;
 	return messages.map((m) => {
@@ -238,6 +242,7 @@ function withTraceCropChip(
 
 export const VisualTraceCard = memo(function VisualTraceCard({
 	trace,
+	paperAbsPath,
 	screen,
 	streaming: streamingProp = false,
 	error = null,
@@ -252,6 +257,34 @@ export const VisualTraceCard = memo(function VisualTraceCard({
 }: VisualTraceCardProps) {
 	const { t } = useTranslation("viewer");
 	const [expanded, setExpanded] = useState(initialExpanded);
+	const cropData = trace.image?.data;
+	const cropMimeType = trace.image?.mimeType || "image/png";
+	const cropPath = trace.image?.path;
+	const [cropImage, setCropImage] = useState<
+		Awaited<ReturnType<typeof loadPdfVisualTraceImage>>
+	>(cropData ? { data: cropData, mimeType: cropMimeType } : null);
+	useEffect(() => {
+		let cancelled = false;
+		if (cropData) {
+			setCropImage({
+				data: cropData,
+				mimeType: cropMimeType,
+			});
+			return () => {
+				cancelled = true;
+			};
+		}
+		setCropImage(null);
+		void loadPdfVisualTraceImage(
+			paperAbsPath ?? "",
+			cropPath ? { path: cropPath, mimeType: cropMimeType } : undefined,
+		).then((image) => {
+			if (!cancelled) setCropImage(image);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [cropData, cropMimeType, cropPath, paperAbsPath]);
 	// Same transcript as the right-rail Agent panel (single store).
 	const boundSessionId = useAgentSessionStore(
 		(s) =>
@@ -285,8 +318,8 @@ export const VisualTraceCard = memo(function VisualTraceCard({
 						content: m.content,
 					}));
 		// Pin crop chip on first user turn (matches Agent panel Open-in-Agent lines).
-		return withTraceCropChip(raw, trace);
-	}, [boundLines, trace]);
+		return withTraceCropChip(raw, trace, cropImage);
+	}, [boundLines, cropImage, trace]);
 	const preview = tracePreview(trace, t("pdfExplain.visualAnnotation"), 280);
 	const title = preview || t("pdfExplain.traceCardTitle");
 	/** Keep the user's annotation turn in view; do not auto-jump to the answer. */

--- a/src/components/workspace/dock-workspace.tsx
+++ b/src/components/workspace/dock-workspace.tsx
@@ -362,6 +362,12 @@ function reconcileAfterLayoutRestore(api: DockviewApi, list: DocTab[]): void {
 	reconcilePanelMembership(api, list);
 }
 
+function visiblePanelIds(api: DockviewApi): string[] {
+	return api.groups.flatMap((group) =>
+		group.activePanel ? [group.activePanel.id] : [],
+	);
+}
+
 type DockWorkspaceProps = {
 	tabs: DocTab[];
 	activePanelId: string | null;
@@ -370,6 +376,7 @@ type DockWorkspaceProps = {
 	pdfKeepMountedIds: string[];
 	centerProps: Omit<DocViewProps, "tab" | "active" | "pdfKeepMounted">;
 	onActivePanelChange: (panelId: string | null) => void;
+	onVisiblePanelIdsChange: (panelIds: string[]) => void;
 	onClosePanel: (panelId: string) => void;
 	onLayoutChange: (layout: unknown) => void;
 	/** Switch an HTML-backed paper panel between its PDF and HTML views. */
@@ -399,6 +406,7 @@ export const DockWorkspace = memo(
 			pdfKeepMountedIds,
 			centerProps,
 			onActivePanelChange,
+			onVisiblePanelIdsChange,
 			onClosePanel,
 			onLayoutChange,
 			onToggleHtmlMode,
@@ -422,6 +430,8 @@ export const DockWorkspace = memo(
 		onCloseRef.current = onClosePanel;
 		const onActiveRef = useRef(onActivePanelChange);
 		onActiveRef.current = onActivePanelChange;
+		const onVisibleRef = useRef(onVisiblePanelIdsChange);
+		onVisibleRef.current = onVisiblePanelIdsChange;
 		const onLayoutRef = useRef(onLayoutChange);
 		onLayoutRef.current = onLayoutChange;
 		const onToggleHtmlRef = useRef(onToggleHtmlMode);
@@ -471,15 +481,20 @@ export const DockWorkspace = memo(
 			}, 120);
 		}, []);
 
+		const publishVisiblePanels = useCallback((api: DockviewApi) => {
+			onVisibleRef.current(visiblePanelIds(api));
+		}, []);
+
 		const endSync = useCallback(
 			(api: DockviewApi) => {
 				requestAnimationFrame(() => {
 					syncingRef.current = false;
 					onActiveRef.current(api.activePanel?.id ?? null);
+					publishVisiblePanels(api);
 					scheduleLayoutSave(api);
 				});
 			},
-			[scheduleLayoutSave],
+			[publishVisiblePanels, scheduleLayoutSave],
 		);
 
 		const pdfKeepSet = useMemo(
@@ -595,6 +610,7 @@ export const DockWorkspace = memo(
 					api.onDidActivePanelChange((ev) => {
 						if (syncingRef.current) return;
 						onActiveRef.current(ev.panel?.id ?? null);
+						publishVisiblePanels(api);
 					}),
 					api.onDidRemovePanel((panel) => {
 						if (syncingRef.current) return;
@@ -603,6 +619,7 @@ export const DockWorkspace = memo(
 					// Single layout-save path (debounce). Programmatic + user changes
 					// (incl. tab-group rename / color / membership via toJSON).
 					api.onDidLayoutChange(() => {
+						if (!syncingRef.current) publishVisiblePanels(api);
 						scheduleLayoutSave(api);
 					}),
 				];
@@ -627,7 +644,7 @@ export const DockWorkspace = memo(
 					syncPanels(api);
 				}
 			},
-			[endSync, scheduleLayoutSave, syncPanels],
+			[endSync, publishVisiblePanels, scheduleLayoutSave, syncPanels],
 		);
 
 		// Sync membership when panel ids change (not titles).

--- a/src/components/workspace/workspace-host.tsx
+++ b/src/components/workspace/workspace-host.tsx
@@ -5,7 +5,7 @@
  * annotation updates re-render this host only — never the whole App.
  */
 
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { registerPdfHandle } from "@/components/viewer/pdf-viewer-registry";
 import {
@@ -49,9 +49,11 @@ import {
 	persistFile,
 } from "@/lib/workspace/actions";
 import { registerDockHandle } from "@/lib/workspace/dock-registry";
+import { evictPdfBuffers, nextPdfLru } from "@/lib/workspace/pdf-retention";
 import {
 	setDockLayout,
 	setPdfLru,
+	setTabs,
 	toggleTabHtmlMode,
 	updateTab,
 } from "@/lib/workspace/store";
@@ -63,7 +65,7 @@ import { savePersistedTabs } from "@/lib/workspace/tabs";
  * EmbedPDF/PDFium so switching among recent PDFs is instant without holding
  * every open document on the main thread.
  */
-const PDF_TAB_MOUNT_LRU = 4;
+const PDF_TAB_MOUNT_LRU = 2;
 
 function handleWorkspaceDrop(drop: WorkspaceExternalDrop): void {
 	const path = drop.paths[0];
@@ -98,27 +100,59 @@ export function WorkspaceHost() {
 	const libraryColumns = useSettings((s) => s.libraryColumns);
 	const editorFontSize = useSettings((s) => s.editorFontSize);
 	const showEditorToolbar = useSettings((s) => s.showEditorToolbar);
+	const [visiblePanelIds, setVisiblePanelIds] = useState<string[]>([]);
 
 	const activeTab = useMemo(
 		() => tabs.find((tab) => tab.id === activeTabId) ?? null,
 		[tabs, activeTabId],
 	);
 
-	// Keep active PDF panels plus a few recently viewed ones mounted.
+	const handleVisiblePanelIdsChange = useCallback((ids: string[]) => {
+		setVisiblePanelIds((previous) => {
+			if (
+				ids.length === previous.length &&
+				ids.every((id, index) => id === previous[index])
+			) {
+				return previous;
+			}
+			return ids;
+		});
+	}, []);
+
+	const visiblePdfIds = useMemo(() => {
+		const visible = new Set(visiblePanelIds);
+		return tabs
+			.filter((tab) => tab.mode === "pdf" && visible.has(tab.id))
+			.map((tab) => tab.id);
+	}, [tabs, visiblePanelIds]);
+
+	// Keep visible/recent PDF panels mounted without bootstrapping every restored PDF.
 	useEffect(() => {
 		const ids = tabs.filter((tab) => tab.mode === "pdf").map((tab) => tab.id);
 		const activePdf = activeTab?.mode === "pdf" ? activeTab.id : null;
-		if (!activePdf && !ids.length) return;
-		setPdfLru((prev) => {
-			let next = prev;
-			const promote = activePdf ? [activePdf, ...ids] : ids;
-			for (const id of promote) {
-				if (next[0] === id) continue;
-				next = [id, ...next.filter((x) => x !== id)];
-			}
-			return next.slice(0, PDF_TAB_MOUNT_LRU);
-		});
-	}, [activeTab?.mode, activeTab?.id, tabs]);
+		if (!ids.length) {
+			setPdfLru((previous) => (previous.length ? [] : previous));
+			return;
+		}
+		const promoted = activePdf
+			? [activePdf, ...visiblePdfIds.filter((id) => id !== activePdf)]
+			: visiblePdfIds;
+		setPdfLru((previous) =>
+			nextPdfLru(previous, ids, promoted, PDF_TAB_MOUNT_LRU),
+		);
+	}, [activeTab?.mode, activeTab?.id, tabs, visiblePdfIds]);
+
+	// Local PDF ArrayBuffers are large and keep PDFium documents alive indirectly.
+	// Evicted tabs become placeholders and reload only when one of their groups
+	// exposes them again.
+	useEffect(() => {
+		const retained = new Set([
+			...pdfLru,
+			...visiblePanelIds,
+			...(activeTab?.mode === "pdf" ? [activeTab.id] : []),
+		]);
+		setTabs((previous) => evictPdfBuffers(previous, retained));
+	}, [activeTab?.mode, activeTab?.id, pdfLru, visiblePanelIds]);
 
 	// Tree selection / create-parent follows the active document.
 	// Scoped library keeps the tree highlight on the org folder.
@@ -132,10 +166,16 @@ export function WorkspaceHost() {
 		setTreeSelectedPath(selectedPath);
 	}, [selectedPath, libraryScopePath, vaultPath]);
 
-	// After seeding placeholders from layout, load resources once (mount-only).
+	// Restore only panels visible in a dock group. Hidden historical tabs hydrate
+	// on activation, avoiding concurrent reads and PDFium mounts during startup.
 	useEffect(() => {
-		hydratePlaceholderTabs();
-	}, []);
+		const ids = visiblePanelIds.length
+			? visiblePanelIds
+			: activeTabId
+				? [activeTabId]
+				: [];
+		hydratePlaceholderTabs(ids);
+	}, [activeTabId, visiblePanelIds]);
 
 	// Default page: empty strip with a Vault open → show full Library.
 	useEffect(() => {
@@ -238,10 +278,12 @@ export function WorkspaceHost() {
 			layout={dockLayout}
 			pdfKeepMountedIds={[
 				...pdfLru,
+				...visiblePanelIds,
 				...(activeTab?.mode === "pdf" && activeTab ? [activeTab.id] : []),
 			]}
 			centerProps={centerProps}
 			onActivePanelChange={handleActivePanelChange}
+			onVisiblePanelIdsChange={handleVisiblePanelIdsChange}
 			onClosePanel={closeTab}
 			onLayoutChange={setDockLayout}
 			onToggleHtmlMode={toggleTabHtmlMode}

--- a/src/lib/paper/media.ts
+++ b/src/lib/paper/media.ts
@@ -1,12 +1,12 @@
-import { readDir, readFile } from "@tauri-apps/plugin-fs";
+import { readDir } from "@tauri-apps/plugin-fs";
 import { logger } from "@/lib/core/logger";
 import { joinPath } from "@/lib/core/path";
 import { isTauri } from "@/lib/core/tauri";
 import { arxivUrls } from "@/lib/paper/arxiv";
 import type { PaperMetadata } from "@/lib/paper/types";
+import { readVaultBytes } from "@/lib/vault";
 import {
 	parseRemoteJoinedPath,
-	remoteCacheFile,
 	remoteList,
 } from "@/lib/vault/remote/remote-vault";
 
@@ -32,21 +32,10 @@ export function isPdfViewerSource(
 	return false;
 }
 
-async function readVaultBytes(absPath: string): Promise<Uint8Array | null> {
+async function tryReadVaultBytes(absPath: string): Promise<Uint8Array | null> {
 	if (!isTauri() || !absPath?.trim()) return null;
 	try {
-		let bytes: Uint8Array;
-		const parsed = parseRemoteJoinedPath(absPath);
-		if (parsed) {
-			const localPath = await remoteCacheFile(parsed.sessionId, parsed.rel);
-			bytes = await readFile(localPath);
-		} else {
-			bytes = await readFile(absPath);
-		}
-		// Copy into a fresh ArrayBuffer consumers can own (plugin may return a view).
-		const copy = new Uint8Array(bytes.byteLength);
-		copy.set(bytes);
-		return copy;
+		return await readVaultBytes(absPath);
 	} catch (e) {
 		// Read failed (fs scope / OneDrive placeholder / missing file). Log so the
 		// silent fall back to a remote URL (which can fail CORS) is diagnosable.
@@ -69,7 +58,7 @@ export async function localBytesToViewerSource(
 	absPath: string,
 	mimeType: string,
 ): Promise<string | null> {
-	const bytes = await readVaultBytes(absPath);
+	const bytes = await tryReadVaultBytes(absPath);
 	if (!bytes) return null;
 	const blob = new Blob([bytes], { type: mimeType });
 	return URL.createObjectURL(blob);
@@ -97,7 +86,7 @@ export async function localPdfToViewerSource(
 export async function localFileToArrayBuffer(
 	absPath: string,
 ): Promise<ArrayBuffer | null> {
-	const bytes = await readVaultBytes(absPath);
+	const bytes = await tryReadVaultBytes(absPath);
 	return bytes ? bytes.buffer : null;
 }
 

--- a/src/lib/pdf/agent-trace/image.ts
+++ b/src/lib/pdf/agent-trace/image.ts
@@ -1,0 +1,129 @@
+import type { PromptImage } from "@/lib/agent/api";
+import type { PdfVisualSessionTrace } from "@/lib/pdf/agent-trace/types";
+import { joinVaultPath, readVaultBytes } from "@/lib/vault";
+
+export const VISUAL_TRACE_ASSET_FOLDER = "assets";
+
+export type PdfVisualTraceImageAssetWrite = {
+	path: string;
+	bytes: Uint8Array;
+};
+
+/** Accept only mark-local asset paths; never resolve absolute or parent paths. */
+export function normalizeVisualTraceImagePath(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const normalized = value.trim().replace(/\\/g, "/").replace(/^\.\//, "");
+	const parts = normalized.split("/");
+	if (
+		parts.length !== 2 ||
+		parts[0] !== VISUAL_TRACE_ASSET_FOLDER ||
+		!parts[1] ||
+		parts[1] === "." ||
+		parts[1] === ".."
+	) {
+		return null;
+	}
+	return normalized;
+}
+
+function imageExtension(mimeType: string): string {
+	switch (mimeType.toLowerCase()) {
+		case "image/jpeg":
+			return "jpg";
+		case "image/webp":
+			return "webp";
+		default:
+			return "png";
+	}
+}
+
+export function visualTraceImageAssetRelPath(
+	traceId: string,
+	mimeType: string,
+): string {
+	return `${VISUAL_TRACE_ASSET_FOLDER}/${encodeURIComponent(traceId)}.${imageExtension(mimeType)}`;
+}
+
+export function visualTraceImageAssetPath(
+	paperAbsPath: string,
+	imagePath: string,
+): string | null {
+	const rel = normalizeVisualTraceImagePath(imagePath);
+	return rel ? joinVaultPath(joinVaultPath(paperAbsPath, "marks"), rel) : null;
+}
+
+export function base64ToBytes(data: string): Uint8Array {
+	const binary = atob(data);
+	return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+export function bytesToBase64(bytes: Uint8Array): string {
+	let binary = "";
+	const chunkSize = 0x8000;
+	for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+		const chunk = bytes.subarray(offset, offset + chunkSize);
+		binary += String.fromCharCode(...chunk);
+	}
+	return btoa(binary);
+}
+
+/**
+ * Convert a runtime inline crop into the only on-disk representation.
+ * The returned trace is safe to serialize into the mark JSON.
+ */
+export function preparePdfVisualTraceImageWrite(trace: PdfVisualSessionTrace): {
+	trace: PdfVisualSessionTrace;
+	asset?: PdfVisualTraceImageAssetWrite;
+} {
+	const image = trace.image;
+	if (!image) return { trace };
+	if (image.data) {
+		const mimeType = image.mimeType || "image/png";
+		const path = visualTraceImageAssetRelPath(trace.id, mimeType);
+		return {
+			trace: {
+				...trace,
+				image: { path, mimeType },
+			},
+			asset: {
+				path,
+				bytes: base64ToBytes(image.data),
+			},
+		};
+	}
+	const path = normalizeVisualTraceImagePath(image.path);
+	if (!path) {
+		throw new Error("invalid visual trace image path");
+	}
+	return {
+		trace: {
+			...trace,
+			image: {
+				path,
+				mimeType: image.mimeType || "image/png",
+			},
+		},
+	};
+}
+
+/** Resolve a runtime crop or mark-owned asset only when a consumer needs it. */
+export async function loadPdfVisualTraceImage(
+	paperAbsPath: string,
+	image: PdfVisualSessionTrace["image"],
+): Promise<PromptImage | null> {
+	if (image?.data) {
+		return { data: image.data, mimeType: image.mimeType || "image/png" };
+	}
+	if (!image?.path || !paperAbsPath) return null;
+	const path = visualTraceImageAssetPath(paperAbsPath, image.path);
+	if (!path) return null;
+	try {
+		const bytes = await readVaultBytes(path);
+		return {
+			data: bytesToBase64(bytes),
+			mimeType: image.mimeType || "image/png",
+		};
+	} catch {
+		return null;
+	}
+}

--- a/src/lib/pdf/agent-trace/index.ts
+++ b/src/lib/pdf/agent-trace/index.ts
@@ -1,3 +1,4 @@
+export * from "@/lib/pdf/agent-trace/image";
 export * from "@/lib/pdf/agent-trace/io";
 export * from "@/lib/pdf/agent-trace/open-session";
 export * from "@/lib/pdf/agent-trace/pending";

--- a/src/lib/pdf/agent-trace/io.ts
+++ b/src/lib/pdf/agent-trace/io.ts
@@ -1,5 +1,10 @@
 import { nanoid } from "nanoid";
 
+import { isTauri } from "@/lib/core/tauri";
+import {
+	preparePdfVisualTraceImageWrite,
+	visualTraceImageAssetPath,
+} from "@/lib/pdf/agent-trace/image";
 import { isVisualTraceSessionPending } from "@/lib/pdf/agent-trace/pending";
 import { parsePdfVisualSessionTrace } from "@/lib/pdf/agent-trace/schema";
 import type {
@@ -9,6 +14,7 @@ import type {
 	PdfVisualTraceMessage,
 } from "@/lib/pdf/agent-trace/types";
 import { createMarkStore } from "@/lib/pdf/marks/io";
+import { writeVaultBytes } from "@/lib/vault";
 
 const store = createMarkStore<PdfVisualSessionTrace>({
 	parse: parsePdfVisualSessionTrace,
@@ -277,7 +283,7 @@ export async function reconcileOrphanRunningVisualTraces(
 		// they are not disk-backed long-term, but if one lands on disk, fail it too.
 		const failed = failTrace(trace, { error: errorMessage });
 		try {
-			await store.write(paperAbsPath, failed);
+			await writePdfVisualTrace(paperAbsPath, failed);
 		} catch {
 			// Best-effort: still surface the reconciled status in memory.
 		}
@@ -295,5 +301,25 @@ export async function listPdfVisualTraces(
 }
 
 export const readPdfVisualTrace = store.read;
-export const writePdfVisualTrace = store.write;
+
+export async function writePdfVisualTrace(
+	paperAbsPath: string,
+	trace: PdfVisualSessionTrace,
+): Promise<void> {
+	if (!isTauri()) {
+		await store.write(paperAbsPath, trace);
+		return;
+	}
+	const prepared = preparePdfVisualTraceImageWrite(trace);
+	if (prepared.asset) {
+		const assetPath = visualTraceImageAssetPath(
+			paperAbsPath,
+			prepared.asset.path,
+		);
+		if (!assetPath) throw new Error("invalid visual trace asset path");
+		await writeVaultBytes(assetPath, prepared.asset.bytes);
+	}
+	await store.write(paperAbsPath, prepared.trace);
+}
+
 export const deletePdfVisualTrace = store.remove;

--- a/src/lib/pdf/agent-trace/io.ts
+++ b/src/lib/pdf/agent-trace/io.ts
@@ -14,7 +14,7 @@ import type {
 	PdfVisualTraceMessage,
 } from "@/lib/pdf/agent-trace/types";
 import { createMarkStore } from "@/lib/pdf/marks/io";
-import { writeVaultBytes } from "@/lib/vault";
+import { removeVaultPath, writeVaultBytes } from "@/lib/vault";
 
 const store = createMarkStore<PdfVisualSessionTrace>({
 	parse: parsePdfVisualSessionTrace,
@@ -322,4 +322,23 @@ export async function writePdfVisualTrace(
 	await store.write(paperAbsPath, prepared.trace);
 }
 
-export const deletePdfVisualTrace = store.remove;
+export async function deletePdfVisualTrace(
+	paperAbsPath: string,
+	id: string,
+): Promise<void> {
+	if (!isTauri()) {
+		await store.remove(paperAbsPath, id);
+		return;
+	}
+	const trace = await store.read(paperAbsPath, id);
+	await store.remove(paperAbsPath, id);
+	const assetPath =
+		trace?.image?.path &&
+		visualTraceImageAssetPath(paperAbsPath, trace.image.path);
+	if (!assetPath) return;
+	try {
+		await removeVaultPath(assetPath);
+	} catch {
+		// Mark deletion remains successful when an owned asset is already missing.
+	}
+}

--- a/src/lib/pdf/agent-trace/schema.ts
+++ b/src/lib/pdf/agent-trace/schema.ts
@@ -1,3 +1,4 @@
+import { normalizeVisualTraceImagePath } from "@/lib/pdf/agent-trace/image";
 import type {
 	PdfVisualNormalizedRect,
 	PdfVisualSessionTrace,
@@ -14,12 +15,13 @@ function isStatus(v: unknown): v is PdfVisualTraceStatus {
 
 function parseImage(v: unknown): PdfVisualTraceImage | undefined {
 	if (!isRecord(v)) return undefined;
-	if (typeof v.data !== "string" || !v.data) return undefined;
+	const path = normalizeVisualTraceImagePath(v.path);
+	if (!path) return undefined;
 	const mimeType =
 		typeof v.mimeType === "string" && v.mimeType.trim()
 			? v.mimeType.trim()
 			: "image/png";
-	return { data: v.data, mimeType };
+	return { path, mimeType };
 }
 
 function parseMessages(v: unknown): PdfVisualTraceMessage[] | undefined {

--- a/src/lib/pdf/agent-trace/types.ts
+++ b/src/lib/pdf/agent-trace/types.ts
@@ -13,9 +13,13 @@ export type PdfVisualNormalizedRect = {
 
 export type PdfVisualTraceStatus = "running" | "completed" | "failed";
 
-/** Crop snapshot for hover/list preview (base64, no data: prefix). */
+/**
+ * Crop snapshot. `data` exists only before the first write or after an explicit
+ * asset load; persisted marks contain `path` relative to `marks/`.
+ */
 export type PdfVisualTraceImage = {
-	data: string;
+	data?: string;
+	path?: string;
 	mimeType: string;
 };
 

--- a/src/lib/pdf/annotation-ref.ts
+++ b/src/lib/pdf/annotation-ref.ts
@@ -12,6 +12,7 @@
  */
 
 import { paperDirFromPath } from "@/lib/paper/detect";
+import { loadPdfVisualTraceImage } from "@/lib/pdf/agent-trace/image";
 import { listPdfVisualTraces } from "@/lib/pdf/agent-trace/io";
 import {
 	parsePdfVisualSessionTrace,
@@ -217,6 +218,7 @@ export async function lookupAnnotationRef(
 	const trace = parsePdfVisualSessionTrace(raw);
 	if (trace && trace.id === id) {
 		const messages = traceMessages(trace);
+		const image = await loadPdfVisualTraceImage(paperAbsPath, trace.image);
 		return {
 			kind: "agent-trace",
 			id,
@@ -224,7 +226,7 @@ export async function lookupAnnotationRef(
 			page: trace.page,
 			quote: "",
 			comment: trace.comment,
-			image: trace.image,
+			...(image ? { image } : {}),
 			rects: rectsFromVisual(trace.rects),
 			...(messages.length ? { messages } : {}),
 		};

--- a/src/lib/pdf/annotation-ref.ts
+++ b/src/lib/pdf/annotation-ref.ts
@@ -175,6 +175,7 @@ function transferItemId(item: unknown): string | null {
 export async function lookupAnnotationRef(
 	paperAbsPath: string,
 	id: string,
+	options?: { includeImage?: boolean },
 ): Promise<AnnotationRef | null> {
 	if (!paperAbsPath || !id) return null;
 
@@ -218,7 +219,9 @@ export async function lookupAnnotationRef(
 	const trace = parsePdfVisualSessionTrace(raw);
 	if (trace && trace.id === id) {
 		const messages = traceMessages(trace);
-		const image = await loadPdfVisualTraceImage(paperAbsPath, trace.image);
+		const image = options?.includeImage
+			? await loadPdfVisualTraceImage(paperAbsPath, trace.image)
+			: null;
 		return {
 			kind: "agent-trace",
 			id,

--- a/src/lib/pdf/selection/marks-io.ts
+++ b/src/lib/pdf/selection/marks-io.ts
@@ -10,7 +10,12 @@
 import { readDir } from "@tauri-apps/plugin-fs";
 
 import { isTauri } from "@/lib/core/tauri";
-import { joinVaultPath, readVaultFile, writeVaultFile } from "@/lib/vault";
+import {
+	joinVaultPath,
+	readVaultFile,
+	removeVaultPath,
+	writeVaultFile,
+} from "@/lib/vault";
 
 export const MARKS_FOLDER = "marks";
 
@@ -85,8 +90,7 @@ export async function deleteMarkFile(
 ): Promise<void> {
 	if (!isTauri() || !paperAbsPath || !id) return;
 	try {
-		const { remove } = await import("@tauri-apps/plugin-fs");
-		await remove(markPath(paperAbsPath, id));
+		await removeVaultPath(markPath(paperAbsPath, id));
 	} catch {
 		// missing is fine
 	}

--- a/src/lib/vault/fs.ts
+++ b/src/lib/vault/fs.ts
@@ -1,8 +1,9 @@
-import { readTextFile } from "@tauri-apps/plugin-fs";
+import { readFile, readTextFile } from "@tauri-apps/plugin-fs";
 import i18n from "@/i18n";
 import { isTauri } from "@/lib/core/tauri";
 import {
 	parseRemoteJoinedPath,
+	remoteCacheFile,
 	remoteMkdir,
 	remoteReadText,
 	remoteRemove,
@@ -33,6 +34,29 @@ export async function readVaultFile(path: string): Promise<string> {
 	}
 
 	return readTextFile(path);
+}
+
+/** Read a local or remote Vault file into an owned byte array. */
+export async function readVaultBytes(path: string): Promise<Uint8Array> {
+	if (!isTauri()) {
+		throw new Error(i18n.t("app:vault.readDesktopOnly"));
+	}
+
+	const remoteRead = parseRemoteJoinedPath(path);
+	let bytes: Uint8Array;
+	if (remoteRead) {
+		if (!remoteRead.rel) throw new Error("invalid remote path");
+		const localPath = await remoteCacheFile(
+			remoteRead.sessionId,
+			remoteRead.rel,
+		);
+		bytes = await readFile(localPath);
+	} else {
+		bytes = await readFile(path);
+	}
+	const copy = new Uint8Array(bytes.byteLength);
+	copy.set(bytes);
+	return copy;
 }
 
 /** Write text file (creates parent dirs when possible). */

--- a/src/lib/vault/index.ts
+++ b/src/lib/vault/index.ts
@@ -4,6 +4,7 @@ export {
 	isTextOpenable,
 	readVaultBytes,
 	readVaultFile,
+	removeVaultPath,
 	writeVaultBytes,
 	writeVaultFile,
 } from "@/lib/vault/fs";

--- a/src/lib/vault/index.ts
+++ b/src/lib/vault/index.ts
@@ -2,6 +2,7 @@ export {
 	createVaultDirectory,
 	isMarkdownPath,
 	isTextOpenable,
+	readVaultBytes,
 	readVaultFile,
 	writeVaultBytes,
 	writeVaultFile,

--- a/src/lib/workspace/actions.ts
+++ b/src/lib/workspace/actions.ts
@@ -796,39 +796,63 @@ export function ensureLibraryTabPresent(): void {
 	setActiveTabId(ensured.activeId);
 }
 
-/** Load resources for restored placeholder panels (mount-only hydrate). */
-export function hydratePlaceholderTabs(): void {
+const placeholderLoads = new Set<string>();
+
+/** Load resources for restored panels only when their dock group exposes them. */
+export function hydratePlaceholderTabs(tabIds: readonly string[]): void {
 	if (!isTauri() || !getVaultPath()) return;
 	if (!getTabs().length) {
 		ensureLibraryTabPresent();
 		return;
 	}
-	for (const tab of getTabs()) {
-		if (tab.loaded) continue;
+	for (const id of new Set(tabIds)) {
+		const tab = getTabs().find((candidate) => candidate.id === id);
+		if (!tab || tab.loaded || placeholderLoads.has(id)) continue;
+		placeholderLoads.add(id);
 		void (async () => {
 			const vaultState = vaultStore.getState();
-			const res = await loadTabResources(
-				tab.path,
-				vaultState.vaultPath,
-				vaultState.tree,
-				vaultState.paperFolders,
-			);
-			if (!getTabs().some((t) => t.id === tab.id)) return;
-			updateTab(tab.id, {
-				kind: res.kind,
-				title: res.title,
-				mode: res.mode,
-				paperMeta: res.paperMeta,
-				pdfUrl: res.pdfUrl,
-				pdfBytes: res.pdfBytes ?? null,
-				htmlUrl: res.htmlUrl,
-				imageUrl: res.imageUrl,
-				notesPath: res.notesPath,
-				notesSeed: res.notesSeed,
-				markdownSeed: res.markdownSeed,
-				seedKey: 1,
-				loaded: true,
-			});
+			try {
+				const res = await loadTabResources(
+					tab.path,
+					vaultState.vaultPath,
+					vaultState.tree,
+					vaultState.paperFolders,
+				);
+				const current = getTabs().find((candidate) => candidate.id === id);
+				if (
+					!current ||
+					current.path !== tab.path ||
+					vaultStore.getState().vaultPath !== vaultState.vaultPath
+				) {
+					return;
+				}
+				if (res.error) {
+					notifyError(
+						res.error === "cannotPreview"
+							? i18n.t("app:errors.cannotPreview", {
+									name: basenameOf(tab.path),
+								})
+							: res.error,
+					);
+				}
+				updateTab(id, {
+					kind: res.kind,
+					title: res.title,
+					mode: res.mode,
+					paperMeta: res.paperMeta,
+					pdfUrl: res.pdfUrl,
+					pdfBytes: res.pdfBytes ?? null,
+					htmlUrl: res.htmlUrl,
+					imageUrl: res.imageUrl,
+					notesPath: res.notesPath,
+					notesSeed: res.notesSeed,
+					markdownSeed: res.markdownSeed,
+					seedKey: 1,
+					loaded: true,
+				});
+			} finally {
+				placeholderLoads.delete(id);
+			}
 		})();
 	}
 }

--- a/src/lib/workspace/pdf-retention.ts
+++ b/src/lib/workspace/pdf-retention.ts
@@ -1,0 +1,42 @@
+import type { DocTab } from "@/lib/workspace/tabs/types";
+
+/** Keep promoted PDFs first, then retain still-open entries from the previous LRU. */
+export function nextPdfLru(
+	previous: string[],
+	availablePdfIds: readonly string[],
+	promotedIds: readonly string[],
+	limit: number,
+): string[] {
+	const available = new Set(availablePdfIds);
+	const seen = new Set<string>();
+	const next: string[] = [];
+	for (const id of [...promotedIds, ...previous]) {
+		if (!available.has(id) || seen.has(id)) continue;
+		seen.add(id);
+		next.push(id);
+		if (next.length >= limit) break;
+	}
+	if (
+		next.length === previous.length &&
+		next.every((id, index) => id === previous[index])
+	) {
+		return previous;
+	}
+	return next;
+}
+
+/** Release local PDF buffers after their viewer leaves the visible/recent set. */
+export function evictPdfBuffers(
+	tabs: DocTab[],
+	retainedIds: ReadonlySet<string>,
+): DocTab[] {
+	let changed = false;
+	const next = tabs.map((tab) => {
+		if (tab.mode !== "pdf" || tab.pdfBytes == null || retainedIds.has(tab.id)) {
+			return tab;
+		}
+		changed = true;
+		return { ...tab, pdfBytes: null, loaded: false };
+	});
+	return changed ? next : tabs;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -90,6 +90,8 @@ async function boot() {
 	// downloads/parses the heavyweight workspace bundle. The PDF engine host and
 	// KaTeX styles ride along here for the same reason: the settings webview has
 	// no viewer and no math, so it must not pay for PDFium or the KaTeX fonts.
+	// Keep the engine host outside StrictMode below so dev effect replay cannot
+	// initialize a second PDFium instance.
 	const [{ default: App }, { PdfEngineHost }] = await Promise.all([
 		import(isMobileApp() ? "./components/mobile/mobile-app" : "./App"),
 		import("@/components/viewer/embed/engine-provider"),
@@ -97,19 +99,19 @@ async function boot() {
 	]);
 	bootStage("app-module");
 	ReactDOM.createRoot(root).render(
-		<React.StrictMode>
-			<I18nextProvider i18n={i18n}>
-				<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-					<TooltipProvider delayDuration={300}>
-						<PdfEngineHost>
+		<PdfEngineHost>
+			<React.StrictMode>
+				<I18nextProvider i18n={i18n}>
+					<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+						<TooltipProvider delayDuration={300}>
 							<App />
-						</PdfEngineHost>
-						{/* Global error / notice stack (top-right); use notifyError from @/lib/notify */}
-						<Toaster />
-					</TooltipProvider>
-				</ThemeProvider>
-			</I18nextProvider>
-		</React.StrictMode>,
+							{/* Global error / notice stack (top-right); use notifyError from @/lib/notify */}
+							<Toaster />
+						</TooltipProvider>
+					</ThemeProvider>
+				</I18nextProvider>
+			</React.StrictMode>
+		</PdfEngineHost>,
 	);
 	logger.info(
 		`op end frontend_boot ok=true duration_ms=${bootElapsed()} window=main`,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -32,9 +32,9 @@ function bootStage(name: string) {
 }
 
 async function boot() {
-	await initLogger();
+	void initLogger();
 	logger.info("op start frontend_boot");
-	bootStage("logger");
+	bootStage("entry");
 
 	// Host XDG settings.json (migrates legacy localStorage once).
 	await ensureSettingsLoaded();

--- a/test/pdf-agent-trace.test.ts
+++ b/test/pdf-agent-trace.test.ts
@@ -16,11 +16,14 @@ import {
 	buildVisualAnnotationsPrompt,
 	buildVisualTraceContinuePrompt,
 	buildVisualTraceHistoryItem,
+	bytesToBase64,
 	completeTrace,
 	createRunningTraces,
 	failTrace,
 	isVisualTraceSessionPending,
+	normalizeVisualTraceImagePath,
 	parsePdfVisualSessionTrace,
+	preparePdfVisualTraceImageWrite,
 	reconcileOrphanRunningVisualTraces,
 	rememberPendingVisualTraces,
 	resetPendingVisualTracesForTests,
@@ -169,7 +172,7 @@ describe("agent-trace schema and lifecycle", () => {
 			page: 3,
 			rects: [rect],
 			comment: "λ 是什么",
-			image: { data: "abc", mimeType: "image/png" },
+			image: { path: "assets/tr1.png", mimeType: "image/png" },
 			agentId: "agent-1",
 			runtimeSessionId: "sess-rt",
 			messageId: "msg-1",
@@ -182,11 +185,40 @@ describe("agent-trace schema and lifecycle", () => {
 		if (!t) return;
 		expect(t.kind).toBe("agent-trace");
 		expect(t.comment).toBe("λ 是什么");
-		expect(t.image?.data).toBe("abc");
+		expect(t.image?.path).toBe("assets/tr1.png");
 		expect(tracePreview(t)).toContain("λ");
 		const pin = tracePin(t);
 		expect(pin.x).toBeGreaterThan(0.3);
 		expect(pin.y).toBeCloseTo(0.275, 2);
+	});
+
+	it("rejects inline image data in persisted marks", () => {
+		const trace = parsePdfVisualSessionTrace({
+			version: 1,
+			kind: "agent-trace",
+			id: "inline",
+			paperPath: "papers/a",
+			page: 1,
+			rects: [rect],
+			comment: "inline",
+			image: { data: "abc", mimeType: "image/png" },
+			agentId: "a",
+			runtimeSessionId: "r",
+			messageId: "m",
+			status: "completed",
+			createdAt: "t1",
+			updatedAt: "t2",
+		});
+		expect(trace?.image).toBeUndefined();
+	});
+
+	it("normalizes mark-owned image paths", () => {
+		expect(normalizeVisualTraceImagePath("./assets/a.png")).toBe(
+			"assets/a.png",
+		);
+		expect(normalizeVisualTraceImagePath("assets\\a.png")).toBe("assets/a.png");
+		expect(normalizeVisualTraceImagePath("assets/nested/a.png")).toBeNull();
+		expect(normalizeVisualTraceImagePath("../a.png")).toBeNull();
 	});
 
 	it("rejects wrong kind or missing geometry", () => {
@@ -389,7 +421,7 @@ describe("agent-trace schema and lifecycle", () => {
 		expect(prompt).toContain("Page: 3");
 	});
 
-	it("round-trips create → complete → parse", () => {
+	it("externalizes create → complete before persisted parse", () => {
 		const [running] = createRunningTraces({
 			paperPath: "papers/x",
 			agentId: "a",
@@ -413,10 +445,23 @@ describe("agent-trace schema and lifecycle", () => {
 			answerSnapshot: "answer",
 			updatedAt: "2026-01-01T00:01:00.000Z",
 		});
-		const parsed = parsePdfVisualSessionTrace(
-			JSON.parse(JSON.stringify(completed)),
+		const prepared = preparePdfVisualTraceImageWrite({
+			...completed,
+			image: { data: "YWJj", mimeType: "image/png" },
+		});
+		expect(prepared.trace.image).toEqual({
+			path: "assets/fixed-id.png",
+			mimeType: "image/png",
+		});
+		expect(prepared.asset?.path).toBe("assets/fixed-id.png");
+		expect(bytesToBase64(prepared.asset?.bytes ?? new Uint8Array())).toBe(
+			"YWJj",
 		);
-		expect(parsed).toEqual(completed);
+		expect(JSON.stringify(prepared.trace)).not.toContain('"data"');
+		const parsed = parsePdfVisualSessionTrace(
+			JSON.parse(JSON.stringify(prepared.trace)),
+		);
+		expect(parsed).toEqual(prepared.trace);
 	});
 
 	it("synthesizes messages from comment + answerSnapshot for legacy marks", () => {

--- a/test/pdf-agent-trace.test.ts
+++ b/test/pdf-agent-trace.test.ts
@@ -19,11 +19,14 @@ import {
 	bytesToBase64,
 	completeTrace,
 	createRunningTraces,
+	deletePdfVisualTrace,
 	failTrace,
 	isVisualTraceSessionPending,
+	loadPdfVisualTraceImage,
 	normalizeVisualTraceImagePath,
 	parsePdfVisualSessionTrace,
 	preparePdfVisualTraceImageWrite,
+	readPdfVisualTrace,
 	reconcileOrphanRunningVisualTraces,
 	rememberPendingVisualTraces,
 	resetPendingVisualTracesForTests,
@@ -32,6 +35,7 @@ import {
 	tracePin,
 	tracePreview,
 	visualTraceHistoryId,
+	writePdfVisualTrace,
 } from "@/lib/pdf/agent-trace";
 
 const rect = { x: 0.1, y: 0.2, w: 0.4, h: 0.15 };
@@ -219,6 +223,41 @@ describe("agent-trace schema and lifecycle", () => {
 		expect(normalizeVisualTraceImagePath("assets\\a.png")).toBe("assets/a.png");
 		expect(normalizeVisualTraceImagePath("assets/nested/a.png")).toBeNull();
 		expect(normalizeVisualTraceImagePath("../a.png")).toBeNull();
+	});
+
+	it("loads inline runtime crops and degrades when an asset is missing", async () => {
+		await expect(
+			loadPdfVisualTraceImage("/vault/papers/a", {
+				data: "YWJj",
+				mimeType: "image/png",
+			}),
+		).resolves.toEqual({ data: "YWJj", mimeType: "image/png" });
+		await expect(
+			loadPdfVisualTraceImage("/vault/papers/a", {
+				path: "assets/missing.png",
+				mimeType: "image/png",
+			}),
+		).resolves.toBeNull();
+	});
+
+	it("deletes visual traces through the lifecycle wrapper", async () => {
+		const [trace] = createRunningTraces({
+			paperPath: "papers/delete",
+			agentId: "a",
+			runtimeSessionId: "r",
+			messageId: "m",
+			items: [{ id: "delete-me", page: 1, rects: [rect], comment: "q", image }],
+		});
+		expect(trace).toBeDefined();
+		if (!trace) return;
+		await writePdfVisualTrace("/vault/papers/delete", trace);
+		expect(
+			await readPdfVisualTrace("/vault/papers/delete", trace.id),
+		).not.toBeNull();
+		await deletePdfVisualTrace("/vault/papers/delete", trace.id);
+		expect(
+			await readPdfVisualTrace("/vault/papers/delete", trace.id),
+		).toBeNull();
 	});
 
 	it("rejects wrong kind or missing geometry", () => {

--- a/test/pdf-retention.test.ts
+++ b/test/pdf-retention.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { evictPdfBuffers, nextPdfLru } from "@/lib/workspace/pdf-retention";
+import { createPlaceholderTab, type DocTab } from "@/lib/workspace/tabs";
+
+function pdfTab(id: string, bytes: ArrayBuffer | null): DocTab {
+	return {
+		...createPlaceholderTab(id, "pdf"),
+		loaded: true,
+		pdfBytes: bytes,
+	};
+}
+
+describe("PDF workspace retention", () => {
+	it("promotes visible PDFs without loading every available restored tab", () => {
+		expect(nextPdfLru([], ["a", "b", "c", "d"], ["c"], 2)).toEqual(["c"]);
+		expect(nextPdfLru(["c"], ["a", "b", "c", "d"], ["a"], 2)).toEqual([
+			"a",
+			"c",
+		]);
+	});
+
+	it("drops closed entries, deduplicates promotions, and preserves equal state", () => {
+		const previous = ["a", "b"];
+		expect(nextPdfLru(previous, ["a", "b"], ["a", "a"], 2)).toBe(previous);
+		expect(nextPdfLru(previous, ["b", "c"], ["c"], 2)).toEqual(["c", "b"]);
+		expect(nextPdfLru(previous, [], [], 2)).toEqual([]);
+	});
+
+	it("releases local buffers outside the visible/recent set", () => {
+		const retained = pdfTab("retained", new ArrayBuffer(8));
+		const evicted = pdfTab("evicted", new ArrayBuffer(16));
+		const markdown = {
+			...createPlaceholderTab("notes.md", "markdown"),
+			loaded: true,
+		};
+		const next = evictPdfBuffers(
+			[retained, evicted, markdown],
+			new Set([retained.id]),
+		);
+
+		expect(next[0]).toBe(retained);
+		expect(next[1]).toMatchObject({
+			id: "evicted",
+			pdfBytes: null,
+			loaded: false,
+		});
+		expect(next[2]).toBe(markdown);
+	});
+});


### PR DESCRIPTION
## 摘要

视觉批注裁剪不再以 base64 写进 mark JSON，改为 `marks/assets/` 下的自有文件；图片按需读取，删 mark 时一并清掉。工作区恢复时只加载当前可见的 PDF，并限制同时保留的 viewer 数量。另补冷启动占位壳，以及 dev reload 时的 PDFium engine 清理。

## 主要改动

### 1. 视觉批注产物迁移

- 裁剪图写到 `papers/<id>/marks/assets/<trace-id>.png`，JSON 只保留 `image.path` + `mimeType`
- 列表 / 轮询只读 metadata；悬浮预览、打开 Agent、Wiki 嵌入时再读图
- 删除视觉批注时删除对应图片；图丢了仍保留位置、批注和多轮 transcript
- 与笔记用的 `assets/` 分开；路径只允许 `assets/<filename>`

### 2. 工作区 / PDF 内存

- 启动恢复只 hydrate 各组当前可见 panel，隐藏 PDF 标签切到前台再加载
- 最多保留「当前可见 + 最近使用」共 2 个 PDF viewer
- 离开保留集后释放本地 `pdfBytes`，避免多标签重启时一次性加载全部 PDF

### 3. 启动与 Engine

- 窗口等 Webview 加载完再显示；`index.html` 用零依赖启动壳占位，减少冷启动 / dev 加载时的空白窗
- PDFium engine 在窗口内共享，宿主放在 StrictMode 外；dev reload 时销毁未完成初始化的 engine，减少孤儿 WASM

### 4. 文档与测试

- 更新 data-model / pdf / workspace / shell 文档
- 补充 agent-trace 资产 IO 与 PDF retention 测试