### PR TITLE
feat(doctor): 双链语义探测与安全修复

### DIFF
--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1881,9 +1881,23 @@ snapshot 保存所有 Wiki target 的 size+mtime stat 指纹（不读文件内�
 - 仅接受 Catalog paper 对应的 `papers/**/NOTES.md`。
 - 批量预检脏路径、哈希、alias 冲突与 YAML 安全范围；全部通过后**原地写入** frontmatter（不改 path），失败按规划内容回滚。不使用 tmp+rename，以免被 watcher 误报为外部改名。
 
+#### `doctor_plan_wikilinks`
+
+- 参数：`{ vaultPath }`。
+- 返回：`{ suggestions, residuals }`。  
+  - `suggestions`：可勾选修复项（`deterministic` 默认勾选，`manual` 默认可手改）；含 `rangeStart/End`、`expected`、`expectedHash`、`suggestedReplacement`、`linePrefix` / `lineSuffix`。  
+  - `residuals`：与 manual 对应的结构化详情（供设置页生成 Agent 提示词），不单独渲染列表。
+
+#### `doctor_apply_wikilinks`
+
+- 参数：`{ vaultPath, changes, dirtyPaths? }`；每条 change 含 `source`、`rangeStart/End`、`expected`、`replacement`、`expectedHash`。
+- 只改链接 target/fragment 的字节范围；脏路径 / 哈希 / 重叠 range 预检；原地写入，失败回滚。
+
+设置页对 Agent 采用 **提示词 handoff**（复制 / 打开 Agent 预填 composer），不在 Doctor 内批量调用模型。
+
 #### `doctor_set_dirty_paths`
 
-主窗口向 Host 镜像当前 Vault 的未保存 Markdown 相对路径，供独立 Settings Webview 发起 alias 修复时做全批次写前拒绝。它只维护进程内保护状态，不落盘。
+主窗口向 Host 镜像当前 Vault 的未保存 Markdown 相对路径，供独立 Settings Webview 发起修复时做全批次写前拒绝。它只维护进程内保护状态，不落盘。
 
 详见 [doctor.md](doctor.md)。
 

--- a/docs/backend/doctor.md
+++ b/docs/backend/doctor.md
@@ -1,6 +1,6 @@
 # Vault Doctor
 
-Doctor 聚合本地 Vault 的只读完整性检查，并为 Catalog 论文笔记提供一类显式确认的安全修复。
+Doctor 聚合本地 Vault 的只读完整性检查，并为论文别名与双链提供**显式确认**的安全修复。
 
 ## 检查范围
 
@@ -11,7 +11,7 @@ Doctor 聚合本地 Vault 的只读完整性检查，并为 Catalog 论文笔记
 3. 与桌面导航共用 `WikiIndex::check_links` 的双链语义结果；
 4. Catalog 中每篇 `papers/**/NOTES.md` 的 frontmatter aliases。
 
-其它 Markdown 不参与论文 aliases 迁移。一次检查不会创建目录、迁移 Catalog 或修改 Markdown；Catalog 以只读 SQLite connection 打开。
+一次检查不会创建目录、迁移 Catalog 或修改 Markdown；Catalog 以只读 SQLite connection 打开。
 
 一篇论文笔记至少要有两个按 Wiki resolver 规则归一化后仍不同的非空 alias。Doctor 保留现有自定义 aliases，并提出可编辑的标题 alias 与确定性短 alias：
 
@@ -24,6 +24,8 @@ Doctor 聚合本地 Vault 的只读完整性检查，并为 Catalog 论文笔记
 
 ## 安全修复
 
+### 论文 aliases
+
 `doctor_apply_aliases` 只接受当前 Catalog 行对应的 `NOTES.md`。批量写入前会：
 
 - 拒绝主窗口报告的未保存编辑路径；
@@ -32,16 +34,26 @@ Doctor 聚合本地 Vault 的只读完整性检查，并为 Catalog 论文笔记
 - 先规划全部文件，再**原地写入**（不改 path / 文件名，只改 frontmatter）；
 - 任一写入失败时按规划内容回滚本批已写文件。
 
-不使用 tmp+rename 式原子替换：那样会被 Vault 文件监听器当成「不完整改名」，误报外部改名未修复链接。双链以 path 为主，别名修复本来就不需要改链接。
+不使用 tmp+rename 式原子替换：那样会被 Vault 文件监听器当成「不完整改名」，误报外部改名未修复链接。
 
-无 frontmatter 时只前插一个 YAML 块；简单 frontmatter 缺 aliases 时在关闭 fence 前插入；简单 inline/block aliases 只替换该属性的字节范围。其它键、注释、顺序与正文不重新序列化。
+### 双链语义
+
+1. **探测** `doctor_plan_wikilinks`  
+   - 对 unresolved 边做唯一高置信匹配（path / stem / alias 近邻、heading/block 近邻）→ `layer=deterministic`（默认勾选）  
+   - 无法唯一匹配时仍输出可编辑候选项 → `layer=manual`（默认不勾选，绿色区可手改）  
+   - 每条 suggestion 含 `rangeStart/End`、`expected`、`expectedHash`、`linePrefix` / `lineSuffix`（整行上下文）  
+2. **UI 列表**：git 风格整行展示，核心变更居中高亮，按容器宽度窗口化前后文  
+3. **Agent 协作（不自动跑）**：探测后展示可复制提示词（随 UI 语言 en/zh）；「在 Agent 中打开」关闭设置窗、打开主窗 Agent 并预填 composer；Agent 应先给计划、等用户确认再改文件  
+4. **修复** `doctor_apply_wikilinks`：用户勾选后原地写入选中 range；脏路径 / 哈希 / 重叠 range 预检，失败回滚  
+
+设置页流程：探测 → 建议列表（全选 / 修复）→ 下方 Agent 提示词（复制或打开 Agent）。
 
 ## 入口
 
 - 桌面：设置 → 知识库诊断；远程 Vault 当前显示不可用。
 - CLI：`agentero doctor`、`agentero doctor fix aliases`、`agentero -y doctor fix aliases`。
-- Host：`doctor_check`、`doctor_apply_aliases`、`doctor_set_dirty_paths`。
+- Host：`doctor_check`、`doctor_apply_aliases`、`doctor_set_dirty_paths`、`doctor_plan_wikilinks`、`doctor_apply_wikilinks`。
 
 ![Vault Doctor 设置页](../assets/doctor-settings.png)
 
-代码：`src-tauri/src/features/doctor/`、`src-tauri/src/features/wiki/frontmatter.rs`。
+代码：`src-tauri/src/features/doctor/`（含 `wikilink_repair.rs`）、`src/lib/doctor/`、`src/components/settings/panes/doctor-pane.tsx`。

--- a/docs/frontend/settings.md
+++ b/docs/frontend/settings.md
@@ -22,7 +22,18 @@
 | 知识库诊断 | Vault / Catalog / 双链 / 论文 aliases；本地 Vault 可确认批量修复 |
 | 关于 | 版本信息与应用更新 |
 
-知识库诊断页调用 Host 的只读 Doctor 报告。四个检查项（Vault 结构 / Catalog / 双链 / 论文别名）各自作为小标题，标题行右侧显示 icon + 问题数；有问题时再展开 border 列表。论文别名支持勾选与编辑标题/短 alias，可修复时在标题行最右侧提供「修复」，确认后批量写入。别名修复只改 frontmatter、不改 path，避免触发外部改名修复误报。主窗口把未保存的 Markdown 路径同步到 Host，因此独立设置 Webview 发起修复时仍能在任何写入前拒绝脏文件。远程 Vault 首版只显示不可用。
+知识库诊断页调用 Host 的只读 Doctor 报告。四个检查项各自作为小标题（带一行检测说明），标题行右侧显示 icon + 问题数；模块间用非通栏次要分隔线。列表过长时（双链 / 别名）`max-h` 内滚动。
+
+- **论文别名**：勾选与编辑标题/短 alias，标题行「修复」→ 确认后批量写入 frontmatter（不改 path）。
+- **双链语义**：
+  1. 「探测」→ 自动建议（默认勾选）+ 可手改候选项（默认不勾选）；
+  2. 每条 git 风格整行 diff：核心变更居中高亮，按设置窗宽度窗口化前后文；
+  3. 标题行「全选 / 修复」应用选中项；
+  4. 下方 Agent 提示词（随 UI 语言 en/zh）：复制，或「在 Agent 中打开」（关设置、打开主窗 Agent 并预填 composer）。
+
+主窗口把未保存的 Markdown 路径同步到 Host，因此独立设置 Webview 发起修复时仍能在任何写入前拒绝脏文件。远程 Vault 首版只显示不可用。
+
+相关代码：`src/lib/doctor/`、`src/lib/agent/composer-seed.ts`、`src/components/settings/panes/doctor-pane.tsx`。
 
 ## 应用更新
 

