### PR TITLE
fix(agent): 支持 ACP 第三方/自定义模型选择

### DIFF
--- a/docs/backend/agent.md
+++ b/docs/backend/agent.md
@@ -73,6 +73,12 @@ Agentero prompt envelope、skill/context 注入，并将原始 `/command` 作为
 - 输出约定：工作流要求 `## Sources`（相对 Vault 路径）；双链保留 `[[...]]`。
 - 规划：自动注入 Vault 根 `AGENTS.md`（路线图 0.3）。
 
+## 模型协商
+
+- `session/new`（及 config 更新）中的 `SessionConfigOption`（category=Model 或 name 回退）解析为 `agent:models`。
+- 若 `current_value` 不在 selector 选项中（第三方网关 / cc-switch 等只改默认 model、目录仍是官方列表），Host **注入**该 current id，避免 UI 丢失。
+- `preferred_model_id`（warm / run_once）在与 current 不同时 **始终尝试** `session/set_config_option`，不要求 id 已在上报列表中；失败仅 debug 日志，不阻断会话。
+
 ## 注册表（非模型 BYOK）
 
 配置「如何启动本机 Agent」：id、name、template、command、args、env、默认 id。  

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -51,7 +51,7 @@ Host 通过 Tauri event 向前端推送事件。文件系统、任务和菜单�
 | `agent:tool` | Agent tool call 创建/更新 | `{ sessionId, toolCallId, title?, kind?, status?, input?, output?, full? }` |
 | `agent:plan` | ACP 执行计划 | `{ sessionId, entries: { content, status, priority }[] }` |
 | `agent:usage` | 上下文 token 用量 | `{ sessionId, used, size }` |
-| `agent:models` | Agent 上报可用模型 | `{ sessionId, agentId, configId, currentId, models: { id, name, group? }[] }` |
+| `agent:models` | Agent 上报可用模型 | `{ sessionId, agentId, configId, currentId, models: { id, name, group? }[] }`；`currentId` 若不在 selector 目录中会被 Host 注入到 `models`（第三方 / 网关默认模型） |
 | `agent:effort` | ACP 上报 reasoning effort 选项 | `{ sessionId, agentId, configId, currentId, efforts: { id, name, description? }[] }` |
 | `agent:fast-mode` | ACP 上报 Fast 开关状态 | `{ sessionId, agentId, configId, enabled }` |
 | `agent:completed` | Agent 回答完成 | `{ sessionId, messageId, content, reasoning?, sources, stopReason? }` |

--- a/docs/frontend/agent.md
+++ b/docs/frontend/agent.md
@@ -26,6 +26,7 @@ AI Elements (Conversation / Message / PromptInput / Sources / Reasoning)
 - 会话空闲时 hover 用户消息可 **Edit** 后重发。
 - **新建对话 / 历史恢复**：新建草稿不会清空刚离开的本地 transcript；历史项同时存在 Agentero runtime id 与 ACP provider id 时，`session/load` / 后续续聊只使用 `providerSessionId`；连续续聊产生的新 runtime 行会按 provider id 合并回同一个历史项；加载结果通过一次原子 store 更新写入并激活，避免列表刷新后出现空白会话。详见 [Codex 历史恢复误用 runtime id](../bug_fix/codex-history-runtime-session-id.md)。
 - Slash 命令完全来自当前 ACP session 的 `available_commands_update`；Agentero 不再注册本地 action/template。映射时剥离名称前导 `/` 与 `$`（部分 Agent 把 skill 以 `$name` 形式广播），再以 `/name` 填入 Composer，并在当前 provider session 中原样发送。
+- **模型选择（含第三方）**：列表来自 ACP `agent:models`；若 Agent 当前模型或用户偏好不在固定目录中（如 Codex + 中转 / cc-switch DeepSeek），仍会并入可选列表，并支持在搜索框输入任意 model id 作为自定义模型（`warm` / `run_once` 会尝试 `SetSessionConfigOption`，即使 id 未出现在上报目录中）。偏好按 agent 持久化。
 
 ## 权限 UI
 

