### PR TITLE
fix(vault): upgrade bundled skills by frontmatter version

### DIFF
--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -82,7 +82,7 @@ Host 通过 Tauri event 向前端推送事件。文件系统、任务和菜单�
 > **实现状态（V0.1）**  
 >
 > - 已实现：`vault_create`、`vault_ensure`（snake_case invoke 名）、`vault_allow_fs_scope`、`vault_tree_build` / `vault_tree_children`、`path_open_in_terminal`、`path_trash`（+ `path_list_trash` / `path_restore_item` / `path_purge_item` / `path_purge_trash`）、`window_new`、`set_locale`。  
-> - 打开 Vault / 最近列表：当前主要由前端 `plugin-fs` + `localStorage`/`sessionStorage` 完成；本地树加载走 Host `vault_tree_build`（一次 IPC）；打开或恢复时会调用 `vault_ensure` 补种 bundled skills，并按 hash 安全升级未定制的第一方 Skill。Host 侧 `vault:open` / `vault:recent` 仍为规划契约。
+> - 打开 Vault / 最近列表：当前主要由前端 `plugin-fs` + `localStorage`/`sessionStorage` 完成；本地树加载走 Host `vault_tree_build`（一次 IPC）；打开或恢复时会调用 `vault_ensure` 补种 bundled skills，并按 frontmatter `version` 安全升级未定制的第一方 Skill。Host 侧 `vault:open` / `vault:recent` 仍为规划契约。
 > - 实际 command 注册见 `src-tauri/src/lib.rs`。
 
 #### `vault_create`（已实现）
@@ -105,7 +105,7 @@ Host 通过 Tauri event 向前端推送事件。文件系统、任务和菜单�
   data: {
     path: string;
     created: string[]; // 创建的目录/文件相对路径列表
-    updated: string[]; // hash 命中已知旧版后安全升级的第一方 Skill
+    updated: string[]; // frontmatter version 更低后安全升级的第一方 Skill
     openPath: string;  // 建议首开，如 AGENTS.md
   };
 }
