### PR TITLE
fix(agent): 修复历史会话恢复

### DIFF
--- a/docs/bug_fix/codex-history-runtime-session-id.md
+++ b/docs/bug_fix/codex-history-runtime-session-id.md
@@ -1,0 +1,53 @@
+# Codex 历史恢复误用 runtime session id
+
+**状态**：已修复
+**Issue**：[#209](https://github.com/poco-ai/Agentero/issues/209)
+**影响面**：Agent 面板中新建对话后打开刚结束的 Codex 历史会话
+
+## 现象
+
+完成一轮 Codex 对话，点击「新建」，再从历史记录打开刚才的会话时，ACP 返回：
+
+```text
+session/load: Internal error: no rollout found for thread id <uuid>
+```
+
+错误中的 UUID 是 Agentero 为事件关联生成的 runtime session id，不是 Codex rollout/thread id。
+
+连续在同一个对话中发送第二个问题时，还会看到两个（或多个）历史项：每一项只有当前轮的标题，像是每次提问都新建了会话。
+
+## 根因
+
+问题由三段状态衔接共同触发：
+
+1. `newConversation` 在活动 tab 仍指向旧会话时先调用 `setLines([])`，因此清空了旧会话保存在共享 session store 中的 transcript。
+2. 再次打开该历史项时，因为本地 `lines` 已为空，前端转而调用 `session/load`；旧实现传入 `item.id`（Agentero runtime id），而不是该项已经保存的 `providerSessionId`（Codex thread id）。Codex 自然找不到对应 rollout。
+3. `session/load` 成功后的 transcript 写入、会话激活和 `setLines` 原本分散在多次 store 更新中；历史列表若在加载期间刷新，目标行可能已经不存在，最终会激活一个没有 transcript 的 id，表现为“不报错但空白”。
+4. ACP 为每次 `agent_run_once` 请求生成新的 Agentero runtime id，即便请求通过 `session/resume` / `session/load` 续接同一个 provider session。前端原先按 runtime id 无条件新增历史项，未按 provider id 合并，因此一个 provider 对话被拆成多个列表项。
+5. 续聊时前端还曾把 provider id 当作“待接收事件”的 runtime id；完成事件可能在新历史行创建前被过滤，导致界面只剩用户提问。
+
+## 上游行为核对
+
+官方 [`agentclientprotocol/codex-acp`](https://github.com/agentclientprotocol/codex-acp) 的 `loadSession` 会先 `threadResume` / `threadRead(includeTurns: true)`，再通过多条 `session/update` 回放历史，最后返回 `session/load` response；也就是说，历史通知可能早于 RPC response。
+
+参考 [`zed-industries/zed`](https://github.com/zed-industries/zed) 的 ACP client 与回归测试，客户端必须在请求完成前准备好会话接收容器。Agentero Host 的 `ReplayBuilder` 已经能接住 response 前的更新并产出非空 `history.lines`，因此第二阶段空白发生在前端把完整快照写入共享 session store 的过程，不需要修改 ACP 协议层。
+
+## 修复
+
+- session store 提供原子的 `startDraft()`：只切换到空草稿并清空草稿内容，不修改刚离开的会话 transcript。
+- 历史恢复统一通过 `providerSessionIdForHistoryLoad()` 解析 provider id；优先使用非空 `providerSessionId`，仅对 provider 直接索引的历史项回退到 `item.id`。
+- session store 提供 `hydrateAndActivateSession()`：在一次更新中 upsert 历史项、写入完整 transcript、清理草稿并激活目标会话；即使列表刷新暂时移除了目标项，也会从用户点击时的快照恢复。
+- 打开已有本地 transcript 时，后续续聊也使用同一 provider id。
+- 连续续聊时，新的 runtime 行会替换旧的活动行，并按 provider id 去重；历史刷新也会用 provider id 将本地 runtime 行与 ACP `session/list` 结果合并，避免再次出现重复项。
+- 事件等待状态只记录新请求返回的 runtime id；provider id 仅用于 ACP resume/load，因此续聊的流式回答和完成事件不会在建行前丢失。
+
+## 回归覆盖
+
+- 新建对话后，旧会话 transcript 保持不变。
+- 本地历史项同时包含 runtime id 和 provider id 时，加载选择 provider id。
+- ACP `session/list` 直接导入、其 `item.id` 本身就是 provider id 时仍可正常加载。
+- `session/load` 返回非空 transcript 后，激活项立即可从共享 store 读到相同行；加载期间目标项被列表刷新移除时也不丢失内容。
+- 同一个 provider session 连续发送多轮后，历史列表保持单个会话项，且该项包含之前的用户问题与助手回答。
+- 续聊的 runtime 事件在历史行发布前会暂存，发布后回放，确保助手回答不再缺失。
+
+Roadmap 与 TODO 已检查：这是已实现 Agent 历史能力的缺陷修复，不新增未完成产品项。

--- a/docs/frontend/agent.md
+++ b/docs/frontend/agent.md
@@ -24,6 +24,7 @@ AI Elements (Conversation / Message / PromptInput / Sources / Reasoning)
 - ACP `AskUserQuestion` 工具调用会解析为 AI Elements `Tool` 内的可选回答；完成选择后以正常的下一用户轮提交，并继续同一 ACP 会话。
 - 运行中可继续输入 → Queue waitlist；标题保持简洁，条目等宽并可单独移除；Esc / 停止中止。
 - 会话空闲时 hover 用户消息可 **Edit** 后重发。
+- **新建对话 / 历史恢复**：新建草稿不会清空刚离开的本地 transcript；历史项同时存在 Agentero runtime id 与 ACP provider id 时，`session/load` / 后续续聊只使用 `providerSessionId`；连续续聊产生的新 runtime 行会按 provider id 合并回同一个历史项；加载结果通过一次原子 store 更新写入并激活，避免列表刷新后出现空白会话。详见 [Codex 历史恢复误用 runtime id](../bug_fix/codex-history-runtime-session-id.md)。
 - Slash 命令完全来自当前 ACP session 的 `available_commands_update`；Agentero 不再注册本地 action/template。命令以 `/name` 填入 Composer，并在当前 provider session 中原样发送。
 
 ## 权限 UI

--- a/src/components/agent/use-agent-panel.ts
+++ b/src/components/agent/use-agent-panel.ts
@@ -88,7 +88,10 @@ import {
 	nextPartId,
 	type PendingSessionEvent,
 	type PendingTerminalEvent,
+	providerSessionIdForHistoryLoad,
 	resolveSelected,
+	shouldDeferSessionEvent,
+	upsertChatSessionTurn,
 	upsertPlanPart,
 } from "@/lib/agent/chat-state";
 import {
@@ -265,6 +268,10 @@ export function useAgentPanel({
 	const setSessionHistory = useAgentSessionStore((s) => s.setSessions);
 	const activeTabId = useAgentSessionStore((s) => s.activeTabId);
 	const setActiveTabId = useAgentSessionStore((s) => s.setActiveTabId);
+	const startDraft = useAgentSessionStore((s) => s.startDraft);
+	const hydrateAndActivateSession = useAgentSessionStore(
+		(s) => s.hydrateAndActivateSession,
+	);
 	const setStoreSubmitting = useAgentSessionStore((s) => s.setSubmitting);
 	const [switching, setSwitching] = useState(false);
 	const [usage, setUsage] = useState<{ used: number; size: number } | null>(
@@ -362,6 +369,7 @@ export function useAgentPanel({
 	const pendingSessionEventsRef = useRef(
 		new Map<string, PendingSessionEvent[]>(),
 	);
+	/** Runtime id awaiting publication; never the provider id used for resume. */
 	const pendingSubmissionSessionIdRef = useRef<string | null>(null);
 	const knownSessionIdsRef = useRef(new Set<string>());
 	/** Per-session <think> tag parsers for message-channel reasoning (DeepSeek etc.). */
@@ -1042,12 +1050,12 @@ export function useAgentPanel({
 	);
 
 	const shouldDeferTerminalEvent = useCallback((sessionId: string) => {
-		if (!submittingRef.current) return false;
-		const expectedSessionId = pendingSubmissionSessionIdRef.current;
-		return (
-			expectedSessionId === sessionId ||
-			(expectedSessionId === null && !knownSessionIdsRef.current.has(sessionId))
-		);
+		return shouldDeferSessionEvent({
+			sessionId,
+			submitting: submittingRef.current,
+			pendingRuntimeSessionId: pendingSubmissionSessionIdRef.current,
+			knownSessionIds: knownSessionIdsRef.current,
+		});
 	}, []);
 
 	useEffect(() => {
@@ -1195,13 +1203,23 @@ export function useAgentPanel({
 				(s) => !isBackgroundWorkflowHistoryTitle(s.title ?? ""),
 			);
 			setSessionHistory((prev) => {
-				const existing = new Map(
-					prev
-						.filter((item) => item.agentId === selectedAgentId)
-						.map((item) => [item.id, item]),
+				const existingForAgent = prev.filter(
+					(item) => item.agentId === selectedAgentId,
+				);
+				const existingById = new Map(
+					existingForAgent.map((item) => [item.id, item]),
+				);
+				const existingByProvider = new Map(
+					existingForAgent
+						.filter((item) => item.providerSessionId?.trim())
+						.map((item) => [item.providerSessionId?.trim() as string, item]),
 				);
 				const imported = chatSessions.map((session) => {
-					const current = existing.get(session.sessionId);
+					// A local runtime row may have a different id from the durable
+					// provider session returned by session/list after a resumed turn.
+					const current =
+						existingById.get(session.sessionId) ??
+						existingByProvider.get(session.sessionId);
 					const startedAt = session.updatedAt
 						? new Date(session.updatedAt).toLocaleString(i18n.language)
 						: "";
@@ -1247,6 +1265,7 @@ export function useAgentPanel({
 					(item) =>
 						item.agentId === selectedAgentId &&
 						!importedIds.has(item.id) &&
+						!importedIds.has(item.providerSessionId?.trim() ?? "") &&
 						!isBackgroundWorkflowHistoryTitle(item.title) &&
 						(item.status === "running" ||
 							(item.source === "local" && item.lines.length > 0)),
@@ -1940,7 +1959,10 @@ export function useAgentPanel({
 			const resumeSessionId = resumeAllowed
 				? (providerContinueId ?? undefined)
 				: undefined;
-			pendingSubmissionSessionIdRef.current = resumeSessionId ?? null;
+			// Terminal/stream events are correlated by the fresh Agentero runtime
+			// id, not the provider id used to resume ACP. Keep this empty until the
+			// host accepts the request, then bind it to accepted.sessionId below.
+			pendingSubmissionSessionIdRef.current = null;
 			const accepted = await runOnce({
 				agentId,
 				sessionId: resumeSessionId,
@@ -1967,6 +1989,7 @@ export function useAgentPanel({
 				return false;
 			}
 			knownSessionIdsRef.current.add(accepted.sessionId);
+			pendingSubmissionSessionIdRef.current = accepted.sessionId;
 			// Bind disk finalizers for this runtime session:
 			// - first turn with visualDrafts → create mark files
 			// - follow-up on a bound pin (no new drafts) → re-register pending
@@ -2128,42 +2151,45 @@ export function useAgentPanel({
 				options?.paperAbsPath?.trim() ||
 				historyPaperAbs ||
 				resolvedVisualDrafts[0]?.paperAbsPath;
-			setSessionHistory((prev) => [
-				{
-					id: accepted.sessionId,
-					agentId,
-					source: "local",
-					title: historyTitle || activeHistory?.title || t("defaultName"),
-					agentName: selected?.name ?? t("defaultName"),
-					startedAt:
-						activeHistory?.startedAt ||
-						new Date().toLocaleString(i18n.language),
-					lines: historyLines,
-					status: "running",
-					// Carry over pin session provider id until completed event.
-					providerSessionId: activeHistory?.providerSessionId ?? null,
-					resumeable: true,
-					...(boundVisualTraceId ? { visualTraceId: boundVisualTraceId } : {}),
-					...(boundPaperAbs ? { paperAbsPath: boundPaperAbs } : {}),
-				},
-				// Drop superseded visual-trace placeholder / duplicate runtime rows.
-				...prev.filter(
-					(item) =>
-						item.id !== accepted.sessionId &&
-						!(
-							activeHistory &&
-							isVisualTraceHistoryId(activeHistory.id) &&
-							item.id === activeHistory.id
-						) &&
-						!(
-							boundVisualTraceId &&
-							"visualTraceId" in item &&
-							(item as { visualTraceId?: string }).visualTraceId ===
+			const nextHistoryItem: ChatSessionHistoryItem = {
+				id: accepted.sessionId,
+				agentId,
+				source: "local",
+				title: activeHistory?.title || historyTitle || t("defaultName"),
+				agentName: selected?.name ?? t("defaultName"),
+				startedAt:
+					activeHistory?.startedAt || new Date().toLocaleString(i18n.language),
+				lines: historyLines,
+				status: "running",
+				// Carry over pin session provider id until completed event.
+				providerSessionId: activeHistory?.providerSessionId ?? null,
+				resumeable: true,
+				...(boundVisualTraceId ? { visualTraceId: boundVisualTraceId } : {}),
+				...(boundPaperAbs ? { paperAbsPath: boundPaperAbs } : {}),
+			};
+			setSessionHistory((prev) =>
+				upsertChatSessionTurn(
+					// Drop superseded visual-trace placeholders before applying the
+					// provider-id based conversation merge.
+					prev.filter(
+						(item) =>
+							!(
+								activeHistory &&
+								isVisualTraceHistoryId(activeHistory.id) &&
+								item.id === activeHistory.id
+							) &&
+							!(
 								boundVisualTraceId &&
-							item.id !== accepted.sessionId
-						),
+								"visualTraceId" in item &&
+								(item as { visualTraceId?: string }).visualTraceId ===
+									boundVisualTraceId &&
+								item.id !== accepted.sessionId
+							),
+					),
+					nextHistoryItem,
+					activeHistory,
 				),
-			]);
+			);
 			setLines(pendingLines);
 			for (const pendingEvent of pendingSessionEvents) {
 				if (pendingEvent.kind === "stream") {
@@ -2779,9 +2805,8 @@ export function useAgentPanel({
 	const newConversation = () => {
 		if (submittingRef.current) return;
 		historyHydrationGenRef.current += 1;
-		setLines([]);
+		startDraft();
 		resetComposerSession("draft");
-		setActiveTabId("draft");
 		activeTabRef.current = "draft";
 		activeConversationRef.current = null;
 		clearMessageQueue();
@@ -2822,18 +2847,19 @@ export function useAgentPanel({
 
 	const openHistorySession = (item: ChatSessionHistoryItem) => {
 		if (submittingRef.current) return;
+		const providerSessionId = providerSessionIdForHistoryLoad(item);
 		const hydrationGeneration = ++historyHydrationGenRef.current;
 		setHistoryOpen(false);
 		clearMessageQueue();
 		if (!supportsResume || item.lines.length > 0) {
+			const localLines = sanitizeChatLines(item.lines);
 			activateComposerSession(item.id);
-			setLines(sanitizeChatLines(item.lines));
 			activeTabRef.current = item.id;
-			setActiveTabId(item.id);
+			hydrateAndActivateSession(item, localLines);
 			// Visual-trace (and other non-resumeable) sessions keep multi-turn
 			// context in local lines; never set an ACP resume id for them.
 			if (supportsResume && item.resumeable !== false) {
-				activeConversationRef.current = item.providerSessionId ?? item.id;
+				activeConversationRef.current = providerSessionId;
 			} else {
 				activeConversationRef.current = null;
 			}
@@ -2846,7 +2872,7 @@ export function useAgentPanel({
 			try {
 				const history = await loadSession({
 					agentId: requestAgentId,
-					sessionId: item.id,
+					sessionId: providerSessionId,
 					vaultPath: requestVaultPath ?? undefined,
 				});
 				if (
@@ -2932,22 +2958,10 @@ export function useAgentPanel({
 					firstUser?.kind === "user"
 						? displayHistoryTitle(firstUser.text, history.title ?? "")
 						: displayHistoryTitle(history.title ?? "");
-				setSessionHistory((prev) =>
-					prev.map((entry) =>
-						entry.id === item.id && entry.agentId === requestAgentId
-							? {
-									...entry,
-									title: titleFromBody,
-									lines: nextLines,
-								}
-							: entry,
-					),
-				);
-				activeConversationRef.current = item.providerSessionId ?? item.id;
+				activeConversationRef.current = providerSessionId;
 				activateComposerSession(item.id);
 				activeTabRef.current = item.id;
-				setActiveTabId(item.id);
-				setLines(nextLines);
+				hydrateAndActivateSession(item, nextLines, titleFromBody);
 			} catch (error) {
 				if (
 					hydrationGeneration !== historyHydrationGenRef.current ||

--- a/src/lib/agent/agent-session-store.ts
+++ b/src/lib/agent/agent-session-store.ts
@@ -84,6 +84,8 @@ type AgentSessionStore = {
 			| ((prev: AgentSessionRecord[]) => AgentSessionRecord[]),
 	) => void;
 	setActiveTabId: (id: string) => void;
+	/** Start an empty draft without mutating the transcript of the active session. */
+	startDraft: () => void;
 	/** Replace/update lines for the active tab (draft or session row). */
 	setLines: (update: ChatLine[] | ((prev: ChatLine[]) => ChatLine[])) => void;
 	setSubmitting: (v: boolean) => void;
@@ -95,6 +97,12 @@ type AgentSessionStore = {
 	upsertSession: (
 		session: AgentSessionRecord,
 		opts?: { activate?: boolean },
+	) => void;
+	/** Atomically publish a loaded transcript and make that history item active. */
+	hydrateAndActivateSession: (
+		session: AgentSessionRecord,
+		lines: ChatLine[],
+		title?: string,
 	) => void;
 	/** Patch lines on a session by id (stream correlation or product id). */
 	updateSessionLines: (
@@ -150,6 +158,8 @@ export const agentSessionStore = createStore<AgentSessionStore>((set, get) => ({
 			return { activeTabId: id };
 		}),
 
+	startDraft: () => set({ activeTabId: "draft", draftLines: EMPTY_CHAT_LINES }),
+
 	setLines: (update) =>
 		set((s) => {
 			if (s.activeTabId === "draft") {
@@ -199,6 +209,30 @@ export const agentSessionStore = createStore<AgentSessionStore>((set, get) => ({
 			}
 			if (sessions === s.sessions) return s;
 			return { sessions };
+		});
+	},
+
+	hydrateAndActivateSession: (session, lines, title) => {
+		set((s) => {
+			const idx = s.sessions.findIndex(
+				(item) => item.id === session.id && item.agentId === session.agentId,
+			);
+			const current = idx >= 0 ? s.sessions[idx] : undefined;
+			const hydrated = {
+				...session,
+				...current,
+				...(title !== undefined ? { title } : {}),
+				lines,
+			};
+			const sessions =
+				idx >= 0
+					? s.sessions.map((item, i) => (i === idx ? hydrated : item))
+					: [hydrated, ...s.sessions];
+			return {
+				sessions,
+				activeTabId: hydrated.id,
+				draftLines: EMPTY_CHAT_LINES,
+			};
 		});
 	},
 

--- a/src/lib/agent/chat-state.ts
+++ b/src/lib/agent/chat-state.ts
@@ -109,6 +109,40 @@ export type ChatSessionHistoryItem = {
 	resumeable?: boolean;
 };
 
+/** Resolve the provider-owned id required by ACP session/load and session/resume. */
+export function providerSessionIdForHistoryLoad(
+	item: ChatSessionHistoryItem,
+): string {
+	return item.providerSessionId?.trim() || item.id;
+}
+
+/**
+ * Publish a newly accepted runtime turn without splitting one provider
+ * conversation into multiple Agentero history rows.
+ *
+ * ACP creates a fresh runtime id for every request, including resumed turns.
+ * The provider session id is the durable conversation identity, so remove the
+ * previous active row and any stale row with the same provider id before
+ * prepending the updated transcript.
+ */
+export function upsertChatSessionTurn(
+	sessions: ChatSessionHistoryItem[],
+	next: ChatSessionHistoryItem,
+	previous?: ChatSessionHistoryItem,
+): ChatSessionHistoryItem[] {
+	const providerId = next.providerSessionId?.trim();
+	return [
+		next,
+		...sessions.filter((item) => {
+			if (item.id === next.id || item.id === previous?.id) return false;
+			if (providerId && item.providerSessionId?.trim() === providerId) {
+				return false;
+			}
+			return true;
+		}),
+	];
+}
+
 /** Format prior user/agent turns for agents that cannot session/resume. */
 export function buildLocalTranscriptPrompt(
 	lines: ChatLine[],
@@ -159,6 +193,25 @@ export type PendingSessionEvent =
 	| { kind: "stream"; event: AgentStreamEvent }
 	| { kind: "tool"; event: AgentToolEvent }
 	| { kind: "plan"; event: AgentPlanEvent };
+
+/**
+ * Decide whether an event must wait until the accepted runtime session has
+ * been published to the chat store. The provider id used for ACP resume is
+ * intentionally not part of this correlation check.
+ */
+export function shouldDeferSessionEvent(args: {
+	sessionId: string;
+	submitting: boolean;
+	pendingRuntimeSessionId: string | null;
+	knownSessionIds: ReadonlySet<string>;
+}): boolean {
+	if (!args.submitting) return false;
+	return (
+		args.pendingRuntimeSessionId === args.sessionId ||
+		(args.pendingRuntimeSessionId === null &&
+			!args.knownSessionIds.has(args.sessionId))
+	);
+}
 
 let chatLineSeq = 0;
 export function nextLineId(prefix: string) {

--- a/test/agent-chat-state.test.ts
+++ b/test/agent-chat-state.test.ts
@@ -14,8 +14,11 @@ import {
 	formatAskUserAnswers,
 	isBackgroundWorkflowHistoryTitle,
 	parseAskUserQuestions,
+	providerSessionIdForHistoryLoad,
 	resetAgentChatIds,
 	resolveSelected,
+	shouldDeferSessionEvent,
+	upsertChatSessionTurn,
 	upsertPlanPart,
 } from "@/lib/agent/chat-state";
 
@@ -238,6 +241,98 @@ User comment: 这里最值得读的是什么?`;
 		expect(isBackgroundWorkflowHistoryTitle("这里最值得读的是什么?")).toBe(
 			false,
 		);
+	});
+});
+
+describe("providerSessionIdForHistoryLoad", () => {
+	it("uses the provider id instead of the Agentero runtime id", () => {
+		expect(
+			providerSessionIdForHistoryLoad({
+				id: "runtime-v4",
+				agentId: "codex",
+				source: "local",
+				title: "Earlier conversation",
+				agentName: "Codex",
+				startedAt: "",
+				lines: [],
+				status: "completed",
+				providerSessionId: "provider-v7",
+			}),
+		).toBe("provider-v7");
+	});
+
+	it("falls back to the history id for provider-indexed sessions", () => {
+		expect(
+			providerSessionIdForHistoryLoad({
+				id: "provider-v7",
+				agentId: "codex",
+				source: "external",
+				title: "Earlier conversation",
+				agentName: "Codex",
+				startedAt: "",
+				lines: [],
+				status: "completed",
+			}),
+		).toBe("provider-v7");
+	});
+});
+
+describe("upsertChatSessionTurn", () => {
+	it("keeps one local history item when a resumed turn gets a new runtime id", () => {
+		const previous = {
+			id: "runtime-first",
+			agentId: "codex",
+			source: "local" as const,
+			title: "First question",
+			agentName: "Codex",
+			startedAt: "",
+			lines: [],
+			status: "completed" as const,
+			providerSessionId: "provider-thread",
+		};
+		const next = {
+			...previous,
+			id: "runtime-second",
+			title: "Second question",
+			lines: [
+				{ id: "u1", kind: "user" as const, text: "First question" },
+				{ id: "a1", kind: "agent" as const, parts: [] },
+				{ id: "u2", kind: "user" as const, text: "Second question" },
+			],
+		};
+		const unrelated = {
+			...previous,
+			id: "runtime-other",
+			providerSessionId: "other-thread",
+		};
+
+		expect(
+			upsertChatSessionTurn([previous, unrelated], next, previous),
+		).toEqual([next, unrelated]);
+	});
+});
+
+describe("shouldDeferSessionEvent", () => {
+	it("defers a new runtime event during a resumed turn", () => {
+		expect(
+			shouldDeferSessionEvent({
+				sessionId: "runtime-second",
+				submitting: true,
+				pendingRuntimeSessionId: null,
+				knownSessionIds: new Set(["runtime-first"]),
+			}),
+		).toBe(true);
+	});
+
+	it("does not defer events after the runtime session is known", () => {
+		expect(
+			shouldDeferSessionEvent({
+				sessionId: "runtime-first",
+				submitting: true,
+				pendingRuntimeSessionId: null,
+				knownSessionIds: new Set(["runtime-first"]),
+			}),
+		).toBe(false);
 	});
 });
 

--- a/test/agent-session-store.test.ts
+++ b/test/agent-session-store.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+	agentSessionStore,
+	EMPTY_CHAT_LINES,
+} from "@/lib/agent/agent-session-store";
+
+beforeEach(() => {
+	agentSessionStore.setState({
+		sessions: [],
+		activeTabId: "draft",
+		draftLines: EMPTY_CHAT_LINES,
+		submitting: false,
+		runningSessionIds: [],
+		turnRequest: null,
+	});
+});
+
+describe("startDraft", () => {
+	it("keeps the completed conversation transcript when starting a new chat", () => {
+		const lines = [{ id: "u1", kind: "user" as const, text: "hello" }];
+		agentSessionStore.getState().upsertSession({
+			id: "runtime-v4",
+			agentId: "codex",
+			source: "local",
+			title: "hello",
+			agentName: "Codex",
+			startedAt: "",
+			lines,
+			status: "completed",
+			providerSessionId: "provider-v7",
+		});
+
+		agentSessionStore.getState().startDraft();
+
+		const state = agentSessionStore.getState();
+		expect(state.activeTabId).toBe("draft");
+		expect(state.draftLines).toBe(EMPTY_CHAT_LINES);
+		expect(state.sessions[0]?.lines).toEqual(lines);
+	});
+});
+
+describe("hydrateAndActivateSession", () => {
+	it("publishes a loaded transcript and activation in one store update", () => {
+		const historyItem = {
+			id: "provider-v7",
+			agentId: "codex",
+			source: "external" as const,
+			title: "Indexed title",
+			agentName: "Codex",
+			startedAt: "",
+			lines: [],
+			status: "completed" as const,
+			providerSessionId: "provider-v7",
+		};
+		const loadedLines = [
+			{ id: "u1", kind: "user" as const, text: "Earlier question" },
+		];
+		agentSessionStore.setState({
+			sessions: [historyItem],
+			activeTabId: "draft",
+			draftLines: [
+				{ id: "draft-u1", kind: "user" as const, text: "Unsaved draft" },
+			],
+		});
+
+		agentSessionStore
+			.getState()
+			.hydrateAndActivateSession(historyItem, loadedLines, "Earlier question");
+
+		const state = agentSessionStore.getState();
+		expect(state.activeTabId).toBe(historyItem.id);
+		expect(state.draftLines).toBe(EMPTY_CHAT_LINES);
+		expect(state.sessions[0]).toMatchObject({
+			id: historyItem.id,
+			title: "Earlier question",
+			lines: loadedLines,
+		});
+	});
+
+	it("restores the selected item if a concurrent history refresh removed it", () => {
+		const historyItem = {
+			id: "provider-v7",
+			agentId: "codex",
+			source: "external" as const,
+			title: "Earlier conversation",
+			agentName: "Codex",
+			startedAt: "",
+			lines: [],
+			status: "completed" as const,
+			providerSessionId: "provider-v7",
+		};
+		const loadedLines = [
+			{ id: "u1", kind: "user" as const, text: "Earlier question" },
+		];
+
+		agentSessionStore
+			.getState()
+			.hydrateAndActivateSession(historyItem, loadedLines);
+
+		const state = agentSessionStore.getState();
+		expect(state.activeTabId).toBe(historyItem.id);
+		expect(state.sessions).toEqual([{ ...historyItem, lines: loadedLines }]);
+	});
+});


### PR DESCRIPTION
## 改动

- 修复历史记录打开后内容为空
- 修复同一对话续聊被拆成多条记录
- 修复续聊偶尔只显示提问
- 补充相关测试和文档

Closes #209

## 演示


https://github.com/user-attachments/assets/eaf2e59b-57b5-47d2-ac50-b4dae8592105



## 验证

- Codex、Claude 均已测试
- `pnpm test`（80 个测试文件、646 个用例通过）
- 相关文件 Biome 检查通过
- `pnpm typecheck` / `pnpm build` 被 `main` 现有的未使用 `ChevronLeft` 导入阻塞