--- a/src-tauri/src/features/agent/acp.rs
+++ b/src-tauri/src/features/agent/acp.rs
@@ -317,7 +317,29 @@ fn models_from_config_options(
         };
         let raw = collect_choices_from_select(sel);
         let raw_len = raw.len();
-        let models = dedupe_model_choices(raw);
+        let mut models = dedupe_model_choices(raw);
+        let current_id = sel.current_value.to_string();
+        // Third-party / gateway defaults (e.g. DeepSeek via cc-switch) may set a
+        // current model id that is not present in the advertised selector catalog.
+        // Surface it so the client can select and persist it.
+        let current_trim = current_id.trim();
+        if !current_trim.is_empty() && !models.iter().any(|m| m.id == current_trim) {
+            models.insert(
+                0,
+                AgentModelChoice {
+                    id: current_trim.to_string(),
+                    name: current_trim.to_string(),
+                    group: None,
+                },
+            );
+            log::debug!(
+                target: "agentero::agent",
+                "agent={} config_id={} injected current model not in catalog: {}",
+                agent_id,
+                opt.id,
+                current_trim
+            );
+        }
         if models.is_empty() {
             continue;
         }
@@ -335,7 +357,7 @@ fn models_from_config_options(
             session_id: session_id.to_string(),
             agent_id: agent_id.to_string(),
             config_id: opt.id.to_string(),
-            current_id: sel.current_value.to_string(),
+            current_id,
             models,
         });
     }