@@ -117,7 +117,7 @@ Host 通过 Tauri event 向前端推送事件。文件系统、任务和菜单�
   - 写入默认 `AGENTS.md`（若不存在）。
   - 写入 **`.agents/README.md`**（若不存在；内容来自仓库 `templates/vault/.agents/`）。
   - 种子 **bundled skills**：`paper-reader`、`agentero-cli`、`vault-normalizer`、`idea-evaluator`、`deep-research`（后两者含 `references/`，来自 [Supervisor-Skills](https://github.com/HKUSTDial/Supervisor-Skills)，**CC BY-NC-SA 4.0**；另写 `skills/README.md` 与 `LICENSE-Supervisor-Skills.txt`）。
-  - **不**创建根级 `PAPERS.md` / `library.bib`；已有第一方 `SKILL.md` 仅在 hash 命中已知旧版 bundled 内容时升级，用户修改与其它 `.agents/**` 文件保持原样。
+  - **不**创建根级 `PAPERS.md` / `library.bib`；已有第一方 `SKILL.md` 按 frontmatter 整数 `version` 升级（见 `vault_ensure`）；用户去掉/抬高 `version` 的修改与其它 `.agents/**` 文件保持原样。
   - 最近列表由前端在成功打开后写入 `localStorage`（`agentero-recent-vaults`）。
 
 #### `vault_ensure`（已实现）
@@ -136,8 +136,8 @@ Host 通过 Tauri event 向前端推送事件。文件系统、任务和菜单�
 
 - **策略**
   - **补缺失**：目录 / `AGENTS.md` / 模板里有而盘上没有的 skill 文件。
-  - **安全升级**：第一方 `SKILL.md` 的 SHA-256 与已知旧版 bundled 内容完全一致时写入新版。
-  - **保留定制**：用户改过的 `SKILL.md`、第三方 Skill 和 references 保持原样。
+  - **安全升级**（第一方 `SKILL.md`）：盘上 frontmatter 整数 `version` **低于** 模板 → 写入新版（后续升级只需 bump `version`）。同版本 / 更高版本 / 无 `version` → **不**覆盖。
+  - **保留定制**：去掉或抬高 `version` 后的用户 `SKILL.md`、第三方 Skill 和 references 保持原样。
   - 应用升级新增的 skill（如后续模板里加的 id）会在下次打开 Vault 时自动出现。
   - 前端：`created` 与 `updated` 分别触发新增/升级 success toast；均为空时不打扰。
 
@@ -193,7 +193,7 @@ type VaultTreeNode = {
 | `remote_agent_scan` | 目录模板 + 远端 PATH 扫描 → `CatalogEntry[]`（设置页远端 Agent） |
 | `remote_agent_probe` | `{ sessionId, templateId }` → 远端 ACP `initialize`（应用 Agent 代理 env） |
 | `remote_agent_open_install_terminal` | 本机终端确认后 `ssh -t` 在远端执行模板 `install_command`（如 Claude ACP 适配器） |
-| `remote_vault_ensure` | `{ sessionId }` → 通过 SFTP 补种 bundled skills，并按相同 hash 规则安全升级未定制的第一方 Skill |
+| `remote_vault_ensure` | `{ sessionId }` → 通过 SFTP 补种 bundled skills，并按相同 frontmatter `version` 规则安全升级第一方 Skill |
 
 Host 还支持 `__local_sim__` host（本机目录当远端，单测/开发用）。
 

--- a/docs/backend/skill-import.md
+++ b/docs/backend/skill-import.md
@@ -6,7 +6,7 @@
 
 - 魔棒输入的类型识别完全在 Host 侧：`src-tauri/src/features/import/parse.rs` 的 `IdentifierKind::Skill`、`SkillSource` 和 `extract_primary_identifier()`。Skill 识别发生在普通 URL 分支之前，GitHub 链接不会再被送入 Translator `/web`。
 - 前端不做识别，只切分多条输入（`src/components/sidebar/vault-sidebar-header.tsx` `parseLookupTexts()`），经 `lookup_import_batch`（`src-tauri/src/features/import/commands.rs:17`）进入 `import_by_identifier_batch`。
-- Skill 目录约定已存在：`vault/.agents/skills/<id>/SKILL.md`（YAML frontmatter `name` / `description`，解析见 `src-tauri/src/features/agent/skills.rs` `parse_skill_metadata`）；`ensure_vault()` 播种 bundled skills，并只在第一方文件 hash 与已知旧版模板完全一致时升级；用户修改始终保留。
+- Skill 目录约定已存在：`vault/.agents/skills/<id>/SKILL.md`（YAML frontmatter `name` / `description`，解析见 `src-tauri/src/features/agent/skills.rs` `parse_skill_metadata`）；`ensure_vault()` 播种 bundled skills，并按 frontmatter 整数 `version` 升级第一方 Skill（盘上版本低于模板则覆盖；无 `version` / 同版本 / 更高版本不覆盖）。
 - 文件树中 `.agents` 是 eager 目录（`src/lib/vault/tree.ts` `TREE_EAGER_ROOT_NAMES` / `TREE_ALLOWED_DOT_NAMES`），写入后 `refreshTree` 即可见。
 - 仓库内**没有任何 git clone / npm 逻辑**；可复用的下载基础在 `src-tauri/src/features/import/assets.rs`：`http_get_bytes_with_progress()`（reqwest + 进度事件）与 arXiv e-print 的 **tar/gzip 安全解压**（`extract_tar_safe` / `sanitize_tar_path`，防路径穿越）。
 

--- a/docs/backend/vault.md
+++ b/docs/backend/vault.md
@@ -20,7 +20,7 @@
   `templates/vault/notes/zh-CN/`，写入 Vault 时统一展开到 `notes/` 根目录；
   不覆盖用户已编辑的同名文件。
 - `vault_create` 返回的 `openPath` 为首篇教程路径；若教程已存在则回退到 `AGENTS.md`。
-- 每次打开会补种缺失的 bundled skills；第一方 `SKILL.md` 只有在内容 hash 与已知旧版模板完全一致时才升级。用户改过的文件保持原样，返回值的 `updated` 列出本次安全升级路径。
+- 每次打开会补种缺失的 bundled skills；第一方 `SKILL.md` 仅通过 frontmatter 整数 `version` 安全升级（盘上版本低于模板则覆盖并 toast）。无 `version`、同版本或更高版本的文件保持原样；返回值的 `updated` 列出本次安全升级路径。
 
 ## 文件树
 

--- a/docs/frontend/agent.md
+++ b/docs/frontend/agent.md
@@ -25,7 +25,7 @@ AI Elements (Conversation / Message / PromptInput / Sources / Reasoning)
 - 运行中可继续输入 → Queue waitlist；标题保持简洁，条目等宽并可单独移除；Esc / 停止中止。
 - 会话空闲时 hover 用户消息可 **Edit** 后重发。
 - **新建对话 / 历史恢复**：新建草稿不会清空刚离开的本地 transcript；历史项同时存在 Agentero runtime id 与 ACP provider id 时，`session/load` / 后续续聊只使用 `providerSessionId`；连续续聊产生的新 runtime 行会按 provider id 合并回同一个历史项；加载结果通过一次原子 store 更新写入并激活，避免列表刷新后出现空白会话。详见 [Codex 历史恢复误用 runtime id](../bug_fix/codex-history-runtime-session-id.md)。
-- Slash 命令完全来自当前 ACP session 的 `available_commands_update`；Agentero 不再注册本地 action/template。命令以 `/name` 填入 Composer，并在当前 provider session 中原样发送。
+- Slash 命令完全来自当前 ACP session 的 `available_commands_update`；Agentero 不再注册本地 action/template。映射时剥离名称前导 `/` 与 `$`（部分 Agent 把 skill 以 `$name` 形式广播），再以 `/name` 填入 Composer，并在当前 provider session 中原样发送。
 
 ## 权限 UI
 

--- a/src-tauri/src/features/remote/launch.rs
+++ b/src-tauri/src/features/remote/launch.rs
@@ -63,9 +63,10 @@ pub async fn resolve_remote_target(
 /// the remote vault.
 ///
 /// Remote vault handles are opaque session ids, so the local `vault_ensure`
-/// command cannot be used for them. User-customized remote files are never
-/// replaced. When `locale` is `Some`, localized onboarding tutorial notes are
-/// also seeded.
+/// command cannot be used for them. Managed first-party skills upgrade via the
+/// same frontmatter `version` rules as local vaults; user-owned remote files
+/// are never replaced. When `locale` is `Some`, localized onboarding tutorial
+/// notes are also seeded.
 pub async fn ensure_remote_vault_skills(
     session: &RemoteSession,
     locale: Option<&str>,
@@ -74,10 +75,9 @@ pub async fn ensure_remote_vault_skills(
     let mut updated = Vec::new();
     for (rel, content) in vault::bundled_skill_files() {
         if session.fs.exists(rel).await? {
-            if vault::bundled_skill_has_legacy_version(rel) {
+            if vault::bundled_skill_may_upgrade(content) {
                 let existing = session.fs.read(rel).await?;
-                if existing != content.as_bytes() && vault::is_legacy_bundled_skill(rel, &existing)
-                {
+                if vault::should_auto_upgrade_bundled_skill(&existing, content) {
                     session
                         .fs
                         .write(

--- a/src-tauri/src/features/vault/mod.rs
+++ b/src-tauri/src/features/vault/mod.rs
@@ -3,7 +3,6 @@
 use crate::core::error::AppError;
 use crate::features::catalog;
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::Path;
 
@@ -230,65 +229,61 @@ pub(crate) fn bundled_skill_files() -> &'static [(&'static str, &'static str)] {
     ]
 }
 
-/// Previous first-party SKILL.md hashes eligible for an automatic bundled
-/// update. Byte equality by SHA-256 proves that the user has not customized the
-/// seeded file. Any other content is preserved.
-const LEGACY_BUNDLED_SKILL_HASHES: &[(&str, &str)] = &[
-    (
-        ".agents/skills/agentero-cli/SKILL.md",
-        "8195723fd1b75a7c8c396f382b2c5b079d812246a693c65be0b9cd91bfb70f67",
-    ),
-    // Initial paper-reader seed.
-    (
-        ".agents/skills/paper-reader/SKILL.md",
-        "9ef2a2ccf6b251e11639a27877e86c1324dd3f05309b320679b60a1535e67bb2",
-    ),
-    // After wiki-check skill constraints (common vault pin; was missing from
-    // legacy list so ensure_vault never upgraded these installs).
-    (
-        ".agents/skills/paper-reader/SKILL.md",
-        "6a9b35c5bb6858039052e2a19bd3b75beddf0b60dbcd49e026fa94ba21c31e09",
-    ),
-    // Pre-aliases paper-reader (title-only NOTES shell era).
-    (
-        ".agents/skills/paper-reader/SKILL.md",
-        "e8ded7c1b6eec291b8b7ad3069b45ce42708d422597eaa620a0e73103a9cc478",
-    ),
-    // paper-reader before required frontmatter aliases section.
-    (
-        ".agents/skills/paper-reader/SKILL.md",
-        "af3173192e5e94c81d36599ecdc0ad2b95a7531afa099391d85672b992c41359",
-    ),
-    // paper-reader before required `created` date field.
-    (
-        ".agents/skills/paper-reader/SKILL.md",
-        "15978a666783c48b3b4063c29191bba90c9053e4f0d65c35767509eecbc2691b",
-    ),
-    (
-        ".agents/skills/vault-normalizer/SKILL.md",
-        "bec14afc8ad2d9c8b3f2ad06c7c84ef6e99fe546a8c944b757213d743feb2f33",
-    ),
-];
-
-fn sha256_hex(content: &[u8]) -> String {
-    hex::encode(Sha256::digest(content))
+/// Parse optional integer `version:` from YAML frontmatter (Agentero managed
+/// bundled skills). Accepts `version: 1` or `version: "1"`. Non-integer values
+/// are ignored so user/SemVer strings do not trigger silent overwrites.
+pub(crate) fn parse_skill_frontmatter_version(content: &str) -> Option<u32> {
+    let rest = content
+        .strip_prefix("---\n")
+        .or_else(|| content.strip_prefix("---\r\n"))?;
+    let (front_matter, _) = rest
+        .split_once("\n---")
+        .or_else(|| rest.split_once("\r\n---"))?;
+    for line in front_matter.lines() {
+        let line = line.trim();
+        let Some(value) = line.strip_prefix("version:") else {
+            continue;
+        };
+        let value = value.trim().trim_matches(['"', '\'']);
+        if let Ok(v) = value.parse::<u32>() {
+            return Some(v);
+        }
+    }
+    None
 }
 
-fn matches_legacy_bundled_skill(rel: &str, content: &[u8], hashes: &[(&str, &str)]) -> bool {
-    let hash = sha256_hex(content);
-    hashes
-        .iter()
-        .any(|(path, legacy_hash)| *path == rel && *legacy_hash == hash)
+/// Whether `existing` may be replaced by the current bundled template.
+///
+/// Rules:
+/// 1. Identical bytes → no upgrade.
+/// 2. Bundled template has integer frontmatter `version` **and** existing has a
+///    lower integer `version` → upgrade.
+/// 3. Otherwise leave the file alone (no version / equal / higher / non-skill).
+///
+/// Opt out after editing a first-party skill: remove `version`, or set it higher
+/// than the template.
+pub(crate) fn should_auto_upgrade_bundled_skill(existing: &[u8], bundled: &str) -> bool {
+    if existing == bundled.as_bytes() {
+        return false;
+    }
+    let Some(bundled_version) = parse_skill_frontmatter_version(bundled) else {
+        // Non-versioned bundled assets (README, LICENSE, references) are
+        // seed-if-missing only.
+        return false;
+    };
+    let Some(existing_version) = std::str::from_utf8(existing)
+        .ok()
+        .and_then(parse_skill_frontmatter_version)
+    else {
+        // No managed version → treat as user-owned / unversioned install.
+        return false;
+    };
+    existing_version < bundled_version
 }
 
-pub(crate) fn is_legacy_bundled_skill(rel: &str, content: &[u8]) -> bool {
-    matches_legacy_bundled_skill(rel, content, LEGACY_BUNDLED_SKILL_HASHES)
-}
-
-pub(crate) fn bundled_skill_has_legacy_version(rel: &str) -> bool {
-    LEGACY_BUNDLED_SKILL_HASHES
-        .iter()
-        .any(|(path, _)| *path == rel)
+/// True when the bundled template carries a managed `version` (may upgrade).
+pub(crate) fn bundled_skill_may_upgrade(bundled: &str) -> bool {
+    parse_skill_frontmatter_version(bundled).is_some()
 }
 
 /// Normalize a frontend/CLI locale preference to a supported onboarding locale.
@@ -349,31 +344,8 @@ fn seed_file_if_missing(
     Ok(())
 }
 
-/// Seed a missing bundled file, or update an untouched first-party SKILL.md
-/// whose bytes match a known previous bundled version.
-fn seed_or_upgrade_bundled_file_with_hashes(
-    root: &Path,
-    rel: &str,
-    content: &str,
-    created: &mut Vec<String>,
-    updated: &mut Vec<String>,
-    hashes: &[(&str, &str)],
-) -> Result<(), AppError> {
-    let path = join_rel(root, rel);
-    if !path.exists() {
-        return seed_file_if_missing(root, rel, content, created);
-    }
-    if !hashes.iter().any(|(path, _)| *path == rel) {
-        return Ok(());
-    }
-    let existing = fs::read(&path)?;
-    if existing != content.as_bytes() && matches_legacy_bundled_skill(rel, &existing, hashes) {
-        fs::write(&path, content)?;
-        updated.push(rel.to_string());
-    }
-    Ok(())
-}
-
+/// Seed a missing bundled file, or safely upgrade a managed first-party
+/// `SKILL.md` via frontmatter `version`.
 fn seed_or_upgrade_bundled_file(
     root: &Path,
     rel: &str,
@@ -381,23 +353,25 @@ fn seed_or_upgrade_bundled_file(
     created: &mut Vec<String>,
     updated: &mut Vec<String>,
 ) -> Result<(), AppError> {
-    seed_or_upgrade_bundled_file_with_hashes(
-        root,
-        rel,
-        content,
-        created,
-        updated,
-        LEGACY_BUNDLED_SKILL_HASHES,
-    )
+    let path = join_rel(root, rel);
+    if !path.exists() {
+        return seed_file_if_missing(root, rel, content, created);
+    }
+    let existing = fs::read(&path)?;
+    if should_auto_upgrade_bundled_skill(&existing, content) {
+        fs::write(&path, content)?;
+        updated.push(rel.to_string());
+    }
+    Ok(())
 }
 
 /// Idempotent vault scaffold under `path` without overwriting existing user files.
 ///
 /// Creates: `papers/`, `notes/`, `plans/`, `.agentero/`, `.agents/` (+ `skills/`),
 /// `AGENTS.md` (if missing), seeds `.agents/README.md` and bundled skills from
-/// the app template, safely upgrades untouched first-party skills, seeds
-/// localized onboarding tutorial notes under `notes/`, and initializes
-/// `.agentero/catalog.sqlite`.
+/// the app template, safely upgrades managed first-party skills (frontmatter
+/// `version`), seeds localized onboarding tutorial notes under `notes/`, and
+/// initializes `.agentero/catalog.sqlite`.
 /// Does **not** create `PAPERS.md` / `library.bib`.
 ///
 /// Safe to call on every vault open after an app update so newly shipped skills
@@ -645,9 +619,30 @@ mod tests {
     }
 
     #[test]
-    fn bundled_skill_upgrade_requires_an_exact_known_hash() {
+    fn parse_skill_frontmatter_version_reads_integer() {
+        assert_eq!(
+            parse_skill_frontmatter_version("---\nname: x\nversion: 2\n---\nbody\n"),
+            Some(2)
+        );
+        assert_eq!(
+            parse_skill_frontmatter_version("---\nversion: \"3\"\nname: x\n---\n"),
+            Some(3)
+        );
+        assert_eq!(
+            parse_skill_frontmatter_version("---\nname: x\n---\nno version\n"),
+            None
+        );
+        // SemVer / non-integer must not be treated as managed.
+        assert_eq!(
+            parse_skill_frontmatter_version("---\nversion: 1.2.0\n---\n"),
+            None
+        );
+    }
+
+    #[test]
+    fn bundled_skill_upgrades_when_version_is_lower() {
         let dir = env::temp_dir().join(format!(
-            "agentero-vault-upgrade-skill-{}",
+            "agentero-vault-upgrade-version-{}",
             std::process::id()
         ));
         let _ = fs::remove_dir_all(&dir);
@@ -655,38 +650,87 @@ mod tests {
         let rel = ".agents/skills/example/SKILL.md";
         let path = join_rel(&dir, rel);
         fs::create_dir_all(path.parent().unwrap()).unwrap();
-        fs::write(&path, "old bundled skill\n").unwrap();
-        let legacy_hash = sha256_hex(b"old bundled skill\n");
-        let hashes = [(rel, legacy_hash.as_str())];
+        let old = "---\nname: example\nversion: 1\n---\nold body\n";
+        let new = "---\nname: example\nversion: 2\n---\nnew body\n";
+        fs::write(&path, old).unwrap();
         let mut created = Vec::new();
         let mut updated = Vec::new();
 
-        seed_or_upgrade_bundled_file_with_hashes(
-            &dir,
-            rel,
-            "new bundled skill\n",
-            &mut created,
-            &mut updated,
-            &hashes,
-        )
-        .unwrap();
+        seed_or_upgrade_bundled_file(&dir, rel, new, &mut created, &mut updated).unwrap();
         assert!(created.is_empty());
         assert_eq!(updated, vec![rel]);
-        assert_eq!(fs::read_to_string(&path).unwrap(), "new bundled skill\n");
+        assert_eq!(fs::read_to_string(&path).unwrap(), new);
 
-        fs::write(&path, "user customization\n").unwrap();
+        // Same version with user edits must not be overwritten.
+        let customized = "---\nname: example\nversion: 2\n---\nuser edit\n";
+        fs::write(&path, customized).unwrap();
         updated.clear();
-        seed_or_upgrade_bundled_file_with_hashes(
-            &dir,
-            rel,
-            "another bundled skill\n",
-            &mut created,
-            &mut updated,
-            &hashes,
-        )
-        .unwrap();
+        seed_or_upgrade_bundled_file(&dir, rel, new, &mut created, &mut updated).unwrap();
         assert!(updated.is_empty());
-        assert_eq!(fs::read_to_string(&path).unwrap(), "user customization\n");
+        assert_eq!(fs::read_to_string(&path).unwrap(), customized);
+
+        // Higher local version (user fork) must not be overwritten by template.
+        let forked = "---\nname: example\nversion: 9\n---\nfork\n";
+        fs::write(&path, forked).unwrap();
+        updated.clear();
+        seed_or_upgrade_bundled_file(&dir, rel, new, &mut created, &mut updated).unwrap();
+        assert!(updated.is_empty());
+        assert_eq!(fs::read_to_string(&path).unwrap(), forked);
+
+        // No version → treat as user-owned; never overwrite.
+        fs::write(&path, "user customization without version\n").unwrap();
+        updated.clear();
+        seed_or_upgrade_bundled_file(&dir, rel, new, &mut created, &mut updated).unwrap();
+        assert!(updated.is_empty());
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "user customization without version\n"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn ensure_vault_upgrades_versioned_first_party_skills() {
+        let dir = env::temp_dir().join(format!(
+            "agentero-vault-ensure-version-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        create_vault(&dir, "en").expect("create");
+
+        let paper = dir.join(".agents/skills/paper-reader/SKILL.md");
+        let current = fs::read_to_string(&paper).unwrap();
+        let bundled_v = parse_skill_frontmatter_version(&current).expect("bundled version");
+        assert!(bundled_v >= 1);
+
+        // Simulate an older managed install (lower version, different body).
+        let older = "---\nname: paper-reader\nversion: 0\n---\n# stale paper-reader\n";
+        fs::write(&paper, older).unwrap();
+        let r = ensure_vault(&dir, "en").expect("ensure upgrades by version");
+        assert!(
+            r.updated
+                .iter()
+                .any(|p| p == ".agents/skills/paper-reader/SKILL.md"),
+            "expected paper-reader in updated: {:?}",
+            r.updated
+        );
+        let after = fs::read_to_string(&paper).unwrap();
+        assert_eq!(parse_skill_frontmatter_version(&after), Some(bundled_v));
+        assert!(after.contains("# Paper Reader"));
+
+        // User-edited skill without version must not be overwritten.
+        fs::write(&paper, "# my custom paper-reader\n").unwrap();
+        let r2 = ensure_vault(&dir, "en").expect("ensure preserves custom");
+        assert!(!r2
+            .updated
+            .iter()
+            .any(|p| p == ".agents/skills/paper-reader/SKILL.md"));
+        assert_eq!(
+            fs::read_to_string(&paper).unwrap(),
+            "# my custom paper-reader\n"
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src/lib/agent/slash-commands.ts
+++ b/src/lib/agent/slash-commands.ts
@@ -6,6 +6,15 @@ export type AcpCommand = {
 	inputHint?: string;
 };
 
+/**
+ * Normalize an ACP available-command name for slash insertion.
+ * Agents may advertise names with leading `/` and/or `$` (e.g. skills as `$name`);
+ * Composer always prefixes `/`, so strip those markers to avoid `/$foo`.
+ */
+export function normalizeAcpCommandName(raw: string): string {
+	return raw.trim().replace(/^[/$]+/, "");
+}
+
 export function mapAcpCommands(
 	commands: Array<{
 		name: string;
@@ -15,7 +24,7 @@ export function mapAcpCommands(
 ): AcpCommand[] {
 	return commands
 		.map((command) => {
-			const name = command.name.trim().replace(/^\/+/, "");
+			const name = normalizeAcpCommandName(command.name);
 			return {
 				id: `acp:${name}`,
 				name,

--- a/src/lib/vault/actions.ts
+++ b/src/lib/vault/actions.ts
@@ -219,8 +219,9 @@ export function refreshAll(): void {
 }
 
 /**
- * After app updates, seed new bundled skills and safely update untouched
- * first-party skills. User-edited files are never overwritten.
+ * After app updates, seed new bundled skills and safely upgrade managed
+ * first-party skills (frontmatter `version` only). User-owned files
+ * (no/higher/same version) stay put.
  */
 export function seedVaultSkills(path: string): void {
 	if (!isTauri() || !path) return;

--- a/templates/vault/.agents/skills/README.md
+++ b/templates/vault/.agents/skills/README.md
@@ -11,6 +11,23 @@ Create Vault seeds these when missing. Pick with `$` in Composer.
 | `idea-evaluator` | 研究 idea 评审 |
 | `deep-research` | 综述级文献调研 |
 
+## Versioning & upgrades
+
+First-party (and vendored) bundled skills carry an integer frontmatter field:
+
+```yaml
+version: 1
+```
+
+On vault open, Agentero compares this to the app template:
+
+- **lower version** → auto-upgrade to the template, then toast the skill id
+- **same / higher version** → leave the on-disk file alone (including same-version edits)
+- **no `version`** → leave alone (user-owned or unversioned install)
+
+To customize a bundled skill and keep your edits across app updates, either
+remove `version` or set it higher than the template after editing.
+
 ## Third-party source & license
 
 `idea-evaluator` / `deep-research` are vendored from

--- a/templates/vault/.agents/skills/agentero-cli/SKILL.md
+++ b/templates/vault/.agents/skills/agentero-cli/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: agentero-cli
+version: 1
 description: >-
   Use the Agentero CLI (bin `agentero`) to create, discover, and inspect a local
   research vault and catalog—list/get papers, import by id/URL, check wikilinks,

--- a/templates/vault/.agents/skills/deep-research/SKILL.md
+++ b/templates/vault/.agents/skills/deep-research/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: deep-research
+version: 1
 description: >-
   Runs a deep, survey-grade literature investigation on a research topic:
   freezes research questions, searches from multiple adversarial

--- a/templates/vault/.agents/skills/equation-annotation/SKILL.md
+++ b/templates/vault/.agents/skills/equation-annotation/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: equation-annotation
+version: 1
 description: >-
   从论文（优先 LaTeX）抽取公式与变量含义，写入 {paper}/Annotation.md。
 ---

--- a/templates/vault/.agents/skills/idea-evaluator/SKILL.md
+++ b/templates/vault/.agents/skills/idea-evaluator/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: idea-evaluator
+version: 1
 description: >-
   Evaluates a preliminary research idea against a five-dimension framework
   (Higher, Faster, Stronger, Cheaper, Broader) plus idea-lifecycle and

--- a/templates/vault/.agents/skills/paper-reader/SKILL.md
+++ b/templates/vault/.agents/skills/paper-reader/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: paper-reader
+version: 1
 description: >-
   Read and explain a research paper clearly (prefer TeX, else PAPER.md/PDF).
   Use for core contribution, method deep-dive, experiments, limitations, and

--- a/templates/vault/.agents/skills/vault-normalizer/SKILL.md
+++ b/templates/vault/.agents/skills/vault-normalizer/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: vault-normalizer
+version: 1
 description: Normalize an existing research directory into an Agentero vault layout. Use when reorganizing files, papers, notes, PDFs, TeX sources, marks, assets, or legacy Zotero/Obsidian-style folders to match Agentero directory and catalog conventions.
 ---
 

--- a/test/agent-slash-commands.test.ts
+++ b/test/agent-slash-commands.test.ts
@@ -3,6 +3,7 @@ import {
 	type AcpCommand,
 	filterSlashCommands,
 	mapAcpCommands,
+	normalizeAcpCommandName,
 } from "@/lib/agent/slash-commands";
 
 describe("agent-slash-commands", () => {
@@ -33,10 +34,46 @@ describe("agent-slash-commands", () => {
 		]);
 	});
 
+	it("strips leading $ so Composer does not show /$name (issue #222)", () => {
+		const commands = mapAcpCommands([
+			{
+				name: "$deep-research",
+				description: "Runs a deep research",
+				input: null,
+			},
+			{
+				name: "/$idea-evaluator",
+				description: "Evaluates an idea",
+				input: null,
+			},
+			{ name: "  $$git-master  ", description: "Git expert", input: null },
+		]);
+		expect(commands.map((c) => c.name)).toEqual([
+			"deep-research",
+			"idea-evaluator",
+			"git-master",
+		]);
+		expect(commands.map((c) => c.title)).toEqual([
+			"deep-research",
+			"idea-evaluator",
+			"git-master",
+		]);
+	});
+
+	it("normalizeAcpCommandName strips mixed / and $ prefixes", () => {
+		expect(normalizeAcpCommandName("$foo")).toBe("foo");
+		expect(normalizeAcpCommandName("/$foo")).toBe("foo");
+		expect(normalizeAcpCommandName("/foo")).toBe("foo");
+		expect(normalizeAcpCommandName("  /$bar  ")).toBe("bar");
+		expect(normalizeAcpCommandName("plain")).toBe("plain");
+	});
+
 	it("filters out empty ACP command names", () => {
 		const commands = mapAcpCommands([
 			{ name: "", description: "Empty", input: null },
 			{ name: "/valid", description: "Valid", input: null },
+			{ name: "$", description: "Only dollar", input: null },
+			{ name: "/$", description: "Only markers", input: null },
 		]);
 		expect(commands).toHaveLength(1);
 		expect(commands[0].name).toBe("valid");


### PR DESCRIPTION
## Summary
- Replace hash-based first-party skill upgrades with integer frontmatter `version` comparison
- Bundled skills ship `version: 1`; lower version auto-upgrades on vault open (toast via existing `updated` path)
- Unversioned / same / higher version files are left untouched (user customizations preserved)
- Docs and skills README updated

## Test plan
- [x] `cargo test --lib features::vault::`
- [x] `cargo test --lib ensure_remote_vault`

Fix #193