--- a/src-tauri/src/app/handlers.rs
+++ b/src-tauri/src/app/handlers.rs
@@ -36,6 +36,8 @@ macro_rules! common_commands {
             crate::features::doctor::commands::doctor_check,
             crate::features::doctor::commands::doctor_apply_aliases,
             crate::features::doctor::commands::doctor_set_dirty_paths,
+            crate::features::doctor::commands::doctor_plan_wikilinks,
+            crate::features::doctor::commands::doctor_apply_wikilinks,
             crate::features::vault::commands::vault_create,
             crate::features::vault::commands::vault_ensure,
             crate::features::vault::commands::vault_allow_fs_scope,

--- a/src-tauri/src/features/doctor/commands.rs
+++ b/src-tauri/src/features/doctor/commands.rs
@@ -1,6 +1,7 @@
 use super::{
-    apply_alias_repairs, diagnose, AliasRepairChange, AliasRepairResult, DoctorDirtyPathsState,
-    DoctorReport,
+    apply_alias_repairs, apply_wikilink_repairs, diagnose, plan_wikilink_repairs,
+    AliasRepairChange, AliasRepairResult, DoctorDirtyPathsState, DoctorReport,
+    WikilinkRepairChange, WikilinkRepairPlan, WikilinkRepairResult,
 };
 use crate::core::error::{map_err, ApiResult, AppError};
 use crate::features::wiki::WikiIndexState;
@@ -27,6 +28,21 @@ pub struct DoctorApplyAliasesArgs {
 #[serde(rename_all = "camelCase")]
 pub struct DoctorSetDirtyPathsArgs {
     pub vault_path: String,
+    #[serde(default)]
+    pub dirty_paths: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DoctorPlanWikilinksArgs {
+    pub vault_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DoctorApplyWikilinksArgs {
+    pub vault_path: String,
+    pub changes: Vec<WikilinkRepairChange>,
     #[serde(default)]
     pub dirty_paths: Vec<String>,
 }
@@ -84,6 +100,61 @@ pub fn doctor_apply_aliases(
                 if let Err(error) = guard.rebuild(&args.vault_path) {
                     return map_err(AppError::message(format!(
                         "aliases updated but Wiki index rebuild failed: {error}"
+                    )));
+                }
+            }
+            ApiResult::ok(result)
+        }
+        Err(error) => ApiResult::err_with_details(
+            AppError::message(error.to_string()),
+            serde_json::to_value(&error).unwrap_or_default(),
+        ),
+    }
+}
+
+#[tauri::command]
+pub fn doctor_plan_wikilinks(args: DoctorPlanWikilinksArgs) -> ApiResult<WikilinkRepairPlan> {
+    let vault = PathBuf::from(&args.vault_path);
+    if !vault.is_dir() {
+        return map_err(AppError::message("vault path is not a directory"));
+    }
+    match plan_wikilink_repairs(&vault) {
+        Ok(plan) => ApiResult::ok(plan),
+        Err(error) => ApiResult::err_with_details(
+            AppError::message(error.to_string()),
+            serde_json::to_value(&error).unwrap_or_default(),
+        ),
+    }
+}
+
+#[tauri::command]
+pub fn doctor_apply_wikilinks(
+    args: DoctorApplyWikilinksArgs,
+    index: State<'_, WikiIndexState>,
+    dirty_state: State<'_, DoctorDirtyPathsState>,
+) -> ApiResult<WikilinkRepairResult> {
+    let vault = PathBuf::from(&args.vault_path);
+    let mut dirty_paths = match dirty_state.get(&args.vault_path) {
+        Ok(paths) => paths,
+        Err(error) => {
+            return map_err(AppError::message(format!(
+                "doctor dirty paths lock: {error}"
+            )))
+        }
+    };
+    dirty_paths.extend(args.dirty_paths);
+    match apply_wikilink_repairs(&vault, &args.changes, &dirty_paths) {
+        Ok(result) => {
+            if !result.updated_paths.is_empty() {
+                let mut guard = match index.inner.lock() {
+                    Ok(guard) => guard,
+                    Err(error) => {
+                        return map_err(AppError::message(format!("wiki index lock: {error}")))
+                    }
+                };
+                if let Err(error) = guard.rebuild(&args.vault_path) {
+                    return map_err(AppError::message(format!(
+                        "wikilinks updated but Wiki index rebuild failed: {error}"
                     )));
                 }
             }

--- a/src-tauri/src/features/doctor/mod.rs
+++ b/src-tauri/src/features/doctor/mod.rs
@@ -1,6 +1,12 @@
-//! Read-only Vault diagnostics and conservative paper-alias repair.
+//! Read-only Vault diagnostics and conservative paper-alias / wikilink repair.
 
 pub mod commands;
+pub mod wikilink_repair;
+
+pub use wikilink_repair::{
+    apply_wikilink_repairs, plan_wikilink_repairs, WikilinkRepairChange, WikilinkRepairPlan,
+    WikilinkRepairResidual, WikilinkRepairResult, WikilinkRepairSuggestion,
+};
 
 use crate::core::error::AppError;
 use crate::features::catalog::{self, papers::PaperRecord};

--- a/src-tauri/src/features/doctor/wikilink_repair.rs
+++ b/src-tauri/src/features/doctor/wikilink_repair.rs
@@ -1,0 +1,982 @@
+//! Deterministic wikilink repair planning and conservative multi-file apply.
+//!
+//! Agent-layer suggestions are validated on the same apply path: the frontend
+//! (or CLI) supplies a replacement for a residual range; Host only checks that
+//! the expected bytes still match and that the rewrite is in-bounds.
+
+use crate::features::wiki::index::WikiIndex;
+use crate::features::wiki::models::{
+    InternalLinkSyntax, LinkFragment, LinkResolutionStatus, ResolvedLink, SourceRange,
+};
+use crate::features::wiki::rename::content_hash;
+use crate::features::wiki::resolve::{heading_path_ends_with, normalize_rel};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use uuid::Uuid;
+
+use super::DoctorRepairError;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum WikilinkRepairLayer {
+    Deterministic,
+    /// Probe located the edit span but has no safe auto fix — user can type one.
+    Manual,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum WikilinkEditKind {
+    Target,
+    Fragment,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WikilinkRepairSuggestion {
+    pub id: String,
+    pub source: String,
+    pub line: u32,
+    pub status: LinkResolutionStatus,
+    pub syntax: InternalLinkSyntax,
+    pub embed: bool,
+    pub target_raw: String,
+    pub suggested_replacement: String,
+    pub edit_kind: WikilinkEditKind,
+    pub range_start: usize,
+    pub range_end: usize,
+    pub expected: String,
+    pub expected_hash: String,
+    /// Text on the same source line before the edit span (for git-style display).
+    #[serde(default)]
+    pub line_prefix: String,
+    /// Text on the same source line after the edit span.
+    #[serde(default)]
+    pub line_suffix: String,
+    pub layer: WikilinkRepairLayer,
+    pub reason: String,
+    pub selected_by_default: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub candidates: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WikilinkRepairResidual {
+    pub id: String,
+    pub source: String,
+    pub line: u32,
+    pub status: LinkResolutionStatus,
+    pub syntax: InternalLinkSyntax,
+    pub embed: bool,
+    pub target_raw: String,
+    pub edit_kind: WikilinkEditKind,
+    pub range_start: usize,
+    pub range_end: usize,
+    pub expected: String,
+    pub expected_hash: String,
+    #[serde(default)]
+    pub line_prefix: String,
+    #[serde(default)]
+    pub line_suffix: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub candidates: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_path: Option<String>,
+    /// Compact document index for agent prompts (path + aliases + headings).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub vault_hints: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WikilinkRepairPlan {
+    pub suggestions: Vec<WikilinkRepairSuggestion>,
+    pub residuals: Vec<WikilinkRepairResidual>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WikilinkRepairChange {
+    pub source: String,
+    pub range_start: usize,
+    pub range_end: usize,
+    pub expected: String,
+    pub replacement: String,
+    pub expected_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WikilinkRepairResult {
+    pub updated_paths: Vec<String>,
+}
+
+fn normalize_key(value: &str) -> String {
+    value
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+fn stem_of(path: &str) -> String {
+    Path::new(path)
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or(path)
+        .to_string()
+}
+
+fn strip_markdown_extension(path: &str) -> &str {
+    [".markdown", ".mdx", ".md"]
+        .iter()
+        .find_map(|extension| path.strip_suffix(extension))
+        .unwrap_or(path)
+}
+
+fn markdown_relative_target(source: &str, target: &str) -> String {
+    let source_parent = Path::new(source).parent().unwrap_or_else(|| Path::new(""));
+    let source_parts = source_parent
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => value.to_str(),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let target_parts = Path::new(target)
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => value.to_str(),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let common = source_parts
+        .iter()
+        .zip(&target_parts)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let mut parts = Vec::new();
+    parts.extend(std::iter::repeat_n("..", source_parts.len() - common));
+    parts.extend(target_parts[common..].iter().copied());
+    if parts.is_empty() {
+        Path::new(target)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(target)
+            .to_string()
+    } else {
+        parts.join("/")
+    }
+}
+
+fn replacement_target(
+    syntax: &InternalLinkSyntax,
+    target_raw: &str,
+    source: &str,
+    final_target: &str,
+) -> String {
+    if target_raw.is_empty() && source == final_target {
+        return String::new();
+    }
+    match syntax {
+        InternalLinkSyntax::Wikilink => strip_markdown_extension(final_target).to_string(),
+        InternalLinkSyntax::Markdown => markdown_relative_target(source, final_target),
+    }
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr = vec![0; b.len() + 1];
+    for (i, ca) in a.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let cost = if ca == cb { 0 } else { 1 };
+            curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
+}
+
+fn unique_best(scored: Vec<(String, i32)>) -> Option<String> {
+    if scored.is_empty() {
+        return None;
+    }
+    let mut scored = scored;
+    scored.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+    let best_score = scored[0].1;
+    if best_score < 40 {
+        return None;
+    }
+    let winners = scored
+        .iter()
+        .filter(|(_, score)| *score == best_score)
+        .map(|(path, _)| path.clone())
+        .collect::<Vec<_>>();
+    if winners.len() == 1 {
+        Some(winners.into_iter().next().unwrap())
+    } else {
+        None
+    }
+}
+
+fn score_document_match(raw: &str, path: &str, aliases: &[String]) -> i32 {
+    let raw_key = normalize_key(raw);
+    let path_key = normalize_key(path);
+    let stem = normalize_key(&stem_of(path));
+    let raw_stem = normalize_key(&stem_of(raw));
+    let mut best = 0;
+    if path_key == raw_key || stem == raw_key {
+        return 100;
+    }
+    if aliases.iter().any(|alias| normalize_key(alias) == raw_key) {
+        return 95;
+    }
+    for alias in aliases {
+        let alias_key = normalize_key(alias);
+        let distance = levenshtein(&alias_key, &raw_key);
+        // Allow a few typos in long titles (Attention / Attentoin).
+        let max_distance = (alias_key.chars().count() / 8).clamp(1, 4);
+        if distance > 0 && distance <= max_distance {
+            best = best.max(90 - distance as i32 * 5);
+        }
+    }
+    if path_key.ends_with(&format!("/{raw_key}"))
+        || path_key.ends_with(&format!("/{raw_key}.md"))
+        || strip_markdown_extension(&path_key) == raw_key
+    {
+        best = best.max(90);
+    }
+    if !raw_stem.is_empty() && stem == raw_stem {
+        best = best.max(85);
+    }
+    if !raw_stem.is_empty() && stem.contains(&raw_stem) {
+        best = best.max(70);
+    }
+    if !raw_key.is_empty() && path_key.contains(&raw_key) {
+        best = best.max(60);
+    }
+    let distance = levenshtein(&raw_stem, &stem);
+    if !raw_stem.is_empty() && distance <= 2 {
+        best = best.max(55 - distance as i32 * 5);
+    }
+    best
+}
+
+fn pick_document_path(link: &ResolvedLink, index: &WikiIndex) -> Option<String> {
+    if let Some(path) = &link.target_path {
+        return Some(path.clone());
+    }
+    if link.candidates.len() == 1 {
+        return Some(link.candidates[0].clone());
+    }
+    if !link.candidates.is_empty() {
+        let scored = link
+            .candidates
+            .iter()
+            .map(|path| {
+                let aliases = index
+                    .documents()
+                    .iter()
+                    .find(|document| document.path == *path)
+                    .map(|document| document.aliases.as_slice())
+                    .unwrap_or(&[]);
+                (
+                    path.clone(),
+                    score_document_match(&link.occurrence.target_raw, path, aliases),
+                )
+            })
+            .collect::<Vec<_>>();
+        return unique_best(scored);
+    }
+    let scored = index
+        .documents()
+        .iter()
+        .map(|document| {
+            (
+                document.path.clone(),
+                score_document_match(
+                    &link.occurrence.target_raw,
+                    &document.path,
+                    &document.aliases,
+                ),
+            )
+        })
+        .filter(|(_, score)| *score > 0)
+        .collect::<Vec<_>>();
+    unique_best(scored)
+}
+
+fn pick_heading_fragment(
+    raw_path: &[String],
+    document_path: &str,
+    index: &WikiIndex,
+) -> Option<String> {
+    let document = index
+        .documents()
+        .iter()
+        .find(|document| document.path == document_path)?;
+    if raw_path.is_empty() {
+        return None;
+    }
+    let wanted_last = normalize_key(raw_path.last()?);
+    let suffix_len = raw_path.len();
+    let mut scored = Vec::new();
+    for heading in &document.headings {
+        if heading.path.len() < suffix_len {
+            continue;
+        }
+        // Keep the same number of path segments the author wrote after `#`.
+        let suffix = &heading.path[heading.path.len() - suffix_len..];
+        let label = suffix.join("#");
+        let last = normalize_key(suffix.last().map(String::as_str).unwrap_or(""));
+        let mut score = 0;
+        if last == wanted_last {
+            score = 100;
+        } else if last.contains(&wanted_last) || wanted_last.contains(&last) {
+            score = 70;
+        } else {
+            let distance = levenshtein(&last, &wanted_last);
+            if distance <= 2 {
+                score = 55 - distance as i32 * 5;
+            }
+        }
+        if raw_path.len() > 1 && heading_path_ends_with(&heading.path, raw_path) {
+            score = score.max(95);
+        }
+        if score > 0 {
+            scored.push((label, score));
+        }
+    }
+    unique_best(scored)
+}
+
+fn file_slice(content: &str, range: &SourceRange) -> Option<String> {
+    if range.start > range.end
+        || range.end > content.len()
+        || !content.is_char_boundary(range.start)
+        || !content.is_char_boundary(range.end)
+    {
+        return None;
+    }
+    Some(content[range.start..range.end].to_string())
+}
+
+/// Split the source line that contains `range` into prefix / suffix around the span.
+fn line_affixes(content: &str, range: &SourceRange) -> (String, String) {
+    if range.start > content.len()
+        || range.end > content.len()
+        || range.start > range.end
+        || !content.is_char_boundary(range.start)
+        || !content.is_char_boundary(range.end)
+    {
+        return (String::new(), String::new());
+    }
+    let line_start = content[..range.start]
+        .rfind('\n')
+        .map(|index| index + 1)
+        .unwrap_or(0);
+    let line_end = content[range.end..]
+        .find('\n')
+        .map(|index| range.end + index)
+        .unwrap_or(content.len());
+    let prefix = content[line_start..range.start]
+        .trim_end_matches('\r')
+        .to_string();
+    let suffix = content[range.end..line_end]
+        .trim_end_matches('\r')
+        .to_string();
+    (prefix, suffix)
+}
+
+struct ManualCandidateArgs<'a> {
+    link: &'a crate::features::wiki::models::ResolvedLink,
+    content: &'a str,
+    hash: &'a str,
+    range: &'a SourceRange,
+    edit_kind: WikilinkEditKind,
+    target_path: Option<String>,
+    vault_hints: &'a [String],
+}
+
+/// Always produce a manual (editable) suggestion + residual when auto-fix fails.
+fn push_manual_candidate(
+    suggestions: &mut Vec<WikilinkRepairSuggestion>,
+    residuals: &mut Vec<WikilinkRepairResidual>,
+    args: ManualCandidateArgs<'_>,
+) {
+    let ManualCandidateArgs {
+        link,
+        content,
+        hash,
+        range,
+        edit_kind,
+        target_path,
+        vault_hints,
+    } = args;
+    let expected = match file_slice(content, range) {
+        Some(value) => value,
+        None => link.occurrence.target_raw.clone(),
+    };
+    let (line_prefix, line_suffix) = line_affixes(content, range);
+    let id = Uuid::new_v4().to_string();
+    suggestions.push(WikilinkRepairSuggestion {
+        id: id.clone(),
+        source: link.occurrence.source.clone(),
+        line: link.occurrence.line,
+        status: link.status.clone(),
+        syntax: link.occurrence.syntax.clone(),
+        embed: link.occurrence.embed,
+        target_raw: link.occurrence.target_raw.clone(),
+        // Prefill with current text so the full line renders; user edits the green span.
+        suggested_replacement: expected.clone(),
+        edit_kind: edit_kind.clone(),
+        range_start: range.start,
+        range_end: range.end,
+        expected: expected.clone(),
+        expected_hash: hash.to_string(),
+        line_prefix: line_prefix.clone(),
+        line_suffix: line_suffix.clone(),
+        layer: WikilinkRepairLayer::Manual,
+        reason: "manual edit required".into(),
+        selected_by_default: false,
+        candidates: link.candidates.clone(),
+        context: link.occurrence.context.clone(),
+    });
+    residuals.push(WikilinkRepairResidual {
+        id,
+        source: link.occurrence.source.clone(),
+        line: link.occurrence.line,
+        status: link.status.clone(),
+        syntax: link.occurrence.syntax.clone(),
+        embed: link.occurrence.embed,
+        target_raw: link.occurrence.target_raw.clone(),
+        edit_kind,
+        range_start: range.start,
+        range_end: range.end,
+        expected,
+        expected_hash: hash.to_string(),
+        line_prefix,
+        line_suffix,
+        candidates: link.candidates.clone(),
+        context: link.occurrence.context.clone(),
+        target_path,
+        vault_hints: vault_hints.to_vec(),
+    });
+}
+
+fn vault_hints(index: &WikiIndex, limit: usize) -> Vec<String> {
+    let mut hints = index
+        .documents()
+        .iter()
+        .map(|document| {
+            let aliases = if document.aliases.is_empty() {
+                String::new()
+            } else {
+                format!(" | aliases: {}", document.aliases.join(", "))
+            };
+            let headings = document
+                .headings
+                .iter()
+                .take(8)
+                .map(|heading| heading.path.join("#"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let heading_part = if headings.is_empty() {
+                String::new()
+            } else {
+                format!(" | headings: {headings}")
+            };
+            format!("{}{aliases}{heading_part}", document.path)
+        })
+        .collect::<Vec<_>>();
+    hints.sort();
+    hints.truncate(limit);
+    hints
+}
+
+fn read_source_cache(
+    vault: &Path,
+    path: &str,
+    cache: &mut HashMap<String, (String, String)>,
+) -> Result<(String, String), DoctorRepairError> {
+    if let Some(entry) = cache.get(path) {
+        return Ok(entry.clone());
+    }
+    let absolute = vault.join(path);
+    let content = fs::read_to_string(&absolute).map_err(|error| {
+        DoctorRepairError::new(
+            "readFailed",
+            format!("could not read {path}: {error}"),
+            vec![path.to_string()],
+        )
+    })?;
+    let hash = content_hash(&content);
+    cache.insert(path.to_string(), (content.clone(), hash.clone()));
+    Ok((content, hash))
+}
+
+/// Build deterministic suggestions and residuals for Agent / manual review.
+pub fn plan_wikilink_repairs(vault: &Path) -> Result<WikilinkRepairPlan, DoctorRepairError> {
+    if !vault.is_dir() {
+        return Err(DoctorRepairError::new(
+            "invalidVault",
+            "vault path is not a directory",
+            Vec::new(),
+        ));
+    }
+    let mut index = WikiIndex::default();
+    index
+        .rebuild_read_only(&vault.to_string_lossy())
+        .map_err(|error| DoctorRepairError::new("wikiIndexFailed", error, Vec::new()))?;
+
+    let hints = vault_hints(&index, 80);
+    let mut source_cache = HashMap::new();
+    let mut suggestions = Vec::new();
+    let mut residuals = Vec::new();
+
+    let mut edges = index.edges.clone();
+    edges.sort_by(|left, right| {
+        left.occurrence
+            .source
+            .cmp(&right.occurrence.source)
+            .then(left.occurrence.line.cmp(&right.occurrence.line))
+            .then(left.occurrence.target_raw.cmp(&right.occurrence.target_raw))
+    });
+
+    for link in edges {
+        if link.status == LinkResolutionStatus::Resolved {
+            continue;
+        }
+        // Annotation fragments are not Markdown rewrites Doctor can safely invent.
+        if matches!(
+            link.occurrence.fragment,
+            Some(LinkFragment::Annotation { .. })
+        ) {
+            continue;
+        }
+
+        let (content, hash) =
+            match read_source_cache(vault, &link.occurrence.source, &mut source_cache) {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+
+        // Path-level repair when the document itself is missing/ambiguous.
+        if matches!(
+            link.status,
+            LinkResolutionStatus::Missing | LinkResolutionStatus::Ambiguous
+        ) && link.target_path.is_none()
+        {
+            let range = &link.occurrence.source_range;
+            if let Some(path) = pick_document_path(&link, &index) {
+                let expected = file_slice(&content, range)
+                    .unwrap_or_else(|| link.occurrence.target_raw.clone());
+                let replacement = replacement_target(
+                    &link.occurrence.syntax,
+                    &link.occurrence.target_raw,
+                    &link.occurrence.source,
+                    &path,
+                );
+                if !replacement.is_empty() && replacement != expected {
+                    let (line_prefix, line_suffix) = line_affixes(&content, range);
+                    suggestions.push(WikilinkRepairSuggestion {
+                        id: Uuid::new_v4().to_string(),
+                        source: link.occurrence.source.clone(),
+                        line: link.occurrence.line,
+                        status: link.status.clone(),
+                        syntax: link.occurrence.syntax.clone(),
+                        embed: link.occurrence.embed,
+                        target_raw: link.occurrence.target_raw.clone(),
+                        suggested_replacement: replacement,
+                        edit_kind: WikilinkEditKind::Target,
+                        range_start: range.start,
+                        range_end: range.end,
+                        expected,
+                        expected_hash: hash.clone(),
+                        line_prefix,
+                        line_suffix,
+                        layer: WikilinkRepairLayer::Deterministic,
+                        reason: format!("unique document match → {path}"),
+                        selected_by_default: true,
+                        candidates: link.candidates.clone(),
+                        context: link.occurrence.context.clone(),
+                    });
+                    continue;
+                }
+            }
+            // No unique auto fix: still surface an editable candidate.
+            push_manual_candidate(
+                &mut suggestions,
+                &mut residuals,
+                ManualCandidateArgs {
+                    link: &link,
+                    content: &content,
+                    hash: &hash,
+                    range,
+                    edit_kind: WikilinkEditKind::Target,
+                    target_path: None,
+                    vault_hints: &hints,
+                },
+            );
+            continue;
+        }
+
+        // Fragment-level repair when the document resolved but the anchor did not.
+        if matches!(
+            link.status,
+            LinkResolutionStatus::InvalidFragment | LinkResolutionStatus::Ambiguous
+        ) {
+            let Some(target_path) = link.target_path.clone() else {
+                continue;
+            };
+            let Some(fragment) = link.occurrence.fragment.clone() else {
+                continue;
+            };
+            let Some(fragment_range) = link.occurrence.fragment_range.clone() else {
+                // Fall back to target range so the user still gets an editable row.
+                push_manual_candidate(
+                    &mut suggestions,
+                    &mut residuals,
+                    ManualCandidateArgs {
+                        link: &link,
+                        content: &content,
+                        hash: &hash,
+                        range: &link.occurrence.source_range,
+                        edit_kind: WikilinkEditKind::Target,
+                        target_path: Some(target_path),
+                        vault_hints: &hints,
+                    },
+                );
+                continue;
+            };
+            if let Some(label) = match &fragment {
+                LinkFragment::Heading { path } => pick_heading_fragment(path, &target_path, &index),
+                LinkFragment::Block { id } => {
+                    let document = index
+                        .documents()
+                        .iter()
+                        .find(|document| document.path == target_path);
+                    document.and_then(|document| {
+                        let scored = document
+                            .blocks
+                            .iter()
+                            .map(|block| {
+                                let distance =
+                                    levenshtein(&normalize_key(id), &normalize_key(&block.id));
+                                let score = if normalize_key(&block.id) == normalize_key(id) {
+                                    100
+                                } else if distance <= 2 {
+                                    55 - distance as i32 * 5
+                                } else {
+                                    0
+                                };
+                                (block.id.clone(), score)
+                            })
+                            .filter(|(_, score)| *score > 0)
+                            .collect::<Vec<_>>();
+                        unique_best(scored)
+                    })
+                }
+                LinkFragment::Annotation { .. } => None,
+            } {
+                let expected = file_slice(&content, &fragment_range)
+                    .unwrap_or_else(|| link.occurrence.target_raw.clone());
+                if !label.is_empty() && label != expected {
+                    let (line_prefix, line_suffix) = line_affixes(&content, &fragment_range);
+                    suggestions.push(WikilinkRepairSuggestion {
+                        id: Uuid::new_v4().to_string(),
+                        source: link.occurrence.source.clone(),
+                        line: link.occurrence.line,
+                        status: link.status.clone(),
+                        syntax: link.occurrence.syntax.clone(),
+                        embed: link.occurrence.embed,
+                        target_raw: link.occurrence.target_raw.clone(),
+                        suggested_replacement: label,
+                        edit_kind: WikilinkEditKind::Fragment,
+                        range_start: fragment_range.start,
+                        range_end: fragment_range.end,
+                        expected,
+                        expected_hash: hash.clone(),
+                        line_prefix,
+                        line_suffix,
+                        layer: WikilinkRepairLayer::Deterministic,
+                        reason: format!("unique anchor on {target_path}"),
+                        selected_by_default: true,
+                        candidates: link.candidates.clone(),
+                        context: link.occurrence.context.clone(),
+                    });
+                    continue;
+                }
+            }
+            push_manual_candidate(
+                &mut suggestions,
+                &mut residuals,
+                ManualCandidateArgs {
+                    link: &link,
+                    content: &content,
+                    hash: &hash,
+                    range: &fragment_range,
+                    edit_kind: WikilinkEditKind::Fragment,
+                    target_path: Some(target_path),
+                    vault_hints: &hints,
+                },
+            );
+        }
+    }
+
+    Ok(WikilinkRepairPlan {
+        suggestions,
+        residuals,
+    })
+}
+
+fn write_note_bytes(path: &Path, contents: &[u8]) -> Result<(), String> {
+    fs::write(path, contents).map_err(|error| error.to_string())
+}
+
+fn safe_relative_path(raw: &str) -> bool {
+    let path = Path::new(raw);
+    !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
+}
+
+struct PlannedWikilinkWrite {
+    path: String,
+    absolute: PathBuf,
+    original: String,
+    rewritten: String,
+}
+
+/// Apply selected wikilink byte-range edits with dirty/hash checks and rollback.
+pub fn apply_wikilink_repairs(
+    vault: &Path,
+    changes: &[WikilinkRepairChange],
+    dirty_paths: &[String],
+) -> Result<WikilinkRepairResult, DoctorRepairError> {
+    if !vault.is_dir() {
+        return Err(DoctorRepairError::new(
+            "invalidVault",
+            "vault path is not a directory",
+            Vec::new(),
+        ));
+    }
+    if changes.is_empty() {
+        return Ok(WikilinkRepairResult {
+            updated_paths: Vec::new(),
+        });
+    }
+
+    let dirty = dirty_paths
+        .iter()
+        .map(|path| path.replace('\\', "/").trim_matches('/').to_string())
+        .collect::<HashSet<_>>();
+
+    // Group edits by source path.
+    let mut by_source: HashMap<String, Vec<&WikilinkRepairChange>> = HashMap::new();
+    for change in changes {
+        let path = normalize_rel(&change.source.replace('\\', "/"));
+        if !safe_relative_path(&path) {
+            return Err(DoctorRepairError::new(
+                "invalidPath",
+                format!("invalid source path: {path}"),
+                vec![path],
+            ));
+        }
+        if dirty.contains(&path) {
+            return Err(DoctorRepairError::new(
+                "dirtyPath",
+                format!("source has unsaved edits: {path}"),
+                vec![path],
+            ));
+        }
+        by_source.entry(path).or_default().push(change);
+    }
+
+    let mut planned = Vec::new();
+    for (path, edits) in by_source {
+        let absolute = vault.join(&path);
+        let original = fs::read_to_string(&absolute).map_err(|error| {
+            DoctorRepairError::new(
+                "readFailed",
+                format!("could not read {path}: {error}"),
+                vec![path.clone()],
+            )
+        })?;
+        let hash = content_hash(&original);
+        if edits.iter().any(|edit| edit.expected_hash != hash) {
+            return Err(DoctorRepairError::new(
+                "sourceChanged",
+                format!("source changed after diagnosis: {path}"),
+                vec![path],
+            ));
+        }
+        let mut ordered = edits
+            .iter()
+            .map(|edit| {
+                (
+                    edit.range_start,
+                    edit.range_end,
+                    edit.expected.as_str(),
+                    edit.replacement.as_str(),
+                )
+            })
+            .collect::<Vec<_>>();
+        ordered.sort_by_key(|(start, _, _, _)| std::cmp::Reverse(*start));
+        if ordered.iter().any(|(start, end, expected, _)| {
+            *start > *end
+                || *end > original.len()
+                || !original.is_char_boundary(*start)
+                || !original.is_char_boundary(*end)
+                || original.get(*start..*end) != Some(*expected)
+        }) || ordered.windows(2).any(|pair| pair[0].0 < pair[1].1)
+        {
+            return Err(DoctorRepairError::new(
+                "overlappingEdits",
+                format!("planned edits overlap or exceed bounds in {path}"),
+                vec![path],
+            ));
+        }
+        let mut rewritten = original.clone();
+        for (start, end, _, replacement) in ordered {
+            rewritten.replace_range(start..end, replacement);
+        }
+        planned.push(PlannedWikilinkWrite {
+            path,
+            absolute,
+            original,
+            rewritten,
+        });
+    }
+
+    for write in &planned {
+        let current = fs::read_to_string(&write.absolute).map_err(|error| {
+            DoctorRepairError::new(
+                "readFailed",
+                format!("could not re-read {}: {error}", write.path),
+                vec![write.path.clone()],
+            )
+        })?;
+        if current != write.original {
+            return Err(DoctorRepairError::new(
+                "sourceChanged",
+                format!("source changed after preflight: {}", write.path),
+                vec![write.path.clone()],
+            ));
+        }
+    }
+
+    let mut written: Vec<&PlannedWikilinkWrite> = Vec::new();
+    for write in &planned {
+        if let Err(error) = write_note_bytes(&write.absolute, write.rewritten.as_bytes()) {
+            let mut rollback_complete = true;
+            for previous in written.iter().rev() {
+                if write_note_bytes(&previous.absolute, previous.original.as_bytes()).is_err() {
+                    rollback_complete = false;
+                }
+            }
+            let mut failure = DoctorRepairError::new(
+                "writeFailed",
+                format!("could not write {}: {error}", write.path),
+                planned.iter().map(|item| item.path.clone()).collect(),
+            );
+            failure.rollback = if rollback_complete {
+                "completed"
+            } else {
+                "manualRecoveryRequired"
+            }
+            .into();
+            return Err(failure);
+        }
+        written.push(write);
+    }
+
+    Ok(WikilinkRepairResult {
+        updated_paths: planned.into_iter().map(|write| write.path).collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::features::wiki::index::WikiIndex;
+    use uuid::Uuid;
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn deterministic_plan_fixes_missing_path_and_heading() {
+        let vault = std::env::temp_dir().join(format!("agentero-wiki-doctor-{}", Uuid::new_v4()));
+        write(
+            &vault.join("notes/Source.md"),
+            "See [[Attentoin Is All You Need]] and [[papers/demo/NOTES#Methd]].\n",
+        );
+        write(
+            &vault.join("papers/demo/NOTES.md"),
+            "---\naliases:\n  - \"Attention Is All You Need\"\n  - \"AIAYN\"\n---\n# Paper\n\n## Method\n\nBody.\n",
+        );
+        write(&vault.join("notes/Keep.md"), "# Keep\n");
+
+        let plan = plan_wikilink_repairs(&vault).expect("plan");
+        assert!(
+            plan.suggestions
+                .iter()
+                .any(|item| item.target_raw.contains("Attentoin")
+                    && item.suggested_replacement.contains("papers/demo/NOTES")
+                    || item.suggested_replacement.contains("Attention")),
+            "missing alias/path should produce a suggestion: {:?}",
+            plan.suggestions
+        );
+        assert!(
+            plan.suggestions.iter().any(|item| {
+                matches!(item.edit_kind, WikilinkEditKind::Fragment)
+                    && item.suggested_replacement.contains("Method")
+            }),
+            "heading typo should produce fragment suggestion: {:?}",
+            plan.suggestions
+        );
+
+        let changes = plan
+            .suggestions
+            .iter()
+            .map(|item| WikilinkRepairChange {
+                source: item.source.clone(),
+                range_start: item.range_start,
+                range_end: item.range_end,
+                expected: item.expected.clone(),
+                replacement: item.suggested_replacement.clone(),
+                expected_hash: item.expected_hash.clone(),
+            })
+            .collect::<Vec<_>>();
+        let result = apply_wikilink_repairs(&vault, &changes, &[]).expect("apply");
+        assert_eq!(result.updated_paths, vec!["notes/Source.md".to_string()]);
+
+        let mut index = WikiIndex::default();
+        index
+            .rebuild_read_only(&vault.to_string_lossy())
+            .expect("rebuild");
+        let report = index.check_links(&vault.to_string_lossy(), Some("notes/Source.md"));
+        assert!(
+            report.issues.is_empty(),
+            "source should be clean after repair: {:?}",
+            report.issues
+        );
+        let _ = fs::remove_dir_all(vault);
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,10 @@ import { useNativeMenuEvents } from "@/hooks/use-native-menu-events";
 import { useAnyOverlayOpen } from "@/hooks/use-overlay-registration";
 import { useVaultFileEvents } from "@/hooks/use-vault-file-events";
 import { SIDEBAR_DEFAULT_PX, useZenLayout } from "@/hooks/use-zen-layout";
+import {
+	listenOpenAgentWithPrompt,
+	setPendingAgentComposerPrompt,
+} from "@/lib/agent/composer-seed";
 import { pinActiveSelection } from "@/lib/agent/selection-store";
 import { notifyWarning } from "@/lib/core/notify";
 import { closeTopOverlay } from "@/lib/core/overlay-stack";
@@ -250,6 +254,34 @@ export default function App() {
 		return () => {
 			unsubscribeWorkspace();
 			unsubscribeVault();
+		};
+	}, []);
+
+	// Settings Doctor → main: open Agent rail with a prefilled composer prompt.
+	useEffect(() => {
+		if (!isTauri()) return;
+		let cancelled = false;
+		let unlisten: (() => void) | undefined;
+		void listenOpenAgentWithPrompt((payload) => {
+			const text = payload.text.trim();
+			if (!text) return;
+			setPendingAgentComposerPrompt(text);
+			openRightTab("agent");
+			void (async () => {
+				try {
+					const { getCurrentWindow } = await import("@tauri-apps/api/window");
+					await getCurrentWindow().setFocus();
+				} catch {
+					// ignore
+				}
+			})();
+		}).then((off) => {
+			if (cancelled) off();
+			else unlisten = off;
+		});
+		return () => {
+			cancelled = true;
+			unlisten?.();
 		};
 	}, []);
 

--- a/src/components/agent/use-agent-panel.ts
+++ b/src/components/agent/use-agent-panel.ts
@@ -92,6 +92,10 @@ import {
 	upsertPlanPart,
 } from "@/lib/agent/chat-state";
 import {
+	subscribePendingAgentComposerPrompt,
+	takePendingAgentComposerPrompt,
+} from "@/lib/agent/composer-seed";
+import {
 	contextPathDisplayName,
 	contextPathLabel,
 	normalizeContextPath,
@@ -319,6 +323,20 @@ export function useAgentPanel({
 		// Current paper/file is always in context by default (no click-to-add).
 		defaultIncludeSelectedFile: true,
 	});
+
+	// Doctor / Settings may seed the composer via a cross-window event.
+	useEffect(() => {
+		const apply = (text: string) => {
+			const next = text.trim();
+			if (!next) return;
+			setComposerText(next);
+			setComposerMenuDismissed(true);
+		};
+		const pending = takePendingAgentComposerPrompt();
+		if (pending) apply(pending);
+		return subscribePendingAgentComposerPrompt(apply);
+	}, [setComposerText]);
+
 	const activeConversationRef = useRef<string | null>(null);
 	const activeTabRef = useRef("draft");
 	const selectedAgentIdRef = useRef<string | null>(null);

--- a/src/components/settings/panes/doctor-pane.tsx
+++ b/src/components/settings/panes/doctor-pane.tsx
@@ -1,9 +1,11 @@
-import { CheckCircle2, RefreshCw, TriangleAlert } from "lucide-react";
+import { CheckCircle2, Copy, RefreshCw, TriangleAlert } from "lucide-react";
 import {
 	type ReactNode,
 	useCallback,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
+	useRef,
 	useState,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -22,43 +24,61 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { broadcastOpenAgentWithPrompt } from "@/lib/agent/composer-seed";
+import { copyTextToClipboard } from "@/lib/core/clipboard";
 import { notifyError, notifySuccess } from "@/lib/core/notify";
 import {
 	type AliasRepairCandidate,
 	type DoctorIssue,
 	type DoctorReport,
 	doctorApplyAliases,
+	doctorApplyWikilinks,
 	doctorCheck,
+	doctorPlanWikilinks,
 	type WikiCheckIssue,
+	type WikilinkRepairResidual,
+	type WikilinkRepairSuggestion,
 } from "@/lib/doctor/api";
+import { buildDoctorWikilinkAgentPrompt } from "@/lib/doctor/wikilink-prompt";
+import { closeSettingsWindow } from "@/lib/shell/settings-window";
 
 type CandidateDraft = AliasRepairCandidate & { selected: boolean };
+type WikilinkDraft = WikilinkRepairSuggestion & { selected: boolean };
 
 /** Section title with status on the right; issue list below when present. */
 function DoctorSection({
 	title,
+	description,
 	ok,
 	issueCount,
 	action,
+	/** Cap list height and scroll (wikilinks / aliases with many rows). */
+	scrollable = false,
+	/** Short muted rule under the section (omit on the last block). */
+	showDivider = true,
 	children,
 }: {
 	title: string;
+	description?: string;
 	ok: boolean;
 	issueCount: number;
 	action?: ReactNode;
+	scrollable?: boolean;
+	showDivider?: boolean;
 	children?: ReactNode;
 }) {
 	const { t } = useTranslation("settings");
 	const hasList = Boolean(children);
 
 	return (
-		<div className="mb-5">
-			<div className="mb-2 flex items-center gap-3 px-0.5">
+		<div className={showDivider ? "mb-2 pb-6" : "mb-5"}>
+			<div className="mb-1 flex items-center gap-3 px-0.5">
 				<p className="min-w-0 flex-1 font-medium text-[13px]">{title}</p>
 				<span className="flex shrink-0 items-center gap-1.5 text-[13px]">
 					{ok ? (
@@ -70,9 +90,25 @@ function DoctorSection({
 				</span>
 				{action}
 			</div>
+			{description ? (
+				<p className="mb-2 px-0.5 text-muted-foreground text-xs leading-relaxed">
+					{description}
+				</p>
+			) : null}
 			{hasList ? (
-				<div className="overflow-hidden rounded-xl border bg-card">
+				<div
+					className={
+						scrollable
+							? "max-h-60 overflow-y-auto overflow-x-hidden rounded-xl border bg-card"
+							: "overflow-hidden rounded-xl border bg-card"
+					}
+				>
 					{children}
+				</div>
+			) : null}
+			{showDivider ? (
+				<div className="mt-6 flex justify-center px-6" aria-hidden>
+					<div className="h-px w-9/10 max-w-l bg-border/40" />
 				</div>
 			) : null}
 		</div>
@@ -99,25 +135,263 @@ function IssueRows({ issues }: { issues: DoctorIssue[] }) {
 	);
 }
 
+/** Split a full line so `focus` appears once. */
+function splitLineAroundFocus(
+	line: string | undefined,
+	focus: string,
+): { before: string; after: string } {
+	if (!line || !focus) return { before: line ?? "", after: "" };
+	const index = line.lastIndexOf(focus);
+	if (index < 0) return { before: line, after: "" };
+	return {
+		before: line.slice(0, index),
+		after: line.slice(index + focus.length),
+	};
+}
+
+const MONO_FONT =
+	'12px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace';
+
+let monoMeasureCanvas: HTMLCanvasElement | null = null;
+
+function measureMonoText(text: string): number {
+	if (typeof document === "undefined" || !text) return 0;
+	if (!monoMeasureCanvas) monoMeasureCanvas = document.createElement("canvas");
+	const ctx = monoMeasureCanvas.getContext("2d");
+	if (!ctx) return text.length * 7;
+	ctx.font = MONO_FONT;
+	return ctx.measureText(text).width;
+}
+
+/** Keep the right end of `text` so it fits `maxPx` (left ellipsis). */
+function fitEnd(text: string, maxPx: number): string {
+	if (!text || maxPx <= 0) return "";
+	if (measureMonoText(text) <= maxPx) return text;
+	const ellipsis = "…";
+	const ellipsisW = measureMonoText(ellipsis);
+	if (maxPx <= ellipsisW) return ellipsis;
+	let lo = 0;
+	let hi = text.length;
+	while (lo < hi) {
+		const mid = Math.floor((lo + hi) / 2);
+		const candidate = ellipsis + text.slice(mid);
+		if (measureMonoText(candidate) <= maxPx) hi = mid;
+		else lo = mid + 1;
+	}
+	return lo >= text.length ? ellipsis : ellipsis + text.slice(lo);
+}
+
+/** Keep the left start of `text` so it fits `maxPx` (right ellipsis). */
+function fitStart(text: string, maxPx: number): string {
+	if (!text || maxPx <= 0) return "";
+	if (measureMonoText(text) <= maxPx) return text;
+	const ellipsis = "…";
+	const ellipsisW = measureMonoText(ellipsis);
+	if (maxPx <= ellipsisW) return ellipsis;
+	let lo = 0;
+	let hi = text.length;
+	while (lo < hi) {
+		const mid = Math.ceil((lo + hi) / 2);
+		const candidate = text.slice(0, mid) + ellipsis;
+		if (measureMonoText(candidate) <= maxPx) lo = mid;
+		else hi = mid - 1;
+	}
+	return lo <= 0 ? ellipsis : text.slice(0, lo) + ellipsis;
+}
+
+/**
+ * Window the full line around `focus` so the core stays centered and the
+ * container width shows as much surrounding context as possible.
+ */
+function windowAroundFocus(
+	before: string,
+	focus: string,
+	after: string,
+	containerPx: number,
+): { before: string; after: string } {
+	if (containerPx <= 0) {
+		return { before, after };
+	}
+	const focusW = Math.max(measureMonoText(focus), 24);
+	const sideBudget = Math.max(0, (containerPx - focusW) / 2);
+	let left = fitEnd(before, sideBudget);
+	let right = fitStart(after, sideBudget);
+	// Give leftover space from one side to the other.
+	const usedLeft = measureMonoText(left);
+	const usedRight = measureMonoText(right);
+	const leftover = Math.max(0, containerPx - focusW - usedLeft - usedRight);
+	if (leftover > 1) {
+		if (left.startsWith("…") || measureMonoText(before) > usedLeft) {
+			left = fitEnd(before, usedLeft + leftover);
+		} else if (right.endsWith("…") || measureMonoText(after) > usedRight) {
+			right = fitStart(after, usedRight + leftover);
+		}
+	}
+	return { before: left, after: right };
+}
+
+function useWindowedLine(before: string, focus: string, after: string) {
+	const ref = useRef<HTMLDivElement>(null);
+	const [windowed, setWindowed] = useState({ before, after });
+
+	useLayoutEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+		const update = () => {
+			// Content area excludes the "+/-" gutter (~1.5rem) and horizontal padding.
+			const contentPx = Math.max(0, el.clientWidth - 28);
+			setWindowed(windowAroundFocus(before, focus, after, contentPx));
+		};
+		update();
+		const ro = new ResizeObserver(update);
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, [before, focus, after]);
+
+	return { ref, windowed };
+}
+
 function WikiIssueRows({ issues }: { issues: WikiCheckIssue[] }) {
 	return (
 		<>
-			{issues.map((issue) => (
-				<div
-					key={`${issue.source}:${issue.line}:${issue.targetRaw}:${issue.status}:${issue.context ?? ""}`}
-					className="border-b px-3.5 py-2.5 last:border-b-0"
-				>
-					<p className="text-[13px] leading-snug">
-						{issue.targetRaw}
-						<span className="text-muted-foreground"> · {issue.status}</span>
-					</p>
-					<p className="mt-0.5 truncate text-muted-foreground text-xs">
-						{issue.source}:{issue.line}
-						{issue.context ? ` · ${issue.context}` : ""}
-					</p>
-				</div>
-			))}
+			{issues.map((issue) => {
+				const { before, after } = splitLineAroundFocus(
+					issue.context,
+					issue.targetRaw,
+				);
+				return (
+					<div
+						key={`${issue.source}:${issue.line}:${issue.targetRaw}:${issue.status}:${issue.context ?? ""}`}
+						className="border-b px-3.5 py-2.5 last:border-b-0"
+					>
+						<p className="truncate font-mono text-muted-foreground text-xs">
+							{issue.source}:{issue.line}
+						</p>
+						<div className="mt-1 overflow-hidden rounded-md border font-mono text-xs">
+							<GitLine
+								sign="-"
+								tone="bad"
+								before={before}
+								focus={issue.targetRaw}
+								after={after}
+							/>
+						</div>
+					</div>
+				);
+			})}
 		</>
+	);
+}
+
+/** One git-style line: full available width, focus centered, context truncated. */
+function GitLine({
+	sign,
+	tone,
+	before,
+	focus,
+	after,
+	focusNode,
+}: {
+	sign: "+" | "-";
+	tone: "bad" | "good";
+	before: string;
+	focus: string;
+	after: string;
+	/** When set, replaces the static focus highlight (e.g. editable input). */
+	focusNode?: ReactNode;
+}) {
+	const { ref, windowed } = useWindowedLine(before, focus, after);
+	const focusClass =
+		tone === "bad"
+			? "shrink-0 rounded-sm bg-destructive/25 px-0.5 font-medium text-destructive"
+			: "shrink-0 rounded-sm bg-emerald-500/25 px-0.5 font-medium text-emerald-800 dark:text-emerald-300";
+	const rowClass =
+		tone === "bad"
+			? "flex min-w-0 items-center bg-destructive/10"
+			: "flex min-w-0 items-center bg-emerald-500/10 dark:bg-emerald-500/15";
+	const signClass =
+		tone === "bad"
+			? "shrink-0 select-none px-2 py-1 text-destructive/80"
+			: "shrink-0 select-none px-2 py-1 text-emerald-700/80 dark:text-emerald-400/80";
+
+	return (
+		<div ref={ref} className={rowClass}>
+			<span className={signClass}>{sign}</span>
+			<span className="flex min-w-0 flex-1 items-center overflow-hidden whitespace-nowrap py-1 pr-2 leading-relaxed">
+				{windowed.before ? (
+					<span className="shrink-0 text-muted-foreground">
+						{windowed.before}
+					</span>
+				) : null}
+				{focusNode ?? <span className={focusClass}>{focus}</span>}
+				{windowed.after ? (
+					<span className="shrink-0 text-muted-foreground">
+						{windowed.after}
+					</span>
+				) : null}
+			</span>
+		</div>
+	);
+}
+
+/** Path header + red/green hunk; focus stays centered as the modal grows. */
+function WikiLinkDiff({
+	source,
+	line,
+	prefix,
+	suffix,
+	oldText,
+	newText,
+	onNewTextChange,
+	newTextAriaLabel,
+}: {
+	source: string;
+	line: number;
+	prefix?: string;
+	suffix?: string;
+	oldText: string;
+	newText: string;
+	onNewTextChange?: (value: string) => void;
+	newTextAriaLabel?: string;
+}) {
+	const before = prefix ?? "";
+	const after = suffix ?? "";
+	return (
+		<div className="min-w-0 flex-1">
+			<p className="truncate font-mono text-muted-foreground text-xs">
+				{source}:{line}
+			</p>
+			<div className="mt-1 overflow-hidden rounded-md border font-mono text-xs">
+				<GitLine
+					sign="-"
+					tone="bad"
+					before={before}
+					focus={oldText}
+					after={after}
+				/>
+				<GitLine
+					sign="+"
+					tone="good"
+					before={before}
+					focus={newText}
+					after={after}
+					focusNode={
+						onNewTextChange ? (
+							<Input
+								aria-label={newTextAriaLabel}
+								value={newText}
+								onChange={(event) => onNewTextChange(event.currentTarget.value)}
+								className="mx-0.5 h-6 min-w-[4rem] max-w-[min(100%,28rem)] border-0 bg-emerald-500/20 px-1.5 py-0 font-mono text-emerald-800 text-xs shadow-none focus-visible:border-0 focus-visible:ring-1 focus-visible:ring-emerald-500/40 dark:bg-emerald-500/25 dark:text-emerald-300"
+								style={{
+									// Prefer content width for CJK; still allow growth.
+									width: `min(28rem, max(4rem, ${Math.ceil(measureMonoText(newText) + 16)}px))`,
+								}}
+							/>
+						) : undefined
+					}
+				/>
+			</div>
+		</div>
 	);
 }
 
@@ -128,12 +402,25 @@ export function DoctorPane({
 	vaultPath?: string | null;
 	hostContext: SettingsHostContext;
 }) {
-	const { t } = useTranslation("settings");
+	const { t, i18n } = useTranslation("settings");
 	const [report, setReport] = useState<DoctorReport | null>(null);
 	const [drafts, setDrafts] = useState<CandidateDraft[]>([]);
 	const [loading, setLoading] = useState(false);
 	const [applying, setApplying] = useState(false);
 	const [confirmOpen, setConfirmOpen] = useState(false);
+
+	const [wikiDrafts, setWikiDrafts] = useState<WikilinkDraft[]>([]);
+	const [wikiResiduals, setWikiResiduals] = useState<WikilinkRepairResidual[]>(
+		[],
+	);
+	const [wikiPlanning, setWikiPlanning] = useState(false);
+	const [wikiApplying, setWikiApplying] = useState(false);
+	const [wikiConfirmOpen, setWikiConfirmOpen] = useState(false);
+	const [wikiProgress, setWikiProgress] = useState<{
+		percent: number;
+		detail: string;
+	} | null>(null);
+	const [wikiReviewMode, setWikiReviewMode] = useState(false);
 
 	const refresh = useCallback(async () => {
 		if (!vaultPath || hostContext.kind === "remote") return;
@@ -147,6 +434,10 @@ export function DoctorPane({
 					selected: candidate.selectedByDefault,
 				})),
 			);
+			setWikiDrafts([]);
+			setWikiResiduals([]);
+			setWikiReviewMode(false);
+			setWikiProgress(null);
 		} catch (error) {
 			notifyError(error instanceof Error ? error.message : String(error));
 		} finally {
@@ -162,6 +453,10 @@ export function DoctorPane({
 		() => drafts.filter((draft) => draft.fixable && draft.selected),
 		[drafts],
 	);
+	const selectedWiki = useMemo(
+		() => wikiDrafts.filter((draft) => draft.selected),
+		[wikiDrafts],
+	);
 
 	const patchDraft = (
 		path: string,
@@ -172,6 +467,17 @@ export function DoctorPane({
 		setDrafts((current) =>
 			current.map((draft) =>
 				draft.path === path ? { ...draft, ...patch } : draft,
+			),
+		);
+	};
+
+	const patchWikiDraft = (
+		id: string,
+		patch: Partial<Pick<WikilinkDraft, "selected" | "suggestedReplacement">>,
+	) => {
+		setWikiDrafts((current) =>
+			current.map((draft) =>
+				draft.id === id ? { ...draft, ...patch } : draft,
 			),
 		);
 	};
@@ -198,6 +504,108 @@ export function DoctorPane({
 			notifyError(error instanceof Error ? error.message : String(error));
 		} finally {
 			setApplying(false);
+		}
+	};
+
+	/** Deterministic plan only → review list + optional Agent prompt handoff. */
+	const startWikiProbe = async () => {
+		if (!vaultPath) return;
+		setWikiPlanning(true);
+		setWikiReviewMode(false);
+		setWikiProgress({ percent: 15, detail: t("doctor.wikilink.planning") });
+		try {
+			const plan = await doctorPlanWikilinks(vaultPath);
+			const draftsFromPlan = plan.suggestions.map((item) => ({
+				...item,
+				// Manual rows stay unselected until the user edits/chooses them.
+				selected: item.selectedByDefault,
+			}));
+			setWikiDrafts(draftsFromPlan);
+			setWikiResiduals(plan.residuals);
+			setWikiReviewMode(true);
+			setWikiProgress(null);
+			const autoCount = draftsFromPlan.filter(
+				(item) => item.layer === "deterministic",
+			).length;
+			const manualCount = draftsFromPlan.filter(
+				(item) => item.layer === "manual",
+			).length;
+			if (draftsFromPlan.length === 0) {
+				notifyError(t("doctor.wikilink.noSuggestions"));
+			} else {
+				notifySuccess(
+					t("doctor.wikilink.probeDone", {
+						auto: autoCount,
+						manual: manualCount,
+						total: draftsFromPlan.length,
+					}),
+				);
+			}
+		} catch (error) {
+			notifyError(error instanceof Error ? error.message : String(error));
+			setWikiProgress(null);
+		} finally {
+			setWikiPlanning(false);
+		}
+	};
+
+	const agentPrompt = useMemo(() => {
+		if (!vaultPath || !wikiReviewMode) return "";
+		if (wikiResiduals.length === 0 && wikiDrafts.length === 0) return "";
+		return buildDoctorWikilinkAgentPrompt({
+			vaultPath,
+			residuals: wikiResiduals,
+			suggestions: wikiDrafts,
+			issues: report?.wikilinks.issues,
+			language: i18n.resolvedLanguage ?? i18n.language,
+		});
+	}, [
+		vaultPath,
+		wikiReviewMode,
+		wikiResiduals,
+		wikiDrafts,
+		report,
+		i18n.resolvedLanguage,
+		i18n.language,
+	]);
+
+	const copyAgentPrompt = async () => {
+		if (!agentPrompt) return;
+		await copyTextToClipboard(agentPrompt, {
+			successMessage: t("doctor.wikilink.promptCopied"),
+		});
+	};
+
+	const openAgentWithPrompt = () => {
+		if (!agentPrompt) return;
+		broadcastOpenAgentWithPrompt(agentPrompt);
+		closeSettingsWindow();
+	};
+
+	const applyWiki = async () => {
+		if (!vaultPath || selectedWiki.length === 0) return;
+		setWikiApplying(true);
+		try {
+			const result = await doctorApplyWikilinks(
+				vaultPath,
+				selectedWiki.map((draft) => ({
+					source: draft.source,
+					rangeStart: draft.rangeStart,
+					rangeEnd: draft.rangeEnd,
+					expected: draft.expected,
+					replacement: draft.suggestedReplacement,
+					expectedHash: draft.expectedHash,
+				})),
+			);
+			setWikiConfirmOpen(false);
+			notifySuccess(
+				t("doctor.wikilink.success", { count: result.updatedPaths.length }),
+			);
+			await refresh();
+		} catch (error) {
+			notifyError(error instanceof Error ? error.message : String(error));
+		} finally {
+			setWikiApplying(false);
 		}
 	};
 
@@ -232,6 +640,57 @@ export function DoctorPane({
 			(issue) => !drafts.some((draft) => draft.path === issue.path),
 		).length;
 	const hasFixableAliases = drafts.some((draft) => draft.fixable);
+	const wikiAllSelected =
+		wikiDrafts.length > 0 && wikiDrafts.every((draft) => draft.selected);
+
+	const toggleWikiSelectAll = () => {
+		const next = !wikiAllSelected;
+		setWikiDrafts((current) =>
+			current.map((draft) => ({ ...draft, selected: next })),
+		);
+	};
+
+	const wikiSectionAction = (() => {
+		if (wikiPlanning) {
+			return (
+				<Button type="button" size="sm" disabled>
+					{t("doctor.wikilink.working")}
+				</Button>
+			);
+		}
+		if (wikiReviewMode && wikiDrafts.length > 0) {
+			return (
+				<div className="flex shrink-0 items-center gap-2">
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={toggleWikiSelectAll}
+					>
+						{wikiAllSelected
+							? t("doctor.wikilink.deselectAll")
+							: t("doctor.wikilink.selectAll")}
+					</Button>
+					<Button
+						type="button"
+						size="sm"
+						disabled={selectedWiki.length === 0}
+						onClick={() => setWikiConfirmOpen(true)}
+					>
+						{t("doctor.repair.apply")}
+					</Button>
+				</div>
+			);
+		}
+		if (wikiIssues.length > 0) {
+			return (
+				<Button type="button" size="sm" onClick={() => void startWikiProbe()}>
+					{t("doctor.wikilink.probe")}
+				</Button>
+			);
+		}
+		return undefined;
+	})();
 
 	return (
 		<>
@@ -245,7 +704,7 @@ export function DoctorPane({
 								size="icon-sm"
 								variant="ghost"
 								aria-label={t("doctor.refresh")}
-								disabled={loading}
+								disabled={loading || wikiPlanning}
 								onClick={() => void refresh()}
 							>
 								<RefreshCw className={loading ? "animate-spin" : undefined} />
@@ -258,6 +717,7 @@ export function DoctorPane({
 
 			<DoctorSection
 				title={t("doctor.sections.vault")}
+				description={t("doctor.sectionHints.vault")}
 				ok={report?.vault.ok ?? true}
 				issueCount={vaultIssues.length}
 			>
@@ -266,6 +726,7 @@ export function DoctorPane({
 
 			<DoctorSection
 				title={t("doctor.sections.catalog")}
+				description={t("doctor.sectionHints.catalog")}
 				ok={report?.catalog.ok ?? true}
 				issueCount={catalogIssues.length}
 			>
@@ -274,14 +735,111 @@ export function DoctorPane({
 
 			<DoctorSection
 				title={t("doctor.sections.wikilinks")}
+				description={t("doctor.sectionHints.wikilinks")}
 				ok={wikiIssues.length === 0}
 				issueCount={wikiIssues.length}
+				action={wikiSectionAction}
+				scrollable
 			>
-				{wikiIssues.length > 0 ? <WikiIssueRows issues={wikiIssues} /> : null}
+				{wikiPlanning || wikiProgress ? (
+					<div className="space-y-2 px-3.5 py-3">
+						<p className="text-muted-foreground text-xs">
+							{wikiProgress?.detail ?? t("doctor.wikilink.planning")}
+						</p>
+						<Progress value={wikiProgress?.percent ?? 10} />
+					</div>
+				) : null}
+
+				{wikiReviewMode ? (
+					<>
+						{wikiDrafts.map((draft) => (
+							<div
+								key={draft.id}
+								className="border-b px-3.5 py-3 last:border-b-0"
+							>
+								<div className="flex items-start gap-2">
+									<Checkbox
+										className="mt-0.5"
+										checked={draft.selected}
+										aria-label={t("doctor.wikilink.select", {
+											source: draft.source,
+										})}
+										onCheckedChange={(checked) =>
+											patchWikiDraft(draft.id, {
+												selected: checked === true,
+											})
+										}
+									/>
+									<WikiLinkDiff
+										source={draft.source}
+										line={draft.line}
+										prefix={draft.linePrefix}
+										suffix={draft.lineSuffix}
+										oldText={draft.expected}
+										newText={draft.suggestedReplacement}
+										newTextAriaLabel={t("doctor.wikilink.replacement")}
+										onNewTextChange={(value) =>
+											patchWikiDraft(draft.id, {
+												suggestedReplacement: value,
+											})
+										}
+									/>
+								</div>
+							</div>
+						))}
+						{/* Residuals are already mirrored as manual suggestions; only used for Agent prompt. */}
+						{wikiDrafts.length === 0 ? (
+							<p className="px-3.5 py-3 text-muted-foreground text-xs">
+								{t("doctor.wikilink.noSuggestions")}
+							</p>
+						) : null}
+					</>
+				) : wikiIssues.length > 0 ? (
+					<WikiIssueRows issues={wikiIssues} />
+				) : null}
 			</DoctorSection>
+
+			{wikiReviewMode && agentPrompt ? (
+				<div className="mb-5 space-y-2 px-0.5">
+					<p className="text-[13px] text-muted-foreground leading-relaxed">
+						{t("doctor.wikilink.agentHint")}
+					</p>
+					<div className="overflow-hidden rounded-xl border bg-card">
+						<div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
+							<span className="font-medium text-muted-foreground text-xs">
+								{t("doctor.wikilink.agentPromptLabel")}
+							</span>
+							<div className="flex items-center gap-1.5">
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									className="h-7 px-2"
+									onClick={() => void copyAgentPrompt()}
+								>
+									<Copy className="size-3.5" data-icon="inline-start" />
+									{t("doctor.wikilink.copyPrompt")}
+								</Button>
+								<Button
+									type="button"
+									size="sm"
+									className="h-7"
+									onClick={openAgentWithPrompt}
+								>
+									{t("doctor.wikilink.openInAgent")}
+								</Button>
+							</div>
+						</div>
+						<pre className="max-h-32 overflow-auto whitespace-pre-wrap break-words px-3 py-2 font-mono text-[11px] leading-relaxed text-muted-foreground">
+							{agentPrompt}
+						</pre>
+					</div>
+				</div>
+			) : null}
 
 			<DoctorSection
 				title={t("doctor.sections.aliases")}
+				description={t("doctor.sectionHints.aliases")}
 				ok={report?.aliases.ok ?? true}
 				issueCount={aliasIssueCount}
 				action={
@@ -296,6 +854,8 @@ export function DoctorPane({
 						</Button>
 					) : undefined
 				}
+				scrollable
+				showDivider={false}
 			>
 				{drafts.length > 0 || aliasIssues.length > 0 ? (
 					<>
@@ -404,6 +964,29 @@ export function DoctorPane({
 						</DialogClose>
 						<Button disabled={applying} onClick={() => void apply()}>
 							{applying
+								? t("doctor.repair.applying")
+								: t("doctor.repair.confirm")}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={wikiConfirmOpen} onOpenChange={setWikiConfirmOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>{t("doctor.wikilink.confirmTitle")}</DialogTitle>
+						<DialogDescription>
+							{t("doctor.wikilink.confirmDescription", {
+								count: selectedWiki.length,
+							})}
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<DialogClose asChild>
+							<Button variant="outline">{t("doctor.repair.cancel")}</Button>
+						</DialogClose>
+						<Button disabled={wikiApplying} onClick={() => void applyWiki()}>
+							{wikiApplying
 								? t("doctor.repair.applying")
 								: t("doctor.repair.confirm")}
 						</Button>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
 			type={type}
 			data-slot="input"
 			className={cn(
-				"h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+				"h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-sm transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
 				className,
 			)}
 			{...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
 		<textarea
 			data-slot="textarea"
 			className={cn(
-				"flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+				"flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
 				className,
 			)}
 			{...props}

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -255,6 +255,12 @@
 			"wikilinks": "Wiki links",
 			"aliases": "Paper aliases"
 		},
+		"sectionHints": {
+			"vault": "Checks top-level papers/, notes/, plans/, and .agentero/ folders.",
+			"catalog": "Checks that .agentero/catalog.sqlite exists and its schema matches this app.",
+			"wikilinks": "Checks local wiki links for missing, ambiguous, or invalid heading targets.",
+			"aliases": "Checks paper NOTES.md for at least two distinct frontmatter aliases."
+		},
 		"issueCount": "{{count}} issue(s)",
 		"repair": {
 			"select": "Select {{path}}",
@@ -269,6 +275,25 @@
 			"confirm": "Apply changes",
 			"applying": "Applying…",
 			"success": "Updated aliases in {{count}} paper note(s)."
+		},
+		"wikilink": {
+			"probe": "Probe",
+			"planning": "Running lightweight probe…",
+			"working": "Working…",
+			"probeDone": "Probe done: {{auto}} auto, {{manual}} manual ({{total}} total)",
+			"agentHint": "Not sure? Hand the prompt below to your Agent and ask for a fix plan first.",
+			"agentPromptLabel": "Agent prompt",
+			"copyPrompt": "Copy",
+			"promptCopied": "Prompt copied",
+			"openInAgent": "Open in Agent",
+			"select": "Select repair in {{source}}",
+			"replacement": "Replacement",
+			"selectAll": "Select all",
+			"deselectAll": "Deselect all",
+			"noSuggestions": "No automatic suggestions. Edit links in the notes manually.",
+			"confirmTitle": "Apply link repairs?",
+			"confirmDescription": "Doctor will rewrite {{count}} link target(s) as one transaction. Only the selected byte ranges change.",
+			"success": "Updated links in {{count}} file(s)."
 		}
 	},
 	"keyboard": {

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -248,6 +248,12 @@
 			"wikilinks": "双链语义",
 			"aliases": "论文别名"
 		},
+		"sectionHints": {
+			"vault": "检查顶层 papers/、notes/、plans/、.agentero/ 目录是否齐全。",
+			"catalog": "检查 .agentero/catalog.sqlite 是否存在，以及 schema 是否与当前应用一致。",
+			"wikilinks": "检查笔记中的本地双链是否可解析（缺失、歧义、无效标题锚点）。",
+			"aliases": "检查论文 NOTES.md 是否具备至少两个可区分的 frontmatter aliases。"
+		},
 		"issueCount": "{{count}} 个问题",
 		"repair": {
 			"select": "选择 {{path}}",
@@ -262,6 +268,25 @@
 			"confirm": "应用更改",
 			"applying": "正在应用…",
 			"success": "已更新 {{count}} 篇论文笔记的别名。"
+		},
+		"wikilink": {
+			"probe": "探测",
+			"planning": "正在做轻量探测…",
+			"working": "处理中…",
+			"probeDone": "探测完成：自动建议 {{auto}} 条，可手改 {{manual}} 条（共 {{total}}）",
+			"agentHint": "并不确定？把下面的提示词交给 Agent，让它先给修改意见。",
+			"agentPromptLabel": "Agent 提示词",
+			"copyPrompt": "复制",
+			"promptCopied": "已复制提示词",
+			"openInAgent": "在 Agent 中打开",
+			"select": "选择 {{source}} 中的修复",
+			"replacement": "替换为",
+			"selectAll": "全选",
+			"deselectAll": "取消全选",
+			"noSuggestions": "没有自动建议，请在笔记中手动改链接。",
+			"confirmTitle": "应用双链修复？",
+			"confirmDescription": "Doctor 将把 {{count}} 处链接目标作为一个事务写入；只改选中的字节范围。",
+			"success": "已更新 {{count}} 个文件中的链接。"
 		}
 	},
 	"keyboard": {

--- a/src/lib/agent/composer-seed.ts
+++ b/src/lib/agent/composer-seed.ts
@@ -1,0 +1,75 @@
+/**
+ * Cross-window Agent composer seed (Settings → main).
+ * Settings emits a Tauri event; main applies text into the open Agent composer.
+ */
+
+import { isTauri } from "@/lib/core/tauri";
+
+export const AGENT_OPEN_WITH_PROMPT_EVENT = "agent:open-with-prompt";
+
+export type AgentOpenWithPromptPayload = {
+	text: string;
+};
+
+type Listener = (text: string) => void;
+
+/** Main-window only: pending prompt until Agent panel consumes it. */
+let pendingPrompt: string | null = null;
+const listeners = new Set<Listener>();
+
+export function setPendingAgentComposerPrompt(text: string): void {
+	const trimmed = text.trim();
+	if (!trimmed) return;
+	pendingPrompt = trimmed;
+	for (const listener of listeners) {
+		listener(trimmed);
+	}
+}
+
+/** Agent panel: take and clear one pending seed (or null). */
+export function takePendingAgentComposerPrompt(): string | null {
+	const next = pendingPrompt;
+	pendingPrompt = null;
+	return next;
+}
+
+export function subscribePendingAgentComposerPrompt(
+	listener: Listener,
+): () => void {
+	listeners.add(listener);
+	return () => {
+		listeners.delete(listener);
+	};
+}
+
+/** Settings (or any window): ask main to open Agent with this prompt. */
+export function broadcastOpenAgentWithPrompt(text: string): void {
+	if (!isTauri()) return;
+	const trimmed = text.trim();
+	if (!trimmed) return;
+	void (async () => {
+		try {
+			const { emit } = await import("@tauri-apps/api/event");
+			await emit(AGENT_OPEN_WITH_PROMPT_EVENT, {
+				text: trimmed,
+			} satisfies AgentOpenWithPromptPayload);
+		} catch {
+			// non-fatal
+		}
+	})();
+}
+
+export async function listenOpenAgentWithPrompt(
+	handler: (payload: AgentOpenWithPromptPayload) => void,
+): Promise<() => void> {
+	if (!isTauri()) return () => {};
+	const { listen } = await import("@tauri-apps/api/event");
+	return listen<AgentOpenWithPromptPayload>(
+		AGENT_OPEN_WITH_PROMPT_EVENT,
+		(event) => {
+			if (event.payload && typeof event.payload.text === "string") {
+				handler(event.payload);
+			}
+		},
+	);
+}

--- a/src/lib/doctor/api.ts
+++ b/src/lib/doctor/api.ts
@@ -69,6 +69,69 @@ export type AliasRepairChange = {
 	expectedHash: string;
 };
 
+export type WikilinkRepairLayer = "deterministic" | "manual";
+export type WikilinkEditKind = "target" | "fragment";
+
+export type WikilinkRepairSuggestion = {
+	id: string;
+	source: string;
+	line: number;
+	status: string;
+	syntax: string;
+	embed: boolean;
+	targetRaw: string;
+	suggestedReplacement: string;
+	editKind: WikilinkEditKind;
+	rangeStart: number;
+	rangeEnd: number;
+	expected: string;
+	expectedHash: string;
+	/** Same-line text before the edit span (git-style context). */
+	linePrefix?: string;
+	/** Same-line text after the edit span. */
+	lineSuffix?: string;
+	layer: WikilinkRepairLayer;
+	reason: string;
+	selectedByDefault: boolean;
+	candidates?: string[];
+	context?: string;
+};
+
+export type WikilinkRepairResidual = {
+	id: string;
+	source: string;
+	line: number;
+	status: string;
+	syntax: string;
+	embed: boolean;
+	targetRaw: string;
+	editKind: WikilinkEditKind;
+	rangeStart: number;
+	rangeEnd: number;
+	expected: string;
+	expectedHash: string;
+	linePrefix?: string;
+	lineSuffix?: string;
+	candidates?: string[];
+	context?: string;
+	targetPath?: string;
+	vaultHints?: string[];
+};
+
+export type WikilinkRepairPlan = {
+	suggestions: WikilinkRepairSuggestion[];
+	residuals: WikilinkRepairResidual[];
+};
+
+export type WikilinkRepairChange = {
+	source: string;
+	rangeStart: number;
+	rangeEnd: number;
+	expected: string;
+	replacement: string;
+	expectedHash: string;
+};
+
 export function doctorCheck(vaultPath: string): Promise<DoctorReport> {
 	return invokeApi<DoctorReport>("doctor_check", {
 		args: { vaultPath },
@@ -80,6 +143,23 @@ export function doctorApplyAliases(
 	changes: AliasRepairChange[],
 ): Promise<{ updatedPaths: string[] }> {
 	return invokeApi<{ updatedPaths: string[] }>("doctor_apply_aliases", {
+		args: { vaultPath, changes },
+	});
+}
+
+export function doctorPlanWikilinks(
+	vaultPath: string,
+): Promise<WikilinkRepairPlan> {
+	return invokeApi<WikilinkRepairPlan>("doctor_plan_wikilinks", {
+		args: { vaultPath },
+	});
+}
+
+export function doctorApplyWikilinks(
+	vaultPath: string,
+	changes: WikilinkRepairChange[],
+): Promise<{ updatedPaths: string[] }> {
+	return invokeApi<{ updatedPaths: string[] }>("doctor_apply_wikilinks", {
 		args: { vaultPath, changes },
 	});
 }

--- a/src/lib/doctor/wikilink-prompt.ts
+++ b/src/lib/doctor/wikilink-prompt.ts
@@ -1,0 +1,117 @@
+/**
+ * Build a copy/paste Agent prompt for Doctor residual wikilink issues.
+ * Language follows the app UI locale (zh-CN vs en).
+ */
+
+import type {
+	WikiCheckIssue,
+	WikilinkRepairResidual,
+	WikilinkRepairSuggestion,
+} from "@/lib/doctor/api";
+
+function isChineseLocale(language?: string): boolean {
+	const tag = (language ?? "").toLowerCase();
+	return tag.startsWith("zh");
+}
+
+export function buildDoctorWikilinkAgentPrompt(input: {
+	vaultPath: string;
+	residuals: WikilinkRepairResidual[];
+	/** Lightweight suggestions already offered in Doctor (for context). */
+	suggestions?: WikilinkRepairSuggestion[];
+	/** Full diagnosis issues when residuals alone are thin. */
+	issues?: WikiCheckIssue[];
+	/** BCP-47 / i18n language (e.g. zh-CN, en). Defaults to English. */
+	language?: string;
+}): string {
+	const zh = isChineseLocale(input.language);
+
+	const residualLines = input.residuals.map((item, index) => {
+		const bits = [
+			`${index + 1}. ${item.source}:${item.line}`,
+			`status=${item.status}`,
+			`editKind=${item.editKind}`,
+			`current="${item.expected}"`,
+			`targetRaw="${item.targetRaw}"`,
+		];
+		if (item.targetPath) bits.push(`resolvedPath=${item.targetPath}`);
+		if (item.candidates?.length) {
+			bits.push(`candidates=${item.candidates.join(" | ")}`);
+		}
+		if (item.context) bits.push(`context=${item.context}`);
+		return bits.join(" · ");
+	});
+
+	const suggestionLines = (input.suggestions ?? []).map((item, index) => {
+		return `${index + 1}. ${item.source}:${item.line} · ${item.expected} → ${item.suggestedReplacement} (${item.layer})`;
+	});
+
+	const issueLines = (input.issues ?? []).map((item, index) => {
+		return `${index + 1}. ${item.source}:${item.line} · ${item.status} · ${item.targetRaw}`;
+	});
+
+	const copy = zh
+		? {
+				role: "你在帮助修复 Agentero Vault 中失效的本地双链。",
+				vault: `Vault 路径：${input.vaultPath}`,
+				taskTitle: "任务：",
+				tasks: [
+					"- 阅读列出的坏链（必要时查看附近笔记内容）。",
+					"- 合理使用 Vault 工具（读文件 / 搜索）定位正确目标。",
+					"- 先给出具体修改计划：每条写明 文件路径 + 旧链接文本 → 新链接文本。",
+					"- 在我明确同意之前，不要修改任何文件。",
+					"- 优先最小改动（只改链接 target / fragment 文本）。",
+					"- 保持 Obsidian 兼容的 [[wikilink]] / Markdown 链接写法。",
+				],
+				residualTitle: "轻量探测未能安全修复的链接：",
+				suggestionTitle:
+					"可选上下文 — Doctor 已给出的轻量修复建议（设置页中可能已勾选）：",
+				issueTitle: "诊断出的全部双链问题：",
+				closing: "准备好后，只回复编号计划。在我确认 OK 之前不要写入。",
+			}
+		: {
+				role: "You are helping repair broken Vault-local wiki links in Agentero.",
+				vault: `Vault path: ${input.vaultPath}`,
+				taskTitle: "Task:",
+				tasks: [
+					"- Read the listed broken links (and nearby note content if needed).",
+					"- Use Vault tools reasonably (read/search files) to find the correct targets.",
+					"- Propose a concrete fix list first: for each item, show old → new link text and file path.",
+					"- Do NOT modify files until I explicitly approve the plan.",
+					"- Prefer minimal edits (only the link target / fragment text).",
+					"- Keep Obsidian-compatible [[wikilinks]] / Markdown links as written.",
+				],
+				residualTitle:
+					"Links that lightweight Doctor probe could not fix safely:",
+				suggestionTitle:
+					"Optional context — Doctor already proposed these lightweight fixes (may already be selected in UI):",
+				issueTitle: "All diagnosed wiki-link issues:",
+				closing:
+					"When ready, reply with a numbered plan only. Wait for my OK before writing.",
+			};
+
+	const sections = [
+		copy.role,
+		copy.vault,
+		"",
+		copy.taskTitle,
+		...copy.tasks,
+		"",
+	];
+
+	if (residualLines.length > 0) {
+		sections.push(copy.residualTitle, ...residualLines, "");
+	}
+
+	if (suggestionLines.length > 0) {
+		sections.push(copy.suggestionTitle, ...suggestionLines, "");
+	}
+
+	if (residualLines.length === 0 && issueLines.length > 0) {
+		sections.push(copy.issueTitle, ...issueLines, "");
+	}
+
+	sections.push(copy.closing);
+
+	return sections.join("\n");
+}


### PR DESCRIPTION
## 改动概述

- Doctor 双链支持「探测」：确定性自动建议 + 无法自动匹配时的可手改候选项
- 设置页用 git 风格整行 diff 展示（核心高亮、按宽度窗口化前后文），确认后批量写入
- 探测后提供可复制 Agent 提示词（随 UI 语言 en/zh），可一键打开主窗 Agent 并预填
- 写入前校验脏路径与内容哈希，原地写盘并支持批失败回滚
- 顺带：Input/Textarea 默认 `text-sm`，避免窄设置窗字号过大

Closes #215。

## Demo

1. 进入 `知识库诊断` 显示存在问题的双链:
<img width="996" height="538" alt="image" src="https://github.com/user-attachments/assets/de6b1d71-3c62-4dfa-928d-3d57990b002c" />

2. 点击 `探测` 之后自动选中轻量级探测后自动检测到的修正, 并自动勾选(无法识别的 item 保留手动修改建议, 但是更推荐点击下方的"在 Agent 中打开" 来让 agent 给出修改意见)
<img width="996" height="538" alt="image" src="https://github.com/user-attachments/assets/60838200-38f0-492d-9628-d0920563241d" />
> 确定性建议可以一键修正.


3. 使用准备好的提示词让 agent 修改(提示词已经附带了doctor 的探测信息)
<img width="1258" height="567" alt="image" src="https://github.com/user-attachments/assets/f51f1f53-73e3-43a2-a43b-70938b8b48ed" />


## 用户影响

用户可在「设置 → 知识库诊断 → 双链语义」中探测坏链、勾选/手改后修复，不会静默改写 Markdown。复杂情况可把提示词交给 BYOA Agent，先出修改计划再动手。

远程 Vault 仍不可用。

## 验证

- `cargo test -p agentero --lib wikilink_repair`
- `pnpm exec tsc --noEmit`
- 本地设置页：探测 → 列表 diff → 修复 / 打开 Agent