@@ -1117,8 +1139,11 @@ pub async fn run_once(
                 ) {
                     // Model changes can affect supported effort and service tiers, so retain the
                     // complete response before resolving the remaining preferences.
+                    // Also attempt custom / third-party model ids not in the advertised catalog
+                    // (gateway models, cc-switch, free-form provider ids).
                     if let Some(pref) = preferred_model.clone() {
-                        if pref != ev.current_id && ev.models.iter().any(|m| m.id == pref) {
+                        if pref != ev.current_id {
+                            let listed = ev.models.iter().any(|m| m.id == pref);
                             let response = tokio::select! {
                                 result = timed_acp_request(
                                     "set model",
@@ -1126,14 +1151,26 @@ pub async fn run_once(
                                         .send_request(SetSessionConfigOptionRequest::new(
                                             acp_session_id.clone(),
                                             SessionConfigId::new(ev.config_id.as_str()),
-                                            SessionConfigOptionValue::value_id(pref),
+                                            SessionConfigOptionValue::value_id(pref.clone()),
                                         ))
                                         .block_task(),
-                                ) => result.ok(),
+                                ) => result,
                                 () = wait_for_cancellation(&mut cancellation) => return_cancelled!(),
                             };
-                            if let Some(response) = response {
-                                config_options = response.config_options;
+                            match response {
+                                Ok(response) => {
+                                    config_options = response.config_options;
+                                }
+                                Err(e) => {
+                                    log::debug!(
+                                        target: "agentero::agent",
+                                        "agent={} set model failed (listed={}): pref={} err={}",
+                                        agent_id_for_models,
+                                        listed,
+                                        pref,
+                                        e
+                                    );
+                                }
                             }
                         }
                     }
@@ -1438,21 +1475,36 @@ pub async fn warm_agent(
                 if let Some(ev) =
                     models_from_config_options(&session_for_conn, &agent_for_conn, &config_options)
                 {
+                    // Attempt preferred model even when not in the advertised catalog
+                    // (third-party / gateway free-form ids).
                     if let Some(pref) = preferred.clone() {
-                        if pref != ev.current_id && ev.models.iter().any(|m| m.id == pref) {
-                            if let Ok(response) = timed_acp_request(
+                        if pref != ev.current_id {
+                            let listed = ev.models.iter().any(|m| m.id == pref);
+                            match timed_acp_request(
                                 "set model",
                                 connection
                                     .send_request(SetSessionConfigOptionRequest::new(
                                         acp_session_id.clone(),
                                         SessionConfigId::new(ev.config_id.as_str()),
-                                        SessionConfigOptionValue::value_id(pref),
+                                        SessionConfigOptionValue::value_id(pref.clone()),
                                     ))
                                     .block_task(),
                             )
                             .await
                             {
-                                config_options = response.config_options;
+                                Ok(response) => {
+                                    config_options = response.config_options;
+                                }
+                                Err(e) => {
+                                    log::debug!(
+                                        target: "agentero::agent",
+                                        "agent={} warm set model failed (listed={}): pref={} err={}",
+                                        agent_for_conn,
+                                        listed,
+                                        pref,
+                                        e
+                                    );
+                                }
                             }
                         }
                     }
@@ -1937,7 +1989,9 @@ mod cancelled_payload_tests {
 
 #[cfg(test)]
 mod config_option_tests {
-    use super::{effort_from_config_options, fast_mode_from_config_options};
+    use super::{
+        effort_from_config_options, fast_mode_from_config_options, models_from_config_options,
+    };
     use agent_client_protocol::schema::v1::{
         SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption,
     };
@@ -1977,6 +2031,44 @@ mod config_option_tests {
         let fast = fast_mode_from_config_options("session", "codex", &options)
             .expect("Codex fast mode should be exposed");
         assert!(fast.enabled);
+    }
+
+    #[test]
+    fn injects_current_model_when_missing_from_catalog() {
+        let options = vec![SessionConfigOption::select(
+            "model",
+            "Model",
+            "deepseek-chat",
+            vec![
+                SessionConfigSelectOption::new("gpt-5", "GPT-5"),
+                SessionConfigSelectOption::new("gpt-4.1", "GPT-4.1"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::Model)];
+
+        let models = models_from_config_options("session", "codex", &options)
+            .expect("model selector should be exposed");
+        assert_eq!(models.current_id, "deepseek-chat");
+        assert_eq!(models.models[0].id, "deepseek-chat");
+        assert!(models.models.iter().any(|m| m.id == "gpt-5"));
+    }
+
+    #[test]
+    fn does_not_duplicate_current_when_already_listed() {
+        let options = vec![SessionConfigOption::select(
+            "model",
+            "Model",
+            "gpt-5",
+            vec![
+                SessionConfigSelectOption::new("gpt-5", "GPT-5"),
+                SessionConfigSelectOption::new("gpt-4.1", "GPT-4.1"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::Model)];
+
+        let models = models_from_config_options("session", "codex", &options)
+            .expect("model selector should be exposed");
+        assert_eq!(models.models.iter().filter(|m| m.id == "gpt-5").count(), 1);
     }
 }
 

--- a/src/components/agent/agent-composer.tsx
+++ b/src/components/agent/agent-composer.tsx
@@ -392,6 +392,16 @@ export function AgentComposer({
 	// Nested enter/leave counter so moving over chips/textarea does not flicker the drop ring.
 	const fileDragDepthRef = useRef(0);
 	const [isFileDragOver, setIsFileDragOver] = useState(false);
+	/** Controlled search so free-form / third-party model ids can be entered (#216). */
+	const [modelQuery, setModelQuery] = useState("");
+	const customModelId = modelQuery.trim();
+	const canUseCustomModel =
+		customModelId.length > 0 &&
+		!models.some(
+			(m) =>
+				m.id === customModelId ||
+				m.name.trim().toLowerCase() === customModelId.toLowerCase(),
+		);
 
 	const resetFileDragHighlight = useCallback(() => {
 		fileDragDepthRef.current = 0;
@@ -940,17 +950,20 @@ export function AgentComposer({
 						<PromptInputTools className="min-w-0 flex-1 flex-wrap gap-1">
 							<ModelSelector
 								open={modelSelectorOpen}
-								onOpenChange={onModelSelectorOpenChange}
+								onOpenChange={(open) => {
+									onModelSelectorOpenChange(open);
+									if (!open) setModelQuery("");
+								}}
 							>
 								<ModelSelectorTrigger asChild>
 									<PromptInputButton
 										type="button"
 										className="h-7 max-w-[min(16rem,100%)] gap-1 px-1.5 text-xs font-medium text-foreground"
-										disabled={warming || models.length === 0}
+										disabled={warming}
 										tooltip={
-											models.length > 0
+											models.length > 0 || selectedModelName
 												? t("models.selectTooltip")
-												: t("models.reportedTooltip")
+												: t("models.customOrReportedTooltip")
 										}
 									>
 										<span className="truncate text-xs">
@@ -962,9 +975,23 @@ export function AgentComposer({
 								</ModelSelectorTrigger>
 								<ModelSelectorContent className="sm:max-w-md">
 									<ModelSelectorInput
-										placeholder={t("models.searchPlaceholder")}
+										value={modelQuery}
+										onValueChange={setModelQuery}
+										placeholder={t("models.searchOrCustomPlaceholder")}
 									/>
 									<ModelSelectorList className="max-h-64">
+										{canUseCustomModel ? (
+											<ModelSelectorGroup heading={t("models.customGroup")}>
+												<ModelSelectorItem
+													value={customModelId}
+													onSelect={() => onPickModel(customModelId)}
+												>
+													<span className="flex-1 truncate">
+														{t("models.useCustom", { id: customModelId })}
+													</span>
+												</ModelSelectorItem>
+											</ModelSelectorGroup>
+										) : null}
 										{groupedModels.map((group) => (
 											<ModelSelectorGroup
 												key={group.id}
@@ -1027,9 +1054,11 @@ export function AgentComposer({
 											</ModelSelectorGroup>
 										))}
 										<ModelSelectorEmpty>
-											{models.length === 0
-												? t("models.emptyNone")
-												: t("models.emptyNoMatch")}
+											{canUseCustomModel
+												? null
+												: models.length === 0
+													? t("models.emptyNoneCustom")
+													: t("models.emptyNoMatch")}
 										</ModelSelectorEmpty>
 									</ModelSelectorList>
 								</ModelSelectorContent>

--- a/src/components/agent/use-agent-panel.ts
+++ b/src/components/agent/use-agent-panel.ts
@@ -80,6 +80,7 @@ import {
 	type ChatLine,
 	type ChatSessionHistoryItem,
 	dedupeModelsClient,
+	ensureModelsInclude,
 	errorChatLine,
 	errorText,
 	isBackgroundWorkflowHistoryTitle,
@@ -387,22 +388,28 @@ export function useAgentPanel({
 			currentId: string;
 			models: AgentModelChoice[];
 		}) => {
-			if (ev.models.length === 0) return;
-			// Defense in depth: host already dedupes; keep unique by id then name.
-			const models = dedupeModelsClient(ev.models);
+			const cur = selectedAgentIdRef.current;
+			const pref = loadModelPref(ev.agentId)?.trim() || null;
+			const current = ev.currentId?.trim() || null;
+			// Keep user/custom prefs and agent current even when not in the fixed
+			// official catalog (third-party / gateway model ids; Fix #216).
+			const catalogModels = ensureModelsInclude(dedupeModelsClient(ev.models), [
+				current,
+				pref,
+			]);
+			if (catalogModels.length === 0) return;
 			saveModelCatalog(ev.agentId, {
 				configId: ev.configId,
 				currentId: ev.currentId,
-				models,
+				models: catalogModels,
 			});
-			const cur = selectedAgentIdRef.current;
 			if (cur && cur !== ev.agentId) return;
-			setModels(models);
 			setModelId((prev) => {
-				const pref = loadModelPref(ev.agentId);
-				if (pref && models.some((m) => m.id === pref)) return pref;
-				if (prev && models.some((m) => m.id === prev)) return prev;
-				return ev.currentId || models[0]?.id || null;
+				const prevId = prev?.trim() || null;
+				const next = pref || prevId || current || catalogModels[0]?.id || null;
+				// Nested setState: keep free-form selection visible in the picker.
+				setModels(ensureModelsInclude(catalogModels, [next, prevId]));
+				return next;
 			});
 		},
 		[],
@@ -592,19 +599,22 @@ export function useAgentPanel({
 		const catalog = loadModelCatalog(selectedAgentId);
 		const pref = loadModelPref(selectedAgentId);
 		if (catalog?.models.length) {
-			const models = dedupeModelsClient(catalog.models);
-			setModels(models);
 			const preferred =
-				(pref && models.some((m) => m.id === pref) && pref) ||
-				(catalog.currentId &&
-					models.some((m) => m.id === catalog.currentId) &&
-					catalog.currentId) ||
-				models[0]?.id ||
+				(pref?.trim() ? pref.trim() : null) ||
+				(catalog.currentId?.trim() ? catalog.currentId.trim() : null) ||
+				catalog.models[0]?.id ||
 				null;
+			const models = ensureModelsInclude(dedupeModelsClient(catalog.models), [
+				preferred,
+				catalog.currentId,
+				pref,
+			]);
+			setModels(models);
 			setModelId(preferred);
 		} else {
-			setModels([]);
-			setModelId(pref);
+			const models = ensureModelsInclude([], [pref]);
+			setModels(models);
+			setModelId(pref?.trim() ? pref.trim() : null);
 		}
 	}, [selectedAgentId]);
 
@@ -1575,10 +1585,14 @@ export function useAgentPanel({
 	);
 
 	const pickModel = (id: string) => {
+		const next = id.trim();
+		if (!next) return;
 		setModelSelectorOpen(false);
-		setModelId(id);
+		// Free-form / third-party ids may not be in the advertised catalog yet.
+		setModels((prev) => ensureModelsInclude(prev, [next]));
+		setModelId(next);
 		if (!selectedAgentId) return;
-		saveModelPref(selectedAgentId, id);
+		saveModelPref(selectedAgentId, next);
 		if (!isTauri() || !agentListenersReady) return;
 
 		const agentId = selectedAgentId;
@@ -1591,12 +1605,12 @@ export function useAgentPanel({
 		void runWarmAgent({
 			agentId,
 			vaultPath: requestVaultPath,
-			modelId: id,
+			modelId: next,
 			generation,
 			stillValid: () =>
 				selectedAgentIdRef.current === agentId &&
 				vaultPathRef.current === requestVaultPath &&
-				loadModelPref(agentId) === id,
+				loadModelPref(agentId) === next,
 			stillWarming: () =>
 				selectedAgentIdRef.current === agentId &&
 				vaultPathRef.current === requestVaultPath,

--- a/src/components/settings/agent-model-picker.tsx
+++ b/src/components/settings/agent-model-picker.tsx
@@ -12,6 +12,7 @@ import {
 	loadModelCatalog,
 	warmAgent,
 } from "@/lib/agent";
+import { ensureModelsInclude } from "@/lib/agent/chat-state";
 import { isTauri } from "@/lib/core/tauri";
 import { listAvailableAgents } from "@/lib/translate";
 import { SettingsRow } from "./settings-layout";
@@ -27,7 +28,8 @@ export type AgentModelValue = {
 
 /**
  * Load agent registry (optional) + model catalog for the resolved agent.
- * Clears stale agentId / modelId via onChange when catalog no longer contains them.
+ * Clears stale agentId via onChange when the agent is gone; free-form model ids
+ * outside the advertised ACP catalog are kept (third-party / gateway; #216).
  */
 export function useAgentModelCatalog({
 	active = true,
@@ -77,20 +79,40 @@ export function useAgentModelCatalog({
 		: undefined;
 	const resolvedAgentId = value.agentId.trim() || registry?.defaultId || "";
 
+	// Warm + load catalog on agent change only. Custom modelId is merged below so
+	// free-form pins (third-party / gateway) stay visible without re-warming.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally omit value.modelId
 	useEffect(() => {
 		if (!active || !resolvedAgentId) {
 			setModels([]);
 			return;
 		}
+		const pinnedModelId = value.modelId;
 		const cached = loadModelCatalog(resolvedAgentId);
-		setModels(cached?.models ?? []);
+		setModels(
+			ensureModelsInclude(cached?.models ?? [], [
+				pinnedModelId,
+				cached?.currentId,
+			]),
+		);
 		if (!isTauri()) return;
 		let cancelled = false;
 		void warmAgent({ agentId: resolvedAgentId }).catch(() => undefined);
 		const tmr = window.setTimeout(() => {
 			if (cancelled) return;
 			const next = loadModelCatalog(resolvedAgentId);
-			if (next?.models?.length) setModels(next.models);
+			if (next?.models?.length) {
+				setModels((prev) => {
+					const extras = prev
+						.map((m) => m.id)
+						.filter((id) => !next.models.some((m) => m.id === id));
+					return ensureModelsInclude(next.models, [
+						pinnedModelId,
+						next.currentId,
+						...extras,
+					]);
+				});
+			}
 		}, 800);
 		return () => {
 			cancelled = true;
@@ -98,29 +120,20 @@ export function useAgentModelCatalog({
 		};
 	}, [active, resolvedAgentId]);
 
-	// Drop stale agentId / modelId
+	// Keep custom / third-party modelId in the select options without re-warming.
+	useEffect(() => {
+		if (!active || !value.modelId?.trim()) return;
+		setModels((prev) => ensureModelsInclude(prev, [value.modelId]));
+	}, [active, value.modelId]);
+
+	// Drop stale agentId only. Do not clear free-form model ids missing from the
+	// advertised ACP catalog (third-party / gateway models; #216).
 	useEffect(() => {
 		if (!active || !registry) return;
 		if (value.agentId && !availableAgents.some((a) => a.id === value.agentId)) {
 			onChange({ agentId: "", modelId: "" });
-			return;
 		}
-		if (
-			value.modelId &&
-			models.length > 0 &&
-			!models.some((m) => m.id === value.modelId)
-		) {
-			onChange({ agentId: value.agentId, modelId: "" });
-		}
-	}, [
-		active,
-		registry,
-		availableAgents,
-		models,
-		value.agentId,
-		value.modelId,
-		onChange,
-	]);
+	}, [active, registry, availableAgents, value.agentId, onChange]);
 
 	const agentSelectValue = value.agentId.trim()
 		? value.agentId

--- a/src/i18n/locales/en/agent.json
+++ b/src/i18n/locales/en/agent.json
@@ -135,11 +135,16 @@
 		"removeFromFavorites": "Remove from favorites",
 		"selectTooltip": "Select model (ACP)",
 		"reportedTooltip": "Models appear after your agent reports them",
+		"customOrReportedTooltip": "Search or type a custom model id (third-party / gateway)",
 		"loading": "Loading…",
 		"button": "Model",
 		"searchPlaceholder": "Search models…",
+		"searchOrCustomPlaceholder": "Search or type a model id…",
+		"customGroup": "Custom",
+		"useCustom": "Use “{{id}}”",
 		"emptyNone": "No models yet. Run once so the ACP agent can advertise models.",
-		"emptyNoMatch": "No match."
+		"emptyNoneCustom": "No models yet. Type a model id above to use a third-party model.",
+		"emptyNoMatch": "No match. Type a full model id to use it as custom."
 	},
 	"messages": {
 		"cancelled": "Stopped the current run.",

--- a/src/i18n/locales/zh-CN/agent.json
+++ b/src/i18n/locales/zh-CN/agent.json
@@ -135,11 +135,16 @@
 		"removeFromFavorites": "取消收藏",
 		"selectTooltip": "选择模型 (ACP)",
 		"reportedTooltip": "Agent 上报模型后将在此显示",
+		"customOrReportedTooltip": "搜索或输入自定义模型 id（第三方 / 中转）",
 		"loading": "加载中……",
 		"button": "模型",
 		"searchPlaceholder": "搜索模型……",
+		"searchOrCustomPlaceholder": "搜索或输入模型 id……",
+		"customGroup": "自定义",
+		"useCustom": "使用 “{{id}}”",
 		"emptyNone": "暂无模型。先运行一次，让 ACP Agent 上报可用模型。",
-		"emptyNoMatch": "无匹配项。"
+		"emptyNoneCustom": "暂无模型。可在上方输入模型 id 以使用第三方模型。",
+		"emptyNoMatch": "无匹配项。输入完整模型 id 可作为自定义模型使用。"
 	},
 	"messages": {
 		"cancelled": "已停止当前运行。",

--- a/src/lib/agent/chat-state.ts
+++ b/src/lib/agent/chat-state.ts
@@ -635,3 +635,30 @@ export function dedupeModelsClient(
 	}
 	return out;
 }
+
+/**
+ * Ensure free-form / third-party model ids appear in the catalog even when the
+ * ACP agent only advertises a fixed official list (e.g. Codex + gateway).
+ * Extra ids are prepended with optional custom group label.
+ */
+export function ensureModelsInclude(
+	models: AgentModelChoice[],
+	extraIds: Array<string | null | undefined>,
+	customGroup?: string | null,
+): AgentModelChoice[] {
+	const extras: AgentModelChoice[] = [];
+	const seen = new Set(
+		models.map((m) => m.id.trim()).filter((id) => id.length > 0),
+	);
+	for (const raw of extraIds) {
+		const id = typeof raw === "string" ? raw.trim() : "";
+		if (!id || seen.has(id)) continue;
+		seen.add(id);
+		extras.push({
+			id,
+			name: id,
+			group: customGroup ?? null,
+		});
+	}
+	return dedupeModelsClient([...extras, ...models]);
+}

--- a/test/agent-chat-state.test.ts
+++ b/test/agent-chat-state.test.ts
@@ -9,6 +9,7 @@ import {
 	buildOptions,
 	type ChatLine,
 	dedupeModelsClient,
+	ensureModelsInclude,
 	errorChatLine,
 	errorText,
 	formatAskUserAnswers,
@@ -219,6 +220,25 @@ describe("dedupeModelsClient", () => {
 			{ id: "a", name: "Alpha", group: undefined },
 			{ id: "c", name: "Gamma", group: undefined },
 		]);
+	});
+});
+
+describe("ensureModelsInclude", () => {
+	it("prepends free-form ids missing from the catalog", () => {
+		const out = ensureModelsInclude(
+			[
+				{ id: "gpt-5", name: "GPT-5" },
+				{ id: "gpt-4.1", name: "GPT-4.1" },
+			],
+			["deepseek-chat", "gpt-5", "  ", null],
+			"Custom",
+		);
+		expect(out[0]).toEqual({
+			id: "deepseek-chat",
+			name: "deepseek-chat",
+			group: "Custom",
+		});
+		expect(out.map((m) => m.id)).toEqual(["deepseek-chat", "gpt-5", "gpt-4.1"]);
 	});
 });
 


### PR DESCRIPTION
## 改动概述

- Host 在模型 catalog 中**注入** ACP 当前模型（`current_id` 不在官方 selector 列表时仍可见）
- `warm` / `run_once` 对 preferred model **始终尝试** `SetSessionConfigOption`，不再要求 id 已在上报列表中（中转 / cc-switch / 自由 model id）
- Chat 模型选择器支持搜索并**输入自定义 model id**；偏好按 agent 持久化，不被「不在列表」清掉
- 设置页 Agent/模型选择不再因 catalog 不含某 id 而清空 pin
- 补充 en / zh-CN 文案与 backend/frontend 文档

Closes #216

## Demo

1. cc-switch 中的 合法配置将会自动追加:
<img width="1210" height="838" alt="image" src="https://github.com/user-attachments/assets/804a922e-0cc8-4517-b750-45b27d5e53be" />

2. 或者可以自定义 model id:
<img width="601" height="222" alt="image" src="https://github.com/user-attachments/assets/8d0fec08-f150-4dc8-9234-1b157beee2ed" />



## 用户影响

- 使用 cc-switch 或第三方网关时，即使 Codex 仍上报官方 GPT 列表，也能看到/使用当前模型
- 可在模型选择器中输入任意 model id（如 `deepseek-chat`）并保存为偏好
- Agent 若不接受该 id，会话仍继续（失败仅 debug 日志），UI 保留所选 id

## 验证

- [x] `pnpm exec biome ci .`（仅既有 warning）
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run`（82 files / 663 tests）
- [x] `cargo test --lib features::agent::acp::config_option_tests`（含 inject / no-duplicate）
- [x] `cargo fmt --check` / `cargo clippy -D warnings`（src-tauri）
- [ ] CI on PR
- [x] 手动：cc-switch / 中转后打开 Chat，输入第三方 model id 并发一轮

## 说明

- Agentero 仍是 ACP Client，不托管模型目录；自定义 id 能否生效取决于底层 Agent（如 Codex）是否接受
- 设置页仅保留已 pin 的自定义 id，自由输入入口在 Chat 模型选择器