### PR TITLE
feat(agent): 多 harness 结构化提问与底部问卷

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,6 +67,7 @@ BYOA，连接本机 ACP Agent。详见 [frontend/agent.md](frontend/agent.md) / 
 - **选区上下文**：Markdown/PDF 选中文字 → 瞬时选区 chip（虚线）；`⌘L` 或「加入对话」固定为 chip。发送时以引用块消费；PDF 带几何的选区在发送后插入 `kind: ask` 对话卡片页边针（非视觉批注）。
 - **运行中继续输入**：后续消息进 Queue waitlist，当前回复结束后自动发送。
 - **权限**：全局模式 `restricted`（默认）/ `ask` / `auto`。`ask` 时弹权限对话框。
+- **结构化提问**：各 harness 的 ask-user / elicitation / Grok ext 归一为底部问卷（与 free-text composer 互斥）。详见 [frontend/agent.md](frontend/agent.md) / [backend/agent.md](backend/agent.md)。
 - **个人偏好**：`agentPersonalPrompt` 非空时经 Host `build_prompt` 注入 envelope。
 
 ### PDF 阅读

--- a/docs/backend/agent.md
+++ b/docs/backend/agent.md
@@ -75,18 +75,20 @@ Agentero prompt envelope、skill/context 注入，并将原始 `/command` 作为
 
 ## 结构化提问（多 harness）
 
-ACP 无标准 tool 名；client 用 `parseAskUserQuestions` / elicitation / Grok ext 三条通路：
+ACP **没有**统一的 ask-user tool 规范：各 harness 的字段名、挂载点（tool / elicitation / ext method）都不一样。Agentero 作为 ACP Client 做三件事：
+
+1. **打开交互能力**：`initialize` 声明 `elicitation.form`（依赖 crate feature `unstable_elicitation`）；否则 Codex 等对 `request_user_input` 会直接空答。
+2. **Client adapter 归一**：把不同 rawInput / 事件解析成同一套 `AskUserQuestion` 页（`parseAskUserQuestions` 等），前端只渲染一张表。
+3. **Harness 特例**：OpenCode spawn 时注入 `OPENCODE_ENABLE_QUESTION_TOOL=1`；Grok 的 `_x.ai/ask_user_question` 由 Host JSON-RPC 处理（`ask_user.rs`），再经 `agent:ask-user-request` / `agent_respond_ask_user` 与前端对齐；tool 镜像与 ext 去重。
 
 | Harness | 形态 | 回答通路 |
 |---|---|---|
-| Codex | tool `variant: AskUserQuestion` 或 elicitation form | tool → 提升到 Composer → 下一用户轮；elicitation → `agent_respond_elicitation` |
-| Claude | tool `questions[]` | 同 tool 提升 → 下一用户轮 |
-| OpenCode | tool `question` → `questions[]` | 同 tool 提升；**默认 env** `OPENCODE_ENABLE_QUESTION_TOOL=1` |
+| Codex | tool `variant: AskUserQuestion` 或 elicitation form | tool → 提升到 **底部问卷** → 下一用户轮；elicitation → `agent_respond_elicitation` |
+| Claude | tool `questions[]`（含 Other 伴生页合并） | 同 tool 提升 → 下一用户轮 |
+| OpenCode | tool `question` → `questions[]` | 同 tool 提升；spawn **默认 env** `OPENCODE_ENABLE_QUESTION_TOOL=1`；turn 阻塞时 cancel+drain 立刻送出答案 |
 | Grok | ext method `_x.ai/ask_user_question` | Host → `agent:ask-user-request` → `agent_respond_ask_user`；与 tool 镜像去重 |
 
-**UI 约定**：可交互表单只在 Composer；transcript tool 卡不嵌选项。优先级 elicitation > Grok ext > tool 提升。
-
-Grok 实现：`src-tauri/src/features/agent/ask_user.rs`。
+**UI 约定**：可交互表单只在 **`AgentAskUserSurface`（底部问卷）**；与 free-text composer **互斥**；transcript tool 卡不嵌选项。优先级 elicitation > Grok ext > tool 提升。
 
 详见 [frontend/agent.md](../frontend/agent.md)。
 

--- a/docs/backend/agent.md
+++ b/docs/backend/agent.md
@@ -104,8 +104,7 @@ Grok 实现：`src-tauri/src/features/agent/ask_user.rs`。
 - `session/new`（及 config 更新）中的 `SessionConfigOption`（category=Model 或 name 回退）解析为 `agent:models`。
 - 若 `current_value` 不在 selector 选项中（第三方网关 / cc-switch 等只改默认 model、目录仍是官方列表），Host **注入**该 current id，避免 UI 丢失。
 - `preferred_model_id`（warm / run_once）在与 current 不同时 **始终尝试** `session/set_config_option`，不要求 id 已在上报列表中；失败仅 debug 日志，不阻断会话。
-- `category: mode`（或 id `mode` / `session_mode`）解析为 `agent:modes`（权限/沙箱，如 Read-only）；`mode_id` 在选项内且与 current 不同时尝试 `session/set_config_option`。
-- Codex `collaboration_mode`（category `collaboration_mode`，Default / Plan）解析为 `agent:collaboration`；`collaboration_mode_id` 同理写入。与权限 mode **分开**——Plan 才能用 `request_user_input`。
+- Codex `collaboration_mode`（Default / Plan 等）解析为 `agent:collaboration`；`collaboration_mode_id` 在选项内且与 current 不同时尝试 `session/set_config_option`。UI 称「模式」。Plan 才能用 `request_user_input`。不解析 / 不暴露 ACP `category: mode` 沙箱档。
 
 ## User-Agent（中转站亲和）
 

--- a/docs/backend/agent.md
+++ b/docs/backend/agent.md
@@ -48,6 +48,7 @@ commands / config 仍可在 load 期间转发。
 | `agent_list_skills` | Vault skill 列表 |
 | `agent_respond_permission` | 回答权限请求 |
 | `agent_respond_elicitation` | 回答 form elicitation（Codex `request_user_input`） |
+| `agent_respond_ask_user` | 回答 Grok `_x.ai/ask_user_question` |
 | `agent_run_tool_lifecycle` | 静默安装/升级 catalog CLI（及 Claude/Codex ACP 适配器）；见 [api.md](api.md) 与 [#225](https://github.com/poco-ai/Agentero/issues/225) |
 | `agent_tool_lifecycle_supported` / `agent_tool_install_commands` | 是否支持静默安装；平台手动安装文案 |
 
@@ -71,6 +72,23 @@ Agentero prompt envelope、skill/context 注入，并将原始 `/command` 作为
 - Host 依赖 `agent-client-protocol` feature `unstable_elicitation`。
 - `initialize` 声明 `elicitation.form`，否则 codex-acp 对 `request_user_input` 直接返回空 answers。
 - 收到 `elicitation/create` → 事件 `agent:elicitation-request` → 前端表单 → `agent_respond_elicitation`。
+
+## 结构化提问（多 harness）
+
+ACP 无标准 tool 名；client 用 `parseAskUserQuestions` / elicitation / Grok ext 三条通路：
+
+| Harness | 形态 | 回答通路 |
+|---|---|---|
+| Codex | tool `variant: AskUserQuestion` 或 elicitation form | tool → 提升到 Composer → 下一用户轮；elicitation → `agent_respond_elicitation` |
+| Claude | tool `questions[]` | 同 tool 提升 → 下一用户轮 |
+| OpenCode | tool `question` → `questions[]` | 同 tool 提升；**默认 env** `OPENCODE_ENABLE_QUESTION_TOOL=1` |
+| Grok | ext method `_x.ai/ask_user_question` | Host → `agent:ask-user-request` → `agent_respond_ask_user`；与 tool 镜像去重 |
+
+**UI 约定**：可交互表单只在 Composer；transcript tool 卡不嵌选项。优先级 elicitation > Grok ext > tool 提升。
+
+Grok 实现：`src-tauri/src/features/agent/ask_user.rs`。
+
+详见 [frontend/agent.md](../frontend/agent.md)。
 
 ## 工作流与 Skill
 

--- a/docs/backend/agent.md
+++ b/docs/backend/agent.md
@@ -47,6 +47,7 @@ commands / config 仍可在 load 期间转发。
 | `agent_list_sessions` / `agent_load_session` | 会话历史 |
 | `agent_list_skills` | Vault skill 列表 |
 | `agent_respond_permission` | 回答权限请求 |
+| `agent_respond_elicitation` | 回答 form elicitation（Codex `request_user_input`） |
 | `agent_run_tool_lifecycle` | 静默安装/升级 catalog CLI（及 Claude/Codex ACP 适配器）；见 [api.md](api.md) 与 [#225](https://github.com/poco-ai/Agentero/issues/225) |
 | `agent_tool_lifecycle_supported` / `agent_tool_install_commands` | 是否支持静默安装；平台手动安装文案 |
 
@@ -65,6 +66,12 @@ Agentero prompt envelope、skill/context 注入，并将原始 `/command` 作为
 | `ask` | `agent:permission-request` → 用户选择 → `agent_respond_permission` |
 | `auto` | 自动批准策略项 |
 
+## Elicitation（不稳定协议）
+
+- Host 依赖 `agent-client-protocol` feature `unstable_elicitation`。
+- `initialize` 声明 `elicitation.form`，否则 codex-acp 对 `request_user_input` 直接返回空 answers。
+- 收到 `elicitation/create` → 事件 `agent:elicitation-request` → 前端表单 → `agent_respond_elicitation`。
+
 ## 工作流与 Skill
 
 - workflow：`summary` / `qa` / `related_work` 等（面板 chips 映射）。
@@ -79,6 +86,8 @@ Agentero prompt envelope、skill/context 注入，并将原始 `/command` 作为
 - `session/new`（及 config 更新）中的 `SessionConfigOption`（category=Model 或 name 回退）解析为 `agent:models`。
 - 若 `current_value` 不在 selector 选项中（第三方网关 / cc-switch 等只改默认 model、目录仍是官方列表），Host **注入**该 current id，避免 UI 丢失。
 - `preferred_model_id`（warm / run_once）在与 current 不同时 **始终尝试** `session/set_config_option`，不要求 id 已在上报列表中；失败仅 debug 日志，不阻断会话。
+- `category: mode`（或 id `mode` / `session_mode`）解析为 `agent:modes`（权限/沙箱，如 Read-only）；`mode_id` 在选项内且与 current 不同时尝试 `session/set_config_option`。
+- Codex `collaboration_mode`（category `collaboration_mode`，Default / Plan）解析为 `agent:collaboration`；`collaboration_mode_id` 同理写入。与权限 mode **分开**——Plan 才能用 `request_user_input`。
 
 ## User-Agent（中转站亲和）
 

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -60,6 +60,7 @@ Host 通过 Tauri event 向前端推送事件。文件系统、任务和菜单�
 | `agent:failed` | Agent 调用失败 | `{ sessionId, error }` |
 | `agent:permission-request` | 权限「每次询问」档：ACP 权限请求转交用户 | `{ requestId, sessionId, title, kind?, paths, options: { optionId, name, kind }[] }` |
 | `agent:elicitation-request` | form elicitation（Codex request_user_input） | `{ requestId, sessionId, message, toolCallId?, fields: { id, title, description?, required, kind, options[] }[] }` |
+| `agent:ask-user-request` | Grok `_x.ai/ask_user_question` | `{ requestId, sessionId, toolCallId?, mode, questions: { question, options[{label,description?}], multiSelect, allowOther }[] }` |
 | `background-task:progress` | 下载/解析任务进度 | `{ taskId, phase, downloadedBytes, totalBytes?, progress? }`；下载阶段的字节进度由前端聚合为总体进度（PDF 映射到 0–50%，TeX 映射到 50–100%），解析阶段显示为处理中，任务完成时为 100% |
 
 #### `agent_warm`

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -52,11 +52,14 @@ Host 通过 Tauri event 向前端推送事件。文件系统、任务和菜单�
 | `agent:plan` | ACP 执行计划 | `{ sessionId, entries: { content, status, priority }[] }` |
 | `agent:usage` | 上下文 token 用量 | `{ sessionId, used, size }` |
 | `agent:models` | Agent 上报可用模型 | `{ sessionId, agentId, configId, currentId, models: { id, name, group? }[] }`；`currentId` 若不在 selector 目录中会被 Host 注入到 `models`（第三方 / 网关默认模型） |
+| `agent:modes` | ACP 上报权限/沙箱模式 | `{ sessionId, agentId, configId, currentId, modes: { id, name, description? }[] }`（category=mode，如 read-only；无上报则不 emit） |
+| `agent:collaboration` | Codex 协作模式 Default/Plan | `{ sessionId, agentId, configId, currentId, modes: { id, name, description? }[] }`（config id=`collaboration_mode`；无上报则不 emit） |
 | `agent:effort` | ACP 上报 reasoning effort 选项 | `{ sessionId, agentId, configId, currentId, efforts: { id, name, description? }[] }` |
 | `agent:fast-mode` | ACP 上报 Fast 开关状态 | `{ sessionId, agentId, configId, enabled }` |
 | `agent:completed` | Agent 回答完成 | `{ sessionId, messageId, content, reasoning?, sources, stopReason? }` |
 | `agent:failed` | Agent 调用失败 | `{ sessionId, error }` |
 | `agent:permission-request` | 权限「每次询问」档：ACP 权限请求转交用户 | `{ requestId, sessionId, title, kind?, paths, options: { optionId, name, kind }[] }` |
+| `agent:elicitation-request` | form elicitation（Codex request_user_input） | `{ requestId, sessionId, message, toolCallId?, fields: { id, title, description?, required, kind, options[] }[] }` |
 | `background-task:progress` | 下载/解析任务进度 | `{ taskId, phase, downloadedBytes, totalBytes?, progress? }`；下载阶段的字节进度由前端聚合为总体进度（PDF 映射到 0–50%，TeX 映射到 50–100%），解析阶段显示为处理中，任务完成时为 100% |
 
 #### `agent_warm`
@@ -70,6 +73,8 @@ Host 通过 Tauri event 向前端推送事件。文件系统、任务和菜单�
   agentId?: string;
   vaultPath?: string;
   modelId?: string; // preferred ACP model config value
+  modeId?: string; // preferred permission/sandbox mode (category: mode)
+  collaborationModeId?: string; // preferred collaboration mode (default / plan)
 }
 ```
 
@@ -1345,6 +1350,8 @@ Host 作为 ACP Client：按注册表 spawn 用户本机 Agent（`cwd` = 当前 
   workflow?: string;
   target?: string;
   modelId?: string;
+  modeId?: string; // 权限/沙箱 mode（如 read-only）
+  collaborationModeId?: string; // 协作模式 default / plan（Plan 下可用 request_user_input）
   reasoningEffort?: string; // 仅写入当前 ACP 会话声明的 thought_level 选项
   fastMode?: boolean; // 仅写入当前 ACP 会话声明的 fast model_config 选项
   skillIds?: string[]; // 已发现的本机 SKILL.md id，最多 5 个

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -52,8 +52,7 @@ Host 通过 Tauri event 向前端推送事件。文件系统、任务和菜单�
 | `agent:plan` | ACP 执行计划 | `{ sessionId, entries: { content, status, priority }[] }` |
 | `agent:usage` | 上下文 token 用量 | `{ sessionId, used, size }` |
 | `agent:models` | Agent 上报可用模型 | `{ sessionId, agentId, configId, currentId, models: { id, name, group? }[] }`；`currentId` 若不在 selector 目录中会被 Host 注入到 `models`（第三方 / 网关默认模型） |
-| `agent:modes` | ACP 上报权限/沙箱模式 | `{ sessionId, agentId, configId, currentId, modes: { id, name, description? }[] }`（category=mode，如 read-only；无上报则不 emit） |
-| `agent:collaboration` | Codex 协作模式 Default/Plan | `{ sessionId, agentId, configId, currentId, modes: { id, name, description? }[] }`（config id=`collaboration_mode`；无上报则不 emit） |
+| `agent:collaboration` | 会话模式（UI「模式」；Codex `collaboration_mode` Default/Plan） | `{ sessionId, agentId, configId, currentId, modes: { id, name, description? }[] }`（无上报则不 emit；UI 仅显示 name） |
 | `agent:effort` | ACP 上报 reasoning effort 选项 | `{ sessionId, agentId, configId, currentId, efforts: { id, name, description? }[] }` |
 | `agent:fast-mode` | ACP 上报 Fast 开关状态 | `{ sessionId, agentId, configId, enabled }` |
 | `agent:completed` | Agent 回答完成 | `{ sessionId, messageId, content, reasoning?, sources, stopReason? }` |
@@ -74,8 +73,7 @@ Host 通过 Tauri event 向前端推送事件。文件系统、任务和菜单�
   agentId?: string;
   vaultPath?: string;
   modelId?: string; // preferred ACP model config value
-  modeId?: string; // preferred permission/sandbox mode (category: mode)
-  collaborationModeId?: string; // preferred collaboration mode (default / plan)
+  collaborationModeId?: string; // preferred session mode (default / plan)
 }
 ```
 
@@ -1351,8 +1349,7 @@ Host 作为 ACP Client：按注册表 spawn 用户本机 Agent（`cwd` = 当前 
   workflow?: string;
   target?: string;
   modelId?: string;
-  modeId?: string; // 权限/沙箱 mode（如 read-only）
-  collaborationModeId?: string; // 协作模式 default / plan（Plan 下可用 request_user_input）
+  collaborationModeId?: string; // 会话模式 default / plan（Plan 下可用 request_user_input）
   reasoningEffort?: string; // 仅写入当前 ACP 会话声明的 thought_level 选项
   fastMode?: boolean; // 仅写入当前 ACP 会话声明的 fast model_config 选项
   skillIds?: string[]; // 已发现的本机 SKILL.md id，最多 5 个

--- a/docs/frontend/agent.md
+++ b/docs/frontend/agent.md
@@ -28,11 +28,28 @@ AI Elements (Conversation / Message / PromptInput / Sources / Reasoning)
 - **新建对话 / 历史恢复**：新建草稿不会清空刚离开的本地 transcript；历史项同时存在 Agentero runtime id 与 ACP provider id 时，`session/load` / 后续续聊只使用 `providerSessionId`；连续续聊产生的新 runtime 行会按 provider id 合并回同一个历史项；加载结果通过一次原子 store 更新写入并激活，避免列表刷新后出现空白会话。详见 [Codex 历史恢复误用 runtime id](../bug_fix/codex-history-runtime-session-id.md)。
 - Slash 命令完全来自当前 ACP session 的 `available_commands_update`；Agentero 不再注册本地 action/template。映射时剥离名称前导 `/` 与 `$`（部分 Agent 把 skill 以 `$name` 形式广播），再以 `/name` 填入 Composer，并在当前 provider session 中原样发送。
 - **模型选择（含第三方）**：列表来自 ACP `agent:models`；若 Agent 当前模型或用户偏好不在固定目录中（如 Codex + 中转 / cc-switch DeepSeek），仍会并入可选列表，并支持在搜索框输入任意 model id 作为自定义模型（`warm` / `run_once` 会尝试 `SetSessionConfigOption`，即使 id 未出现在上报目录中）。偏好按 agent 持久化。
+- **协作模式 vs 权限模式（capability-driven）**：两套独立 config，不可混用。
+  - **协作**（Codex `collaboration_mode`）：Default / Plan；Plan 下才开放 `request_user_input`。事件 `agent:collaboration`；`warm` / `run_once` 携带 `collaborationModeId`。
+  - **权限**（ACP `category: mode`）：Read-only / Agent 等沙箱档。事件 `agent:modes`；携带 `modeId`。
+  - Composer 有上报时分别显示「协作」「权限」下拉；偏好各自按 agent 持久化。
 
 ## 权限 UI
 
 全局模式（设置）：`restricted` / `ask` / `auto`。  
 `ask` 时弹权限对话框 → `agent_respond_permission`。
+
+## 表单 Elicitation / AskUserQuestion（同一 UI）
+
+两者都是「Agent 向用户结构化提问」，**共用** `AskUserQuestionForm`（AI Elements `Suggestion` 选项芯片）：
+
+| 来源 | 协议 | UI 位置 |
+|---|---|---|
+| Tool `variant: AskUserQuestion` | `agent:tool` | Transcript 内 `Tool` 卡 |
+| Codex `request_user_input` | `elicitation/create` → `agent:elicitation-request` | **Composer 输入框上方** |
+
+多题为 **翻页**：一页一题，上一题 / 下一题，末题显示「提交」；选项点击后自动进下一题。单题仅「提交」。
+
+Client 声明 `elicitation.form`；用户提交 → `agent_respond_elicitation`（accept + content）或 cancel。映射：`questionsFromElicitationFields` / `elicitationContentFromAnswers`。
 
 ## 精读（paper-reader）
 

--- a/docs/frontend/agent.md
+++ b/docs/frontend/agent.md
@@ -28,10 +28,7 @@ AI Elements (Conversation / Message / PromptInput / Sources / Reasoning)
 - **新建对话 / 历史恢复**：新建草稿不会清空刚离开的本地 transcript；历史项同时存在 Agentero runtime id 与 ACP provider id 时，`session/load` / 后续续聊只使用 `providerSessionId`；连续续聊产生的新 runtime 行会按 provider id 合并回同一个历史项；加载结果通过一次原子 store 更新写入并激活，避免列表刷新后出现空白会话。详见 [Codex 历史恢复误用 runtime id](../bug_fix/codex-history-runtime-session-id.md)。
 - Slash 命令完全来自当前 ACP session 的 `available_commands_update`；Agentero 不再注册本地 action/template。映射时剥离名称前导 `/` 与 `$`（部分 Agent 把 skill 以 `$name` 形式广播），再以 `/name` 填入 Composer，并在当前 provider session 中原样发送。
 - **模型选择（含第三方）**：列表来自 ACP `agent:models`；若 Agent 当前模型或用户偏好不在固定目录中（如 Codex + 中转 / cc-switch DeepSeek），仍会并入可选列表，并支持在搜索框输入任意 model id 作为自定义模型（`warm` / `run_once` 会尝试 `SetSessionConfigOption`，即使 id 未出现在上报目录中）。偏好按 agent 持久化。
-- **协作模式 vs 权限模式（capability-driven）**：两套独立 config，不可混用。
-  - **协作**（Codex `collaboration_mode`）：Default / Plan；Plan 下才开放 `request_user_input`。事件 `agent:collaboration`；`warm` / `run_once` 携带 `collaborationModeId`。
-  - **权限**（ACP `category: mode`）：Read-only / Agent 等沙箱档。事件 `agent:modes`；携带 `modeId`。
-  - Composer 有上报时分别显示「协作」「权限」下拉；偏好各自按 agent 持久化。
+- **会话模式（capability-driven）**：Codex `collaboration_mode`（Default / Plan 等）。Plan 下才开放 `request_user_input`。事件 `agent:collaboration`；`warm` / `run_once` 携带 `collaborationModeId`。Composer 有上报时显示「模式」下拉（仅模式名，不展示 description）；偏好按 agent 持久化。不暴露 ACP `category: mode` 沙箱档（Read-only / Agent 等）。
 
 ## 权限 UI
 
@@ -44,11 +41,11 @@ AI Elements (Conversation / Message / PromptInput / Sources / Reasoning)
 
 | 来源 | 协议 / rawInput | UI 位置 | 备注 |
 |---|---|---|---|
-| Codex tool / Claude / OpenCode `question` | `agent:tool` + 可解析 questions | **Composer 输入框上方**（从 tool 提升） | Transcript 只留 tool 行 +「请在下方输入区作答」；不嵌表单 |
-| Codex `request_user_input` | `elicitation/create` → `agent:elicitation-request` | **Composer 输入框上方** | Client 须声明 `elicitation.form` |
-| Grok `_x.ai/ask_user_question` | ACP **ext method** → `agent:ask-user-request` | **Composer 输入框上方** | 提交 → `agent_respond_ask_user`；若同时有 tool 镜像则**抑制** tool 表单 |
+| Codex tool / Claude / OpenCode `question` | `agent:tool` + 可解析 questions | **底部问卷**（从 tool 提升） | Transcript 只留 tool 行 +「请在下方问卷中作答」；不嵌表单 |
+| Codex `request_user_input` | `elicitation/create` → `agent:elicitation-request` | **底部问卷** | Client 须声明 `elicitation.form` |
+| Grok `_x.ai/ask_user_question` | ACP **ext method** → `agent:ask-user-request` | **底部问卷** | 提交 → `agent_respond_ask_user`；若同时有 tool 镜像则**抑制** tool 表单 |
 
-**单一交互面**：优先级 `elicitation` > Grok ext > tool 提升；任意时刻只显示一张表单。表单在 **`AgentAskUserSurface`**，位于 **transcript 与 resize 手柄之间**——拖拽只改变下方输入壳高度，不包含问卷。解析：`parseAskUserQuestions` / `questionsFromElicitationFields` / `questionsFromAskUserDtos`。
+**单一交互面**：优先级 `elicitation` > Grok ext > tool 提升；任意时刻只显示一张表单。表单在 **`AgentAskUserSurface`**（transcript 下方）。问卷与 free-text **composer 互斥**：有可渲染问卷时隐藏 resize 手柄与 `AgentComposer`（草稿状态仍由 session composer state 保留），提交或取消后恢复输入壳。解析：`parseAskUserQuestions` / `questionsFromElicitationFields` / `questionsFromAskUserDtos`。
 
 多题为 **翻页**：一页一题，上一题 / 下一题，末题显示「提交」；单选且无 Other 时选项点击后自动进下一题。多选（`multiSelect` / `multiple`）可点多个芯片，答案以 `, ` 拼接。单题仅「提交」。底部「取消」右对齐。
 

--- a/docs/frontend/agent.md
+++ b/docs/frontend/agent.md
@@ -37,7 +37,11 @@ AI Elements (Conversation / Message / PromptInput / Sources / Reasoning)
 
 ## 表单 Elicitation / AskUserQuestion（同一 UI）
 
-「Agent 向用户结构化提问」**共用** `AskUserQuestionForm`（AI Elements `Suggestion` 选项芯片）。ACP **没有**标准 tool 名 `AskUserQuestion`——各 harness 私货经 client adapter 落到同一表单：
+「Agent 向用户结构化提问」**共用** `AskUserQuestionForm`（AI Elements `Suggestion` 选项芯片）。
+
+**背景**：ACP 无统一 ask-user tool 格式。Client 先声明交互能力（`elicitation.form`），再用 adapter 解析各 harness 的 tool / elicitation / ext；个别 provider 还需 Host 侧 RPC（Grok）或 spawn env（OpenCode `OPENCODE_ENABLE_QUESTION_TOOL`）。详见 [backend/agent.md](../backend/agent.md)「结构化提问」。
+
+各 harness 经 client adapter 落到同一表单：
 
 | 来源 | 协议 / rawInput | UI 位置 | 备注 |
 |---|---|---|---|

--- a/docs/frontend/agent.md
+++ b/docs/frontend/agent.md
@@ -21,7 +21,7 @@ AI Elements (Conversation / Message / PromptInput / Sources / Reasoning)
 - **图片附件**：Composer 支持粘贴 / 点选 / 拖入图片（`image/*`，最多 8 张、单张 ≤ 10 MiB）。提交时转为 ACP `ContentBlock::Image`（与 PDF 视觉批注同一 `runOnce.images` 通路）；会话气泡以缩略 chip 展示，纯图消息无文字气泡。图片仅会话本地保留，不随 `session/load` 历史回放。工具：`src/lib/agent/prompt-image.ts`。
 - `@`：空时优先最近路径与浅层目录；› 进入子目录；论文标签与 `paperTreeLabelMode` 一致。`@`、`$` 与 `/` 候选菜单由 viewport 碰撞处理定位，空间不足时翻转并在可用高度内滚动。
 - ACP `plan` 事件使用 AI Elements `Plan` / `PlanStep` 展示，可折叠查看步骤；步骤状态由图标、完成态和无障碍文案表达。
-- ACP `AskUserQuestion` 工具调用会解析为 AI Elements `Tool` 内的可选回答；完成选择后以正常的下一用户轮提交，并继续同一 ACP 会话。
+- ACP 结构化提问工具会解析为 AI Elements `Tool` 内的可选回答；完成选择后以正常的下一用户轮提交，并继续同一 ACP 会话。支持多 harness 的 rawInput 形状（见下表）。
 - 运行中可继续输入 → Queue waitlist；标题保持简洁，条目等宽并可单独移除；Esc / 停止中止。
 - 右侧栏 composer 顶部有竖向拖拽分隔条，可压低输入区高度；低于紧凑阈值后，当前文件 / `@` 提及 / 选区 / 视觉草稿 / skill / 图片附件都变为图标圆片，隐藏建议 prompts 与模型、推理强度、上下文用量、Fast 等常驻工具，只保留输入、图片附件和发送。
 - 会话空闲时 hover 用户消息可 **Edit** 后重发。
@@ -40,16 +40,23 @@ AI Elements (Conversation / Message / PromptInput / Sources / Reasoning)
 
 ## 表单 Elicitation / AskUserQuestion（同一 UI）
 
-两者都是「Agent 向用户结构化提问」，**共用** `AskUserQuestionForm`（AI Elements `Suggestion` 选项芯片）：
+「Agent 向用户结构化提问」**共用** `AskUserQuestionForm`（AI Elements `Suggestion` 选项芯片）。ACP **没有**标准 tool 名 `AskUserQuestion`——各 harness 私货经 client adapter 落到同一表单：
 
-| 来源 | 协议 | UI 位置 |
-|---|---|---|
-| Tool `variant: AskUserQuestion` | `agent:tool` | Transcript 内 `Tool` 卡 |
-| Codex `request_user_input` | `elicitation/create` → `agent:elicitation-request` | **Composer 输入框上方** |
+| 来源 | 协议 / rawInput | UI 位置 | 备注 |
+|---|---|---|---|
+| Codex tool / Claude / OpenCode `question` | `agent:tool` + 可解析 questions | **Composer 输入框上方**（从 tool 提升） | Transcript 只留 tool 行 +「请在下方输入区作答」；不嵌表单 |
+| Codex `request_user_input` | `elicitation/create` → `agent:elicitation-request` | **Composer 输入框上方** | Client 须声明 `elicitation.form` |
+| Grok `_x.ai/ask_user_question` | ACP **ext method** → `agent:ask-user-request` | **Composer 输入框上方** | 提交 → `agent_respond_ask_user`；若同时有 tool 镜像则**抑制** tool 表单 |
 
-多题为 **翻页**：一页一题，上一题 / 下一题，末题显示「提交」；选项点击后自动进下一题。单题仅「提交」。
+**单一交互面**：优先级 `elicitation` > Grok ext > tool 提升；任意时刻只显示一张表单。表单在 **`AgentAskUserSurface`**，位于 **transcript 与 resize 手柄之间**——拖拽只改变下方输入壳高度，不包含问卷。解析：`parseAskUserQuestions` / `questionsFromElicitationFields` / `questionsFromAskUserDtos`。
 
-Client 声明 `elicitation.form`；用户提交 → `agent_respond_elicitation`（accept + content）或 cancel。映射：`questionsFromElicitationFields` / `elicitationContentFromAnswers`。
+多题为 **翻页**：一页一题，上一题 / 下一题，末题显示「提交」；单选且无 Other 时选项点击后自动进下一题。多选（`multiSelect` / `multiple`）可点多个芯片，答案以 `, ` 拼接。单题仅「提交」。底部「取消」右对齐。
+
+键盘（焦点在问卷区、非自由文本框）：`↑`/`↓` 移动选项焦点，`Space` 勾选/切换，`Enter` 确认当前焦点并下一题（末题提交），`←`/`→` 切题。
+
+Client 声明 `elicitation.form`；用户提交 elicitation → `agent_respond_elicitation`（accept + content）或 cancel。映射：`elicitationContentFromAnswers`。
+
+Tool 提升的作答：`formatAskUserAnswers` 后作为下一用户轮。若当前 turn 仍 `running`（OpenCode 等阻塞在 question tool），会先入队再 **取消该 turn**，以便队列立刻排空发送——避免卡在「等待发送」还要点停止。Grok ext / elicitation 不走此路径。
 
 ## 精读（paper-reader）
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,7 +27,7 @@ tauri-plugin-shell = "2.3.5"
 tauri-plugin-store = "2.4.3"
 tauri-plugin-dialog = "2.7.1"
 tauri-plugin-deep-link = "2.4.9"
-agent-client-protocol = "1.2.0"
+agent-client-protocol = { version = "1.2.0", features = ["unstable_elicitation"] }
 tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread", "macros", "time", "process", "io-util", "net"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "query", "tokio"] }
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/src-tauri/src/app/handlers.rs
+++ b/src-tauri/src/app/handlers.rs
@@ -29,6 +29,7 @@ macro_rules! common_commands {
             crate::features::agent::commands::agent_cancel_run,
             crate::features::agent::background_commands::background_task_cancel,
             crate::features::agent::commands::agent_respond_permission,
+            crate::features::agent::commands::agent_respond_elicitation,
             crate::features::wiki::commands::graph_get_backlinks,
             crate::features::wiki::commands::wiki_get_outgoing,
             crate::features::wiki::commands::wiki_resolve,

--- a/src-tauri/src/app/handlers.rs
+++ b/src-tauri/src/app/handlers.rs
@@ -30,6 +30,7 @@ macro_rules! common_commands {
             crate::features::agent::background_commands::background_task_cancel,
             crate::features::agent::commands::agent_respond_permission,
             crate::features::agent::commands::agent_respond_elicitation,
+            crate::features::agent::commands::agent_respond_ask_user,
             crate::features::wiki::commands::graph_get_backlinks,
             crate::features::wiki::commands::wiki_get_outgoing,
             crate::features::wiki::commands::wiki_resolve,

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -76,6 +76,7 @@ pub fn run() {
         .manage(crate::features::agent::AgentWarmGate::new())
         .manage(crate::features::agent::PermissionGate::new())
         .manage(crate::features::agent::ElicitationGate::new())
+        .manage(crate::features::agent::AskUserGate::new())
         .manage(crate::features::bridge::BridgeController::new())
         .manage(crate::features::bridge::BridgeClientController::new())
         .manage(WikiIndexState::new())

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -75,6 +75,7 @@ pub fn run() {
         .manage(AgentRunController::new())
         .manage(crate::features::agent::AgentWarmGate::new())
         .manage(crate::features::agent::PermissionGate::new())
+        .manage(crate::features::agent::ElicitationGate::new())
         .manage(crate::features::bridge::BridgeController::new())
         .manage(crate::features::bridge::BridgeClientController::new())
         .manage(WikiIndexState::new())

--- a/src-tauri/src/features/agent/acp.rs
+++ b/src-tauri/src/features/agent/acp.rs
@@ -11,9 +11,8 @@ use crate::features::agent::models::{
     AcpSessionCapabilities, AcpSessionInfo, AgentCollaborationEvent, AgentCommand,
     AgentCommandInput, AgentCommandsEvent, AgentDescriptor, AgentEffortChoice, AgentEffortEvent,
     AgentFailedEvent, AgentFastModeEvent, AgentModeChoice, AgentModelChoice, AgentModelsEvent,
-    AgentModesEvent, AgentPlanEntry, AgentPlanEvent, AgentResultPayload, AgentStreamEvent,
-    AgentStreamKind, AgentTemplate, AgentToolEvent, AgentUsageEvent, ProbeResult, PromptImage,
-    WarmResult,
+    AgentPlanEntry, AgentPlanEvent, AgentResultPayload, AgentStreamEvent, AgentStreamKind,
+    AgentTemplate, AgentToolEvent, AgentUsageEvent, ProbeResult, PromptImage, WarmResult,
 };
 use crate::features::agent::permission::PermissionGate;
 use crate::features::agent::prompts::{build_prompt, extract_sources};
@@ -395,23 +394,6 @@ fn is_fast_option(opt: &SessionConfigOption) -> bool {
     ) && (opt.id.0.as_ref() == "fast-mode" || opt.name.to_ascii_lowercase().contains("fast"))
 }
 
-fn is_mode_option(opt: &SessionConfigOption) -> bool {
-    // Permission/sandbox axis (Codex: Read-only / Agent / Full-access). Not collaboration.
-    if is_collaboration_option(opt) {
-        return false;
-    }
-    if matches!(
-        opt.category.as_ref(),
-        Some(SessionConfigOptionCategory::Mode)
-    ) {
-        return true;
-    }
-    // Name/id fallback for agents that omit category. Avoid matching fast-mode.
-    matches!(opt.id.0.as_ref(), "mode" | "session_mode" | "session-mode")
-        || opt.name.eq_ignore_ascii_case("mode")
-        || opt.name.eq_ignore_ascii_case("session mode")
-}
-
 fn is_collaboration_option(opt: &SessionConfigOption) -> bool {
     // Codex codex-acp: id + category "collaboration_mode" (Default / Plan).
     if matches!(
@@ -459,32 +441,6 @@ fn collect_mode_choices_from_select(
         _ => {}
     }
     modes
-}
-
-/// Extract permission/sandbox mode selector from ACP config options.
-fn mode_from_config_options(
-    session_id: &str,
-    agent_id: &str,
-    opts: &[SessionConfigOption],
-) -> Option<AgentModesEvent> {
-    let opt = opts.iter().find(|opt| is_mode_option(opt))?;
-    let SessionConfigKind::Select(sel) = &opt.kind else {
-        return None;
-    };
-    let modes = collect_mode_choices_from_select(sel)
-        .into_iter()
-        .filter(|m| !m.id.trim().is_empty() && !m.name.trim().is_empty())
-        .collect::<Vec<_>>();
-    if modes.is_empty() {
-        return None;
-    }
-    Some(AgentModesEvent {
-        session_id: session_id.to_string(),
-        agent_id: agent_id.to_string(),
-        config_id: opt.id.to_string(),
-        current_id: sel.current_value.to_string(),
-        modes,
-    })
 }
 
 /// Extract collaboration mode (Codex Default / Plan) from ACP config options.
@@ -569,9 +525,6 @@ fn emit_session_config_options(
 ) {
     if let Some(ev) = models_from_config_options(session_id, agent_id, opts) {
         let _ = app.emit("agent:models", ev);
-    }
-    if let Some(ev) = mode_from_config_options(session_id, agent_id, opts) {
-        let _ = app.emit("agent:modes", ev);
     }
     if let Some(ev) = collaboration_from_config_options(session_id, agent_id, opts) {
         let _ = app.emit("agent:collaboration", ev);
@@ -1247,7 +1200,6 @@ pub async fn run_once(
     target: Option<String>,
     vault_path: Option<String>,
     preferred_model_id: Option<String>,
-    preferred_mode_id: Option<String>,
     preferred_collaboration_mode_id: Option<String>,
     preferred_reasoning_effort: Option<String>,
     fast_mode: Option<bool>,
@@ -1474,7 +1426,6 @@ pub async fn run_once(
             let full_prompt = full_prompt.clone();
             let prompt_images = prompt_images.clone();
             let preferred_model = preferred_model_id.clone();
-            let preferred_mode = preferred_mode_id.clone();
             let preferred_collaboration = preferred_collaboration_mode_id.clone();
             let preferred_effort = preferred_reasoning_effort.clone();
             let app_for_models = app_for_conn.clone();
@@ -1655,32 +1606,6 @@ pub async fn run_once(
                                         e
                                     );
                                 }
-                            }
-                        }
-                    }
-                }
-                if let Some(pref) = preferred_mode.clone() {
-                    if let Some(ev) = mode_from_config_options(
-                        &session_for_models,
-                        &agent_id_for_models,
-                        &config_options,
-                    ) {
-                        if pref != ev.current_id && ev.modes.iter().any(|mode| mode.id == pref) {
-                            let response = tokio::select! {
-                                result = timed_acp_request(
-                                    "set mode",
-                                    connection
-                                        .send_request(SetSessionConfigOptionRequest::new(
-                                            acp_session_id.clone(),
-                                            SessionConfigId::new(ev.config_id.as_str()),
-                                            SessionConfigOptionValue::value_id(pref),
-                                        ))
-                                        .block_task(),
-                                ) => result.ok(),
-                                () = wait_for_cancellation(&mut cancellation) => return_cancelled!(),
-                            };
-                            if let Some(response) = response {
-                                config_options = response.config_options;
                             }
                         }
                     }
@@ -1901,7 +1826,6 @@ pub async fn warm_agent(
     desc: AgentDescriptor,
     vault_path: Option<String>,
     preferred_model_id: Option<String>,
-    preferred_mode_id: Option<String>,
     preferred_collaboration_mode_id: Option<String>,
     remote: Option<crate::features::remote::RemoteAgentTarget>,
 ) -> WarmResult {
@@ -1939,7 +1863,6 @@ pub async fn warm_agent(
     let agent_for_notif = agent_id.clone();
 
     let preferred = preferred_model_id.clone();
-    let preferred_mode = preferred_mode_id.clone();
     let preferred_collaboration = preferred_collaboration_mode_id.clone();
     let app_for_conn = app.clone();
     let session_for_conn = session_id.clone();
@@ -1992,7 +1915,6 @@ pub async fn warm_agent(
         )
         .connect_with(acp, {
             let preferred = preferred.clone();
-            let preferred_mode = preferred_mode.clone();
             let preferred_collaboration = preferred_collaboration.clone();
             let models_for_conn = models_for_conn.clone();
             move |connection: ConnectionTo<Agent>| async move {
@@ -2043,41 +1965,6 @@ pub async fn warm_agent(
                                         "agent={} warm set model failed (listed={}): pref={} err={}",
                                         agent_for_conn,
                                         listed,
-                                        pref,
-                                        e
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-                if let Some(pref) = preferred_mode.clone() {
-                    if let Some(ev) = mode_from_config_options(
-                        &session_for_conn,
-                        &agent_for_conn,
-                        &config_options,
-                    ) {
-                        if pref != ev.current_id && ev.modes.iter().any(|mode| mode.id == pref) {
-                            match timed_acp_request(
-                                "set mode",
-                                connection
-                                    .send_request(SetSessionConfigOptionRequest::new(
-                                        acp_session_id.clone(),
-                                        SessionConfigId::new(ev.config_id.as_str()),
-                                        SessionConfigOptionValue::value_id(pref.clone()),
-                                    ))
-                                    .block_task(),
-                            )
-                            .await
-                            {
-                                Ok(response) => {
-                                    config_options = response.config_options;
-                                }
-                                Err(e) => {
-                                    log::debug!(
-                                        target: "agentero::agent",
-                                        "agent={} warm set mode failed: pref={} err={}",
-                                        agent_for_conn,
                                         pref,
                                         e
                                     );
@@ -2603,14 +2490,14 @@ mod cancelled_payload_tests {
 mod config_option_tests {
     use super::{
         collaboration_from_config_options, effort_from_config_options,
-        fast_mode_from_config_options, mode_from_config_options, models_from_config_options,
+        fast_mode_from_config_options, models_from_config_options,
     };
     use agent_client_protocol::schema::v1::{
         SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption,
     };
 
     #[test]
-    fn extracts_permission_mode_from_mode_category() {
+    fn ignores_permission_sandbox_mode_category() {
         let options = vec![SessionConfigOption::select(
             "mode",
             "Session mode",
@@ -2622,15 +2509,12 @@ mod config_option_tests {
         )
         .category(SessionConfigOptionCategory::Mode)];
 
-        let modes = mode_from_config_options("session", "codex", &options)
-            .expect("permission mode selector should be exposed");
-        assert_eq!(modes.current_id, "read-only");
-        assert_eq!(modes.modes[0].id, "read-only");
+        // Host does not surface ACP category:mode (sandbox); only collaboration_mode.
         assert!(collaboration_from_config_options("session", "codex", &options).is_none());
     }
 
     #[test]
-    fn extracts_codex_collaboration_mode_separately() {
+    fn extracts_codex_collaboration_mode() {
         let options = vec![
             SessionConfigOption::select(
                 "mode",
@@ -2657,16 +2541,13 @@ mod config_option_tests {
             )),
         ];
 
-        let modes = mode_from_config_options("session", "codex", &options)
-            .expect("permission mode still extracted");
-        assert_eq!(modes.current_id, "read-only");
-
         let collab = collaboration_from_config_options("session", "codex", &options)
             .expect("collaboration mode should be exposed");
         assert_eq!(collab.config_id, "collaboration_mode");
         assert_eq!(collab.current_id, "default");
         assert_eq!(collab.modes.len(), 2);
         assert_eq!(collab.modes[1].id, "plan");
+        assert_eq!(collab.modes[1].name, "Plan");
     }
 
     #[test]
@@ -2682,7 +2563,6 @@ mod config_option_tests {
         )
         .category(SessionConfigOptionCategory::ModelConfig)];
 
-        assert!(mode_from_config_options("session", "codex", &options).is_none());
         assert!(collaboration_from_config_options("session", "codex", &options).is_none());
     }
 

--- a/src-tauri/src/features/agent/acp.rs
+++ b/src-tauri/src/features/agent/acp.rs
@@ -1,13 +1,15 @@
 use crate::core::error::AppError;
 use crate::features::agent::discover::{path_entries, resolve_command};
+use crate::features::agent::elicitation::{ElicitationAnswer, ElicitationGate};
 use crate::features::agent::events::AgentEventEmitter;
 use crate::features::agent::models::{
     AcpHistoryLine, AcpHistoryPart, AcpHistoryTool, AcpListSessionsResult, AcpLoadSessionResult,
-    AcpSessionCapabilities, AcpSessionInfo, AgentCommand, AgentCommandInput, AgentCommandsEvent,
-    AgentDescriptor, AgentEffortChoice, AgentEffortEvent, AgentFailedEvent, AgentFastModeEvent,
-    AgentModelChoice, AgentModelsEvent, AgentPlanEntry, AgentPlanEvent, AgentResultPayload,
-    AgentStreamEvent, AgentStreamKind, AgentTemplate, AgentToolEvent, AgentUsageEvent, ProbeResult,
-    PromptImage, WarmResult,
+    AcpSessionCapabilities, AcpSessionInfo, AgentCollaborationEvent, AgentCommand,
+    AgentCommandInput, AgentCommandsEvent, AgentDescriptor, AgentEffortChoice, AgentEffortEvent,
+    AgentFailedEvent, AgentFastModeEvent, AgentModeChoice, AgentModelChoice, AgentModelsEvent,
+    AgentModesEvent, AgentPlanEntry, AgentPlanEvent, AgentResultPayload, AgentStreamEvent,
+    AgentStreamKind, AgentTemplate, AgentToolEvent, AgentUsageEvent, ProbeResult, PromptImage,
+    WarmResult,
 };
 use crate::features::agent::permission::PermissionGate;
 use crate::features::agent::prompts::{build_prompt, extract_sources};
@@ -15,23 +17,34 @@ use crate::features::agent::skills::{
     load_skill_instructions, skill_activation_prefix, skill_mention_style,
 };
 use agent_client_protocol::schema::v1::{
-    AvailableCommandInput, CancelNotification, ContentBlock, EnvVariable, ImageContent,
-    InitializeRequest, ListSessionsRequest, LoadSessionRequest, McpServer, McpServerStdio,
-    NewSessionRequest, PermissionOptionKind, PlanEntryPriority, PlanEntryStatus, PromptRequest,
-    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
-    ResumeSessionRequest, SelectedPermissionOutcome, SessionConfigId, SessionConfigKind,
-    SessionConfigOption, SessionConfigOptionCategory, SessionConfigOptionValue,
+    AvailableCommandInput, CancelNotification, ClientCapabilities, ContentBlock,
+    CreateElicitationRequest, CreateElicitationResponse, ElicitationAcceptAction,
+    ElicitationAction, ElicitationCapabilities, ElicitationContentValue,
+    ElicitationFormCapabilities, ElicitationMode, ElicitationPropertySchema, ElicitationScope,
+    EnvVariable, ImageContent, InitializeRequest, ListSessionsRequest, LoadSessionRequest,
+    McpServer, McpServerStdio, NewSessionRequest, PermissionOptionKind, PlanEntryPriority,
+    PlanEntryStatus, PromptRequest, RequestPermissionOutcome, RequestPermissionRequest,
+    RequestPermissionResponse, ResumeSessionRequest, SelectedPermissionOutcome, SessionConfigId,
+    SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory, SessionConfigOptionValue,
     SessionConfigSelectOptions, SessionId, SessionNotification, SessionUpdate,
     SetSessionConfigOptionRequest, TextContent, ToolCallStatus, ToolKind,
 };
 use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::{util, AcpAgent, Agent, ConnectionTo};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::watch;
 use uuid::Uuid;
+
+/// Advertise form elicitation so codex-acp bridges `request_user_input` to the client.
+fn client_initialize_request() -> InitializeRequest {
+    InitializeRequest::new(ProtocolVersion::V1).client_capabilities(
+        ClientCapabilities::new()
+            .elicitation(ElicitationCapabilities::new().form(ElicitationFormCapabilities::new())),
+    )
+}
 
 fn to_acp_agent_local(desc: &AgentDescriptor) -> Result<AcpAgent, AppError> {
     let command = resolve_command(&desc.command).unwrap_or_else(|| PathBuf::from(&desc.command));
@@ -378,6 +391,124 @@ fn is_fast_option(opt: &SessionConfigOption) -> bool {
     ) && (opt.id.0.as_ref() == "fast-mode" || opt.name.to_ascii_lowercase().contains("fast"))
 }
 
+fn is_mode_option(opt: &SessionConfigOption) -> bool {
+    // Permission/sandbox axis (Codex: Read-only / Agent / Full-access). Not collaboration.
+    if is_collaboration_option(opt) {
+        return false;
+    }
+    if matches!(
+        opt.category.as_ref(),
+        Some(SessionConfigOptionCategory::Mode)
+    ) {
+        return true;
+    }
+    // Name/id fallback for agents that omit category. Avoid matching fast-mode.
+    matches!(opt.id.0.as_ref(), "mode" | "session_mode" | "session-mode")
+        || opt.name.eq_ignore_ascii_case("mode")
+        || opt.name.eq_ignore_ascii_case("session mode")
+}
+
+fn is_collaboration_option(opt: &SessionConfigOption) -> bool {
+    // Codex codex-acp: id + category "collaboration_mode" (Default / Plan).
+    if matches!(
+        opt.id.0.as_ref(),
+        "collaboration_mode" | "collaboration-mode"
+    ) {
+        return true;
+    }
+    match opt.category.as_ref() {
+        Some(SessionConfigOptionCategory::Other(cat)) => {
+            cat == "collaboration_mode" || cat == "collaboration-mode"
+        }
+        _ => {
+            opt.name.eq_ignore_ascii_case("collaboration mode")
+                || opt.name.eq_ignore_ascii_case("collaboration")
+        }
+    }
+}
+
+fn collect_mode_choices_from_select(
+    sel: &agent_client_protocol::schema::v1::SessionConfigSelect,
+) -> Vec<AgentModeChoice> {
+    let mut modes = Vec::new();
+    match &sel.options {
+        SessionConfigSelectOptions::Ungrouped(list) => {
+            for o in list {
+                modes.push(AgentModeChoice {
+                    id: o.value.to_string(),
+                    name: o.name.clone(),
+                    description: o.description.clone(),
+                });
+            }
+        }
+        SessionConfigSelectOptions::Grouped(groups) => {
+            for g in groups {
+                for o in &g.options {
+                    modes.push(AgentModeChoice {
+                        id: o.value.to_string(),
+                        name: o.name.clone(),
+                        description: o.description.clone(),
+                    });
+                }
+            }
+        }
+        _ => {}
+    }
+    modes
+}
+
+/// Extract permission/sandbox mode selector from ACP config options.
+fn mode_from_config_options(
+    session_id: &str,
+    agent_id: &str,
+    opts: &[SessionConfigOption],
+) -> Option<AgentModesEvent> {
+    let opt = opts.iter().find(|opt| is_mode_option(opt))?;
+    let SessionConfigKind::Select(sel) = &opt.kind else {
+        return None;
+    };
+    let modes = collect_mode_choices_from_select(sel)
+        .into_iter()
+        .filter(|m| !m.id.trim().is_empty() && !m.name.trim().is_empty())
+        .collect::<Vec<_>>();
+    if modes.is_empty() {
+        return None;
+    }
+    Some(AgentModesEvent {
+        session_id: session_id.to_string(),
+        agent_id: agent_id.to_string(),
+        config_id: opt.id.to_string(),
+        current_id: sel.current_value.to_string(),
+        modes,
+    })
+}
+
+/// Extract collaboration mode (Codex Default / Plan) from ACP config options.
+fn collaboration_from_config_options(
+    session_id: &str,
+    agent_id: &str,
+    opts: &[SessionConfigOption],
+) -> Option<AgentCollaborationEvent> {
+    let opt = opts.iter().find(|opt| is_collaboration_option(opt))?;
+    let SessionConfigKind::Select(sel) = &opt.kind else {
+        return None;
+    };
+    let modes = collect_mode_choices_from_select(sel)
+        .into_iter()
+        .filter(|m| !m.id.trim().is_empty() && !m.name.trim().is_empty())
+        .collect::<Vec<_>>();
+    if modes.is_empty() {
+        return None;
+    }
+    Some(AgentCollaborationEvent {
+        session_id: session_id.to_string(),
+        agent_id: agent_id.to_string(),
+        config_id: opt.id.to_string(),
+        current_id: sel.current_value.to_string(),
+        modes,
+    })
+}
+
 fn effort_from_config_options(
     session_id: &str,
     agent_id: &str,
@@ -434,6 +565,12 @@ fn emit_session_config_options(
 ) {
     if let Some(ev) = models_from_config_options(session_id, agent_id, opts) {
         let _ = app.emit("agent:models", ev);
+    }
+    if let Some(ev) = mode_from_config_options(session_id, agent_id, opts) {
+        let _ = app.emit("agent:modes", ev);
+    }
+    if let Some(ev) = collaboration_from_config_options(session_id, agent_id, opts) {
+        let _ = app.emit("agent:collaboration", ev);
     }
     if let Some(ev) = effort_from_config_options(session_id, agent_id, opts) {
         let _ = app.emit("agent:effort", ev);
@@ -610,6 +747,261 @@ fn option_kind_label(kind: &PermissionOptionKind) -> &'static str {
     }
 }
 
+/// One form field derived from an elicitation schema property (for UI).
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ElicitationFieldView {
+    id: String,
+    title: String,
+    description: Option<String>,
+    required: bool,
+    /// select | text | boolean | number | other
+    kind: String,
+    options: Vec<ElicitationOptionView>,
+    /// Codex companion free-text for "Other" (same logical question).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    is_other_answer: bool,
+    /// Parent question field id when `is_other_answer`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    parent_field_id: Option<String>,
+}
+
+fn codex_meta_flag(meta: &Option<agent_client_protocol::schema::v1::Meta>, key: &str) -> bool {
+    meta.as_ref()
+        .and_then(|m| m.get("codex"))
+        .and_then(|c| c.get(key))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+fn codex_meta_string(
+    meta: &Option<agent_client_protocol::schema::v1::Meta>,
+    key: &str,
+) -> Option<String> {
+    meta.as_ref()
+        .and_then(|m| m.get("codex"))
+        .and_then(|c| c.get(key))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ElicitationOptionView {
+    value: String,
+    title: String,
+    description: Option<String>,
+}
+
+/// Payload for `agent:elicitation-request`.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ElicitationRequestEvent {
+    request_id: String,
+    /// Agentero runtime session id (correlates with the active chat run).
+    session_id: String,
+    message: String,
+    /// Optional ACP provider tool call id when the elicitation is scoped to a tool.
+    tool_call_id: Option<String>,
+    fields: Vec<ElicitationFieldView>,
+}
+
+fn elicitation_fields_from_request(
+    request: &CreateElicitationRequest,
+) -> Vec<ElicitationFieldView> {
+    let ElicitationMode::Form(form) = &request.mode else {
+        return Vec::new();
+    };
+    let required: HashSet<&str> = form
+        .requested_schema
+        .required
+        .as_ref()
+        .map(|r| r.iter().map(String::as_str).collect())
+        .unwrap_or_default();
+
+    form.requested_schema
+        .properties
+        .iter()
+        .map(|(id, prop)| {
+            let is_required = required.contains(id.as_str());
+            match prop {
+                ElicitationPropertySchema::String(s) => {
+                    let options = if let Some(one_of) = &s.one_of {
+                        one_of
+                            .iter()
+                            .map(|o| ElicitationOptionView {
+                                value: o.value.clone(),
+                                title: o.title.clone(),
+                                description: o.description.clone(),
+                            })
+                            .collect()
+                    } else if let Some(enums) = &s.enum_values {
+                        enums
+                            .iter()
+                            .map(|v| ElicitationOptionView {
+                                value: v.clone(),
+                                title: v.clone(),
+                                description: None,
+                            })
+                            .collect()
+                    } else {
+                        Vec::new()
+                    };
+                    let kind = if options.is_empty() {
+                        "text".to_string()
+                    } else {
+                        "select".to_string()
+                    };
+                    let is_other_answer = codex_meta_flag(&s.meta, "isOtherAnswer");
+                    let parent_field_id = codex_meta_string(&s.meta, "questionId");
+                    ElicitationFieldView {
+                        id: id.clone(),
+                        title: s.title.clone().unwrap_or_else(|| id.clone()),
+                        description: s.description.clone(),
+                        required: is_required,
+                        kind,
+                        options,
+                        is_other_answer,
+                        parent_field_id,
+                    }
+                }
+                ElicitationPropertySchema::Boolean(b) => ElicitationFieldView {
+                    id: id.clone(),
+                    title: b.title.clone().unwrap_or_else(|| id.clone()),
+                    description: b.description.clone(),
+                    required: is_required,
+                    kind: "boolean".to_string(),
+                    options: vec![
+                        ElicitationOptionView {
+                            value: "true".into(),
+                            title: "Yes".into(),
+                            description: None,
+                        },
+                        ElicitationOptionView {
+                            value: "false".into(),
+                            title: "No".into(),
+                            description: None,
+                        },
+                    ],
+                    is_other_answer: false,
+                    parent_field_id: None,
+                },
+                ElicitationPropertySchema::Number(n) => ElicitationFieldView {
+                    id: id.clone(),
+                    title: n.title.clone().unwrap_or_else(|| id.clone()),
+                    description: n.description.clone(),
+                    required: is_required,
+                    kind: "number".to_string(),
+                    options: Vec::new(),
+                    is_other_answer: false,
+                    parent_field_id: None,
+                },
+                ElicitationPropertySchema::Integer(n) => ElicitationFieldView {
+                    id: id.clone(),
+                    title: n.title.clone().unwrap_or_else(|| id.clone()),
+                    description: n.description.clone(),
+                    required: is_required,
+                    kind: "number".to_string(),
+                    options: Vec::new(),
+                    is_other_answer: false,
+                    parent_field_id: None,
+                },
+                ElicitationPropertySchema::Array(a) => ElicitationFieldView {
+                    id: id.clone(),
+                    title: a.title.clone().unwrap_or_else(|| id.clone()),
+                    description: a.description.clone(),
+                    required: is_required,
+                    kind: "text".to_string(),
+                    options: Vec::new(),
+                    is_other_answer: false,
+                    parent_field_id: None,
+                },
+                ElicitationPropertySchema::Other(_) | _ => ElicitationFieldView {
+                    id: id.clone(),
+                    title: id.clone(),
+                    description: None,
+                    required: is_required,
+                    kind: "other".to_string(),
+                    options: Vec::new(),
+                    is_other_answer: false,
+                    parent_field_id: None,
+                },
+            }
+        })
+        .collect()
+}
+
+fn session_id_from_elicitation(request: &CreateElicitationRequest) -> Option<String> {
+    match request.mode.scope() {
+        ElicitationScope::Session(s) => Some(s.session_id.to_string()),
+        ElicitationScope::Request(_) | _ => None,
+    }
+}
+
+fn tool_call_id_from_elicitation(request: &CreateElicitationRequest) -> Option<String> {
+    match request.mode.scope() {
+        ElicitationScope::Session(s) => s.tool_call_id.as_ref().map(|id| id.to_string()),
+        ElicitationScope::Request(_) | _ => None,
+    }
+}
+
+fn elicitation_response_from_answer(answer: ElicitationAnswer) -> CreateElicitationResponse {
+    match answer {
+        ElicitationAnswer::Accept(fields) => {
+            let content: BTreeMap<String, ElicitationContentValue> = fields
+                .into_iter()
+                .map(|(k, v)| (k, ElicitationContentValue::String(v)))
+                .collect();
+            CreateElicitationResponse::new(ElicitationAction::Accept(
+                ElicitationAcceptAction::new().content(content),
+            ))
+        }
+        ElicitationAnswer::Decline => CreateElicitationResponse::new(ElicitationAction::Decline),
+        ElicitationAnswer::Cancel => CreateElicitationResponse::new(ElicitationAction::Cancel),
+    }
+}
+
+/// Forward form elicitation to the frontend; timeout → cancel.
+async fn await_user_elicitation(
+    app: &AgentEventEmitter,
+    gate: &ElicitationGate,
+    runtime_session_id: &str,
+    request: &CreateElicitationRequest,
+) -> CreateElicitationResponse {
+    // URL elicitations: surface message only; user can open URL externally later.
+    if matches!(request.mode, ElicitationMode::Url(_)) {
+        log::debug!(
+            target: "agentero::agent",
+            "elicitation url mode not fully implemented; cancelling"
+        );
+        return CreateElicitationResponse::new(ElicitationAction::Cancel);
+    }
+
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let fields = elicitation_fields_from_request(request);
+    let provider_session = session_id_from_elicitation(request);
+    let tool_call_id = tool_call_id_from_elicitation(request);
+
+    let rx = gate.register(&request_id);
+    let _ = app.emit(
+        "agent:elicitation-request",
+        ElicitationRequestEvent {
+            request_id: request_id.clone(),
+            // Prefer Agentero runtime id so the chat panel can match the open run.
+            session_id: runtime_session_id.to_string(),
+            message: request.message.clone(),
+            tool_call_id: tool_call_id.or(provider_session),
+            fields,
+        },
+    );
+
+    let answer = tokio::time::timeout(std::time::Duration::from_secs(300), rx).await;
+    match answer {
+        Ok(Ok(user)) => elicitation_response_from_answer(user),
+        _ => CreateElicitationResponse::new(ElicitationAction::Cancel),
+    }
+}
+
 /// Ask mode: forward the request to the frontend and await the user's choice.
 /// Falls back to cancelling when the user does not answer within the timeout.
 async fn await_user_permission(
@@ -712,7 +1104,7 @@ pub async fn probe_agent(
             let captured = captured_clone;
             move |connection: ConnectionTo<Agent>| async move {
                 let init = connection
-                    .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                    .send_request(client_initialize_request())
                     .block_task()
                     .await
                     .map_err(|e| acp_err(format!("initialize failed: {e}")))?;
@@ -803,11 +1195,14 @@ pub async fn run_once(
     target: Option<String>,
     vault_path: Option<String>,
     preferred_model_id: Option<String>,
+    preferred_mode_id: Option<String>,
+    preferred_collaboration_mode_id: Option<String>,
     preferred_reasoning_effort: Option<String>,
     fast_mode: Option<bool>,
     skill_ids: Vec<String>,
     permission_policy: PermissionPolicy,
     permission_gate: PermissionGate,
+    elicitation_gate: ElicitationGate,
     response_language: Option<String>,
     personal_prompt: Option<String>,
     mut cancellation: watch::Receiver<bool>,
@@ -988,10 +1383,31 @@ pub async fn run_once(
             },
             agent_client_protocol::on_receive_request!(),
         )
+        .on_receive_request(
+            {
+                let app_for_elicit = app_for_conn.clone();
+                let session_for_elicit = session_for_conn.clone();
+                let elicitation_gate = elicitation_gate.clone();
+                async move |request: CreateElicitationRequest, responder, _cx| {
+                    let response = await_user_elicitation(
+                        &app_for_elicit,
+                        &elicitation_gate,
+                        &session_for_elicit,
+                        &request,
+                    )
+                    .await;
+                    let _ = responder.respond(response);
+                    Ok(())
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
         .connect_with(acp, {
             let full_prompt = full_prompt.clone();
             let prompt_images = prompt_images.clone();
             let preferred_model = preferred_model_id.clone();
+            let preferred_mode = preferred_mode_id.clone();
+            let preferred_collaboration = preferred_collaboration_mode_id.clone();
             let preferred_effort = preferred_reasoning_effort.clone();
             let app_for_models = app_for_conn.clone();
             let session_for_models = session_for_conn.clone();
@@ -1005,7 +1421,7 @@ pub async fn run_once(
                     result = timed_acp_request(
                         "initialize",
                         connection
-                            .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                            .send_request(client_initialize_request())
                             .block_task(),
                     ) => result?,
                     () = wait_for_cancellation(&mut cancellation) => {
@@ -1171,6 +1587,58 @@ pub async fn run_once(
                                         e
                                     );
                                 }
+                            }
+                        }
+                    }
+                }
+                if let Some(pref) = preferred_mode.clone() {
+                    if let Some(ev) = mode_from_config_options(
+                        &session_for_models,
+                        &agent_id_for_models,
+                        &config_options,
+                    ) {
+                        if pref != ev.current_id && ev.modes.iter().any(|mode| mode.id == pref) {
+                            let response = tokio::select! {
+                                result = timed_acp_request(
+                                    "set mode",
+                                    connection
+                                        .send_request(SetSessionConfigOptionRequest::new(
+                                            acp_session_id.clone(),
+                                            SessionConfigId::new(ev.config_id.as_str()),
+                                            SessionConfigOptionValue::value_id(pref),
+                                        ))
+                                        .block_task(),
+                                ) => result.ok(),
+                                () = wait_for_cancellation(&mut cancellation) => return_cancelled!(),
+                            };
+                            if let Some(response) = response {
+                                config_options = response.config_options;
+                            }
+                        }
+                    }
+                }
+                if let Some(pref) = preferred_collaboration.clone() {
+                    if let Some(ev) = collaboration_from_config_options(
+                        &session_for_models,
+                        &agent_id_for_models,
+                        &config_options,
+                    ) {
+                        if pref != ev.current_id && ev.modes.iter().any(|mode| mode.id == pref) {
+                            let response = tokio::select! {
+                                result = timed_acp_request(
+                                    "set collaboration mode",
+                                    connection
+                                        .send_request(SetSessionConfigOptionRequest::new(
+                                            acp_session_id.clone(),
+                                            SessionConfigId::new(ev.config_id.as_str()),
+                                            SessionConfigOptionValue::value_id(pref),
+                                        ))
+                                        .block_task(),
+                                ) => result.ok(),
+                                () = wait_for_cancellation(&mut cancellation) => return_cancelled!(),
+                            };
+                            if let Some(response) = response {
+                                config_options = response.config_options;
                             }
                         }
                     }
@@ -1365,6 +1833,8 @@ pub async fn warm_agent(
     desc: AgentDescriptor,
     vault_path: Option<String>,
     preferred_model_id: Option<String>,
+    preferred_mode_id: Option<String>,
+    preferred_collaboration_mode_id: Option<String>,
     remote: Option<crate::features::remote::RemoteAgentTarget>,
 ) -> WarmResult {
     let agent_id = desc.id.clone();
@@ -1401,6 +1871,8 @@ pub async fn warm_agent(
     let agent_for_notif = agent_id.clone();
 
     let preferred = preferred_model_id.clone();
+    let preferred_mode = preferred_mode_id.clone();
+    let preferred_collaboration = preferred_collaboration_mode_id.clone();
     let app_for_conn = app.clone();
     let session_for_conn = session_id.clone();
     let agent_for_conn = agent_id.clone();
@@ -1452,12 +1924,14 @@ pub async fn warm_agent(
         )
         .connect_with(acp, {
             let preferred = preferred.clone();
+            let preferred_mode = preferred_mode.clone();
+            let preferred_collaboration = preferred_collaboration.clone();
             let models_for_conn = models_for_conn.clone();
             move |connection: ConnectionTo<Agent>| async move {
                 timed_acp_request(
                     "initialize",
                     connection
-                        .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                        .send_request(client_initialize_request())
                         .block_task(),
                 )
                 .await?;
@@ -1501,6 +1975,76 @@ pub async fn warm_agent(
                                         "agent={} warm set model failed (listed={}): pref={} err={}",
                                         agent_for_conn,
                                         listed,
+                                        pref,
+                                        e
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+                if let Some(pref) = preferred_mode.clone() {
+                    if let Some(ev) = mode_from_config_options(
+                        &session_for_conn,
+                        &agent_for_conn,
+                        &config_options,
+                    ) {
+                        if pref != ev.current_id && ev.modes.iter().any(|mode| mode.id == pref) {
+                            match timed_acp_request(
+                                "set mode",
+                                connection
+                                    .send_request(SetSessionConfigOptionRequest::new(
+                                        acp_session_id.clone(),
+                                        SessionConfigId::new(ev.config_id.as_str()),
+                                        SessionConfigOptionValue::value_id(pref.clone()),
+                                    ))
+                                    .block_task(),
+                            )
+                            .await
+                            {
+                                Ok(response) => {
+                                    config_options = response.config_options;
+                                }
+                                Err(e) => {
+                                    log::debug!(
+                                        target: "agentero::agent",
+                                        "agent={} warm set mode failed: pref={} err={}",
+                                        agent_for_conn,
+                                        pref,
+                                        e
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+                if let Some(pref) = preferred_collaboration.clone() {
+                    if let Some(ev) = collaboration_from_config_options(
+                        &session_for_conn,
+                        &agent_for_conn,
+                        &config_options,
+                    ) {
+                        if pref != ev.current_id && ev.modes.iter().any(|mode| mode.id == pref) {
+                            match timed_acp_request(
+                                "set collaboration mode",
+                                connection
+                                    .send_request(SetSessionConfigOptionRequest::new(
+                                        acp_session_id.clone(),
+                                        SessionConfigId::new(ev.config_id.as_str()),
+                                        SessionConfigOptionValue::value_id(pref.clone()),
+                                    ))
+                                    .block_task(),
+                            )
+                            .await
+                            {
+                                Ok(response) => {
+                                    config_options = response.config_options;
+                                }
+                                Err(e) => {
+                                    log::debug!(
+                                        target: "agentero::agent",
+                                        "agent={} warm set collaboration mode failed: pref={} err={}",
+                                        agent_for_conn,
                                         pref,
                                         e
                                     );
@@ -1579,7 +2123,7 @@ pub async fn list_acp_sessions(
                 let init = timed_acp_request(
                     "initialize",
                     connection
-                        .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                        .send_request(client_initialize_request())
                         .block_task(),
                 )
                 .await?;
@@ -1921,7 +2465,7 @@ pub async fn load_acp_session(
                 timed_acp_request(
                     "initialize",
                     connection
-                        .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                        .send_request(client_initialize_request())
                         .block_task(),
                 )
                 .await?;
@@ -1990,11 +2534,89 @@ mod cancelled_payload_tests {
 #[cfg(test)]
 mod config_option_tests {
     use super::{
-        effort_from_config_options, fast_mode_from_config_options, models_from_config_options,
+        collaboration_from_config_options, effort_from_config_options,
+        fast_mode_from_config_options, mode_from_config_options, models_from_config_options,
     };
     use agent_client_protocol::schema::v1::{
         SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption,
     };
+
+    #[test]
+    fn extracts_permission_mode_from_mode_category() {
+        let options = vec![SessionConfigOption::select(
+            "mode",
+            "Session mode",
+            "read-only",
+            vec![
+                SessionConfigSelectOption::new("read-only", "Read-only").description("No writes"),
+                SessionConfigSelectOption::new("agent", "Agent"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::Mode)];
+
+        let modes = mode_from_config_options("session", "codex", &options)
+            .expect("permission mode selector should be exposed");
+        assert_eq!(modes.current_id, "read-only");
+        assert_eq!(modes.modes[0].id, "read-only");
+        assert!(collaboration_from_config_options("session", "codex", &options).is_none());
+    }
+
+    #[test]
+    fn extracts_codex_collaboration_mode_separately() {
+        let options = vec![
+            SessionConfigOption::select(
+                "mode",
+                "Session mode",
+                "read-only",
+                vec![
+                    SessionConfigSelectOption::new("read-only", "Read-only"),
+                    SessionConfigSelectOption::new("agent", "Agent"),
+                ],
+            )
+            .category(SessionConfigOptionCategory::Mode),
+            SessionConfigOption::select(
+                "collaboration_mode",
+                "Collaboration mode",
+                "default",
+                vec![
+                    SessionConfigSelectOption::new("default", "Default"),
+                    SessionConfigSelectOption::new("plan", "Plan")
+                        .description("Plan before making changes"),
+                ],
+            )
+            .category(SessionConfigOptionCategory::Other(
+                "collaboration_mode".into(),
+            )),
+        ];
+
+        let modes = mode_from_config_options("session", "codex", &options)
+            .expect("permission mode still extracted");
+        assert_eq!(modes.current_id, "read-only");
+
+        let collab = collaboration_from_config_options("session", "codex", &options)
+            .expect("collaboration mode should be exposed");
+        assert_eq!(collab.config_id, "collaboration_mode");
+        assert_eq!(collab.current_id, "default");
+        assert_eq!(collab.modes.len(), 2);
+        assert_eq!(collab.modes[1].id, "plan");
+    }
+
+    #[test]
+    fn does_not_treat_fast_mode_as_session_mode() {
+        let options = vec![SessionConfigOption::select(
+            "fast-mode",
+            "Fast mode",
+            "on",
+            vec![
+                SessionConfigSelectOption::new("off", "Off"),
+                SessionConfigSelectOption::new("on", "On"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::ModelConfig)];
+
+        assert!(mode_from_config_options("session", "codex", &options).is_none());
+        assert!(collaboration_from_config_options("session", "codex", &options).is_none());
+    }
 
     #[test]
     fn extracts_codex_reasoning_effort_from_thought_level() {

--- a/src-tauri/src/features/agent/acp.rs
+++ b/src-tauri/src/features/agent/acp.rs
@@ -1,4 +1,8 @@
 use crate::core::error::AppError;
+use crate::features::agent::ask_user::{
+    cancelled_response, grok_response_from_answers, questions_to_dto, AskUserAnswer, AskUserGate,
+    AskUserRequestEvent, GrokAskUserRequest,
+};
 use crate::features::agent::discover::{path_entries, resolve_command};
 use crate::features::agent::elicitation::{ElicitationAnswer, ElicitationGate};
 use crate::features::agent::events::AgentEventEmitter;
@@ -852,8 +856,13 @@ fn elicitation_fields_from_request(
                     } else {
                         "select".to_string()
                     };
-                    let is_other_answer = codex_meta_flag(&s.meta, "isOtherAnswer");
-                    let parent_field_id = codex_meta_string(&s.meta, "questionId");
+                    let is_other_answer = codex_meta_flag(&s.meta, "isOtherAnswer")
+                        || codex_meta_flag(&s.meta, "is_other_answer");
+                    // codex-acp uses questionId; some adapters use parentFieldId / parentId.
+                    let parent_field_id = codex_meta_string(&s.meta, "questionId")
+                        .or_else(|| codex_meta_string(&s.meta, "parentFieldId"))
+                        .or_else(|| codex_meta_string(&s.meta, "parent_field_id"))
+                        .or_else(|| codex_meta_string(&s.meta, "parentId"));
                     ElicitationFieldView {
                         id: id.clone(),
                         title: s.title.clone().unwrap_or_else(|| id.clone()),
@@ -958,6 +967,49 @@ fn elicitation_response_from_answer(answer: ElicitationAnswer) -> CreateElicitat
         }
         ElicitationAnswer::Decline => CreateElicitationResponse::new(ElicitationAction::Decline),
         ElicitationAnswer::Cancel => CreateElicitationResponse::new(ElicitationAction::Cancel),
+    }
+}
+
+/// Forward Grok `_x.ai/ask_user_question` to the frontend; timeout → cancel.
+async fn await_grok_ask_user(
+    app: &AgentEventEmitter,
+    gate: &AskUserGate,
+    runtime_session_id: &str,
+    request: &GrokAskUserRequest,
+) -> serde_json::Value {
+    let params = &request.0;
+    let questions = questions_to_dto(&params.questions);
+    if questions.is_empty() {
+        log::warn!(
+            target: "agentero::agent",
+            "grok ask_user_question with no valid questions; cancelling"
+        );
+        return cancelled_response();
+    }
+
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let mode = match params.mode.as_deref() {
+        Some("plan") => "plan".to_string(),
+        _ => "default".to_string(),
+    };
+    let rx = gate.register(&request_id);
+    let _ = app.emit(
+        "agent:ask-user-request",
+        AskUserRequestEvent {
+            request_id: request_id.clone(),
+            session_id: runtime_session_id.to_string(),
+            tool_call_id: Some(params.tool_call_id.clone()).filter(|s| !s.is_empty()),
+            mode,
+            questions,
+        },
+    );
+
+    let answer = tokio::time::timeout(std::time::Duration::from_secs(300), rx).await;
+    match answer {
+        Ok(Ok(AskUserAnswer::Accepted { answers })) => {
+            grok_response_from_answers(&params.questions, &answers)
+        }
+        _ => cancelled_response(),
     }
 }
 
@@ -1203,6 +1255,7 @@ pub async fn run_once(
     permission_policy: PermissionPolicy,
     permission_gate: PermissionGate,
     elicitation_gate: ElicitationGate,
+    ask_user_gate: AskUserGate,
     response_language: Option<String>,
     personal_prompt: Option<String>,
     mut cancellation: watch::Receiver<bool>,
@@ -1396,6 +1449,21 @@ pub async fn run_once(
                         &request,
                     )
                     .await;
+                    let _ = responder.respond(response);
+                    Ok(())
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let app_for_ask = app_for_conn.clone();
+                let session_for_ask = session_for_conn.clone();
+                let ask_user_gate = ask_user_gate.clone();
+                async move |request: GrokAskUserRequest, responder, _cx| {
+                    let response =
+                        await_grok_ask_user(&app_for_ask, &ask_user_gate, &session_for_ask, &request)
+                            .await;
                     let _ = responder.respond(response);
                     Ok(())
                 }

--- a/src-tauri/src/features/agent/ask_user.rs
+++ b/src-tauri/src/features/agent/ask_user.rs
@@ -1,0 +1,363 @@
+//! Grok Build ACP extension: `_x.ai/ask_user_question` / `x.ai/ask_user_question`.
+//!
+//! Not an ACP-standard tool or elicitation — a vendor ext method that blocks the
+//! agent turn until the client returns `{ outcome, answers }`.
+
+use agent_client_protocol::{util, Error, JsonRpcMessage, JsonRpcRequest};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::oneshot;
+
+/// Wire methods Grok (and compatible clients) may use.
+pub const GROK_ASK_USER_METHODS: &[&str] = &["_x.ai/ask_user_question", "x.ai/ask_user_question"];
+
+/// User decision for a pending Grok ask-user request.
+#[derive(Debug, Clone)]
+pub enum AskUserAnswer {
+    /// Accepted: one answer string per question (multi-select joined with ", ").
+    Accepted {
+        answers: Vec<String>,
+    },
+    Cancelled,
+}
+
+/// Process-wide table of ask-user requests awaiting a UI decision.
+#[derive(Clone, Default)]
+pub struct AskUserGate {
+    pending: Arc<Mutex<HashMap<String, oneshot::Sender<AskUserAnswer>>>>,
+}
+
+impl AskUserGate {
+    pub fn new() -> Self {
+        Self {
+            pending: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn register(&self, request_id: &str) -> oneshot::Receiver<AskUserAnswer> {
+        let (tx, rx) = oneshot::channel();
+        if let Ok(mut g) = self.pending.lock() {
+            g.insert(request_id.to_string(), tx);
+        }
+        rx
+    }
+
+    pub fn resolve(&self, request_id: &str, answer: AskUserAnswer) -> bool {
+        let tx = self
+            .pending
+            .lock()
+            .ok()
+            .and_then(|mut g| g.remove(request_id));
+        match tx {
+            Some(tx) => tx.send(answer).is_ok(),
+            None => false,
+        }
+    }
+}
+
+/// One option on a Grok question.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GrokQuestionOption {
+    pub label: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub preview: Option<String>,
+}
+
+/// One question in a Grok ask-user request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GrokQuestion {
+    pub question: String,
+    #[serde(default)]
+    pub options: Vec<GrokQuestionOption>,
+    #[serde(default, alias = "multiple", alias = "multi_select")]
+    pub multi_select: bool,
+}
+
+/// Params of `_x.ai/ask_user_question` (camelCase and snake_case both accepted).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GrokAskUserParams {
+    #[serde(alias = "session_id")]
+    pub session_id: String,
+    #[serde(alias = "tool_call_id")]
+    pub tool_call_id: String,
+    pub questions: Vec<GrokQuestion>,
+    #[serde(default)]
+    pub mode: Option<String>,
+}
+
+/// Typed JSON-RPC request for Grok ask-user (ACP ext method).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct GrokAskUserRequest(pub GrokAskUserParams);
+
+impl JsonRpcMessage for GrokAskUserRequest {
+    fn matches_method(method: &str) -> bool {
+        GROK_ASK_USER_METHODS.contains(&method)
+    }
+
+    fn method(&self) -> &str {
+        // Prefer underscore form when re-serializing (ACP extension convention).
+        GROK_ASK_USER_METHODS[0]
+    }
+
+    fn to_untyped_message(&self) -> Result<agent_client_protocol::UntypedMessage, Error> {
+        agent_client_protocol::UntypedMessage::new(self.method(), self)
+    }
+
+    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, Error> {
+        if !Self::matches_method(method) {
+            return Err(Error::method_not_found());
+        }
+        util::json_cast_params(params)
+    }
+}
+
+impl JsonRpcRequest for GrokAskUserRequest {
+    type Response = Value;
+}
+
+/// Event payload for `agent:ask-user-request`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AskUserRequestEvent {
+    pub request_id: String,
+    pub session_id: String,
+    pub tool_call_id: Option<String>,
+    /// default | plan
+    pub mode: String,
+    pub questions: Vec<AskUserQuestionDto>,
+}
+
+/// Frontend-friendly question (mirrors `AskUserQuestion` in chat-state).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AskUserQuestionDto {
+    pub question: String,
+    pub options: Vec<AskUserOptionDto>,
+    pub multi_select: bool,
+    /// Grok always allows free-text Other.
+    pub allow_other: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AskUserOptionDto {
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+pub fn questions_to_dto(questions: &[GrokQuestion]) -> Vec<AskUserQuestionDto> {
+    questions
+        .iter()
+        .filter_map(|q| {
+            let question = q.question.trim();
+            if question.is_empty() {
+                return None;
+            }
+            let options: Vec<AskUserOptionDto> = q
+                .options
+                .iter()
+                .filter_map(|o| {
+                    let label = o.label.trim();
+                    if label.is_empty() || label.eq_ignore_ascii_case("other") {
+                        return None;
+                    }
+                    let description = o
+                        .description
+                        .as_ref()
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .or_else(|| {
+                            o.preview
+                                .as_ref()
+                                .map(|s| s.trim().to_string())
+                                .filter(|s| !s.is_empty())
+                        });
+                    Some(AskUserOptionDto {
+                        label: label.to_string(),
+                        description,
+                    })
+                })
+                .collect();
+            // Need options or free-text path.
+            if options.is_empty() {
+                // Still allow pure free-text via Other.
+            }
+            Some(AskUserQuestionDto {
+                question: question.to_string(),
+                options,
+                multi_select: q.multi_select,
+                allow_other: true,
+            })
+        })
+        .collect()
+}
+
+/// Build Grok ext-method response JSON from parallel answer strings.
+pub fn grok_response_from_answers(questions: &[GrokQuestion], answers: &[String]) -> Value {
+    let mut answers_map = serde_json::Map::new();
+    let mut annotations = serde_json::Map::new();
+
+    for (i, q) in questions.iter().enumerate() {
+        let raw = answers.get(i).map(|s| s.trim()).unwrap_or("");
+        if raw.is_empty() {
+            continue;
+        }
+        let q_text = q.question.trim();
+        if q_text.is_empty() {
+            continue;
+        }
+        let option_labels: Vec<&str> = q
+            .options
+            .iter()
+            .map(|o| o.label.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        if q.multi_select {
+            let selected: Vec<String> = option_labels
+                .iter()
+                .filter(|label| {
+                    raw.split(", ").any(|part| part.trim() == **label)
+                        || raw.split(',').any(|part| part.trim() == **label)
+                })
+                .map(|s| (*s).to_string())
+                .collect();
+            // Free-text remainder?
+            let mut rest = raw.to_string();
+            for label in &selected {
+                rest = rest
+                    .split(", ")
+                    .filter(|p| p.trim() != label.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+            }
+            rest = rest.trim().to_string();
+            let mut labels = selected;
+            if !rest.is_empty() && !option_labels.contains(&rest.as_str()) {
+                labels.push("Other".to_string());
+                annotations.insert(q_text.to_string(), json!({ "notes": rest }));
+            }
+            if !labels.is_empty() {
+                answers_map.insert(q_text.to_string(), json!(labels));
+            }
+        } else {
+            // Single select: exact option match or Other free-text.
+            if option_labels.contains(&raw) {
+                answers_map.insert(q_text.to_string(), json!([raw]));
+                if let Some(opt) = q.options.iter().find(|o| o.label.trim() == raw) {
+                    if let Some(preview) = opt
+                        .preview
+                        .as_ref()
+                        .map(|s| s.trim())
+                        .filter(|s| !s.is_empty())
+                    {
+                        annotations.insert(q_text.to_string(), json!({ "preview": preview }));
+                    }
+                }
+            } else {
+                answers_map.insert(q_text.to_string(), json!(["Other"]));
+                annotations.insert(q_text.to_string(), json!({ "notes": raw }));
+            }
+        }
+    }
+
+    if answers_map.is_empty() {
+        return json!({ "outcome": "cancelled" });
+    }
+
+    let mut body = json!({
+        "outcome": "accepted",
+        "answers": answers_map,
+    });
+    if !annotations.is_empty() {
+        if let Some(obj) = body.as_object_mut() {
+            obj.insert("annotations".into(), Value::Object(annotations));
+        }
+    }
+    body
+}
+
+pub fn cancelled_response() -> Value {
+    json!({ "outcome": "cancelled" })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_both_method_names() {
+        assert!(GrokAskUserRequest::matches_method(
+            "_x.ai/ask_user_question"
+        ));
+        assert!(GrokAskUserRequest::matches_method("x.ai/ask_user_question"));
+        assert!(!GrokAskUserRequest::matches_method("session/prompt"));
+    }
+
+    #[test]
+    fn builds_accepted_single_select() {
+        let questions = vec![GrokQuestion {
+            question: "Preferred language?".into(),
+            options: vec![
+                GrokQuestionOption {
+                    label: "Chinese".into(),
+                    description: None,
+                    preview: None,
+                },
+                GrokQuestionOption {
+                    label: "English".into(),
+                    description: None,
+                    preview: None,
+                },
+            ],
+            multi_select: false,
+        }];
+        let v = grok_response_from_answers(&questions, &["Chinese".into()]);
+        assert_eq!(v["outcome"], "accepted");
+        assert_eq!(v["answers"]["Preferred language?"], json!(["Chinese"]));
+    }
+
+    #[test]
+    fn builds_other_with_notes() {
+        let questions = vec![GrokQuestion {
+            question: "Q?".into(),
+            options: vec![GrokQuestionOption {
+                label: "A".into(),
+                description: None,
+                preview: None,
+            }],
+            multi_select: false,
+        }];
+        let v = grok_response_from_answers(&questions, &["custom text".into()]);
+        assert_eq!(v["answers"]["Q?"], json!(["Other"]));
+        assert_eq!(v["annotations"]["Q?"]["notes"], "custom text");
+    }
+
+    #[test]
+    fn parses_camel_case_params() {
+        let raw = json!({
+            "sessionId": "s1",
+            "toolCallId": "t1",
+            "questions": [{
+                "question": "Hi?",
+                "multiSelect": true,
+                "options": [{ "label": "Yes", "description": "y" }]
+            }],
+            "mode": "plan"
+        });
+        let p: GrokAskUserParams = serde_json::from_value(raw).unwrap();
+        assert_eq!(p.session_id, "s1");
+        assert_eq!(p.tool_call_id, "t1");
+        assert!(p.questions[0].multi_select);
+        assert_eq!(p.mode.as_deref(), Some("plan"));
+    }
+}

--- a/src-tauri/src/features/agent/commands.rs
+++ b/src-tauri/src/features/agent/commands.rs
@@ -1,4 +1,5 @@
 use crate::core::error::{map_err, ApiResult, AppError};
+use crate::features::agent::ask_user::AskUserAnswer;
 use crate::features::agent::elicitation::ElicitationAnswer;
 use crate::features::agent::models::{
     AgentDescriptor, AgentListResponse, AgentSkill, CatalogScanResponse, ProbeResult,
@@ -6,7 +7,7 @@ use crate::features::agent::models::{
 };
 use crate::features::agent::{
     list_agent_skills, new_ids, probe_agent, run_once, warm_agent, AgentEventEmitter,
-    AgentRegistry, AgentRunController, AgentWarmGate, ElicitationGate, PermissionGate,
+    AgentRegistry, AgentRunController, AgentWarmGate, AskUserGate, ElicitationGate, PermissionGate,
     PermissionPolicy,
 };
 use crate::features::remote::{materialize_skills_to_work, resolve_remote_target, RemoteRegistry};
@@ -291,12 +292,14 @@ pub async fn agent_probe_catalog(
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn agent_run_once(
     window: tauri::WebviewWindow,
     registry: State<'_, AgentRegistry>,
     runs: State<'_, AgentRunController>,
     gate: State<'_, PermissionGate>,
     elicitation_gate: State<'_, ElicitationGate>,
+    ask_user_gate: State<'_, AskUserGate>,
     remote_registry: State<'_, Arc<RemoteRegistry>>,
     request: RunOnceRequest,
 ) -> Result<ApiResult<RunOnceAccepted>, String> {
@@ -352,6 +355,7 @@ pub async fn agent_run_once(
     let events = AgentEventEmitter::new(app_handle.clone(), window.label());
     let permission_gate = gate.inner().clone();
     let elicitation_gate = elicitation_gate.inner().clone();
+    let ask_user_gate = ask_user_gate.inner().clone();
     let permission_policy = match request.permission_mode.as_deref() {
         Some("auto") => PermissionPolicy::Auto,
         Some("ask") => PermissionPolicy::Ask,
@@ -384,6 +388,7 @@ pub async fn agent_run_once(
             permission_policy,
             permission_gate.clone(),
             elicitation_gate.clone(),
+            ask_user_gate.clone(),
             request.response_language,
             request.personal_prompt,
             cancellation,
@@ -547,6 +552,33 @@ pub fn agent_respond_elicitation(
         "accept" => ElicitationAnswer::Accept(request.content.unwrap_or_default()),
         "decline" => ElicitationAnswer::Decline,
         _ => ElicitationAnswer::Cancel,
+    };
+    let resolved = gate.resolve(&request.request_id, answer);
+    ApiResult::ok(PermissionResponded { resolved })
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AskUserResponseRequest {
+    pub request_id: String,
+    /// accept | cancel
+    pub action: String,
+    /// Parallel answer strings (multi-select joined with ", ").
+    #[serde(default)]
+    pub answers: Option<Vec<String>>,
+}
+
+/// Answer a pending Grok `_x.ai/ask_user_question` extension request.
+#[tauri::command]
+pub fn agent_respond_ask_user(
+    gate: State<'_, AskUserGate>,
+    request: AskUserResponseRequest,
+) -> ApiResult<PermissionResponded> {
+    let answer = match request.action.as_str() {
+        "accept" => AskUserAnswer::Accepted {
+            answers: request.answers.unwrap_or_default(),
+        },
+        _ => AskUserAnswer::Cancelled,
     };
     let resolved = gate.resolve(&request.request_id, answer);
     ApiResult::ok(PermissionResponded { resolved })

--- a/src-tauri/src/features/agent/commands.rs
+++ b/src-tauri/src/features/agent/commands.rs
@@ -380,7 +380,6 @@ pub async fn agent_run_once(
             request.target.clone(),
             request.vault_path,
             request.model_id,
-            request.mode_id,
             request.collaboration_mode_id,
             request.reasoning_effort,
             request.fast_mode,
@@ -640,7 +639,6 @@ pub async fn agent_warm(
         desc,
         request.vault_path,
         request.model_id,
-        request.mode_id,
         request.collaboration_mode_id,
         remote,
     )

--- a/src-tauri/src/features/agent/commands.rs
+++ b/src-tauri/src/features/agent/commands.rs
@@ -1,11 +1,13 @@
 use crate::core::error::{map_err, ApiResult, AppError};
+use crate::features::agent::elicitation::ElicitationAnswer;
 use crate::features::agent::models::{
     AgentDescriptor, AgentListResponse, AgentSkill, CatalogScanResponse, ProbeResult,
     RunOnceAccepted, RunOnceRequest, UpsertAgentRequest, WarmRequest, WarmResult,
 };
 use crate::features::agent::{
     list_agent_skills, new_ids, probe_agent, run_once, warm_agent, AgentEventEmitter,
-    AgentRegistry, AgentRunController, AgentWarmGate, PermissionGate, PermissionPolicy,
+    AgentRegistry, AgentRunController, AgentWarmGate, ElicitationGate, PermissionGate,
+    PermissionPolicy,
 };
 use crate::features::remote::{materialize_skills_to_work, resolve_remote_target, RemoteRegistry};
 use serde::Serialize;
@@ -294,6 +296,7 @@ pub async fn agent_run_once(
     registry: State<'_, AgentRegistry>,
     runs: State<'_, AgentRunController>,
     gate: State<'_, PermissionGate>,
+    elicitation_gate: State<'_, ElicitationGate>,
     remote_registry: State<'_, Arc<RemoteRegistry>>,
     request: RunOnceRequest,
 ) -> Result<ApiResult<RunOnceAccepted>, String> {
@@ -348,6 +351,7 @@ pub async fn agent_run_once(
     let app_handle = window.app_handle().clone();
     let events = AgentEventEmitter::new(app_handle.clone(), window.label());
     let permission_gate = gate.inner().clone();
+    let elicitation_gate = elicitation_gate.inner().clone();
     let permission_policy = match request.permission_mode.as_deref() {
         Some("auto") => PermissionPolicy::Auto,
         Some("ask") => PermissionPolicy::Ask,
@@ -372,11 +376,14 @@ pub async fn agent_run_once(
             request.target.clone(),
             request.vault_path,
             request.model_id,
+            request.mode_id,
+            request.collaboration_mode_id,
             request.reasoning_effort,
             request.fast_mode,
             request.skill_ids,
             permission_policy,
             permission_gate.clone(),
+            elicitation_gate.clone(),
             request.response_language,
             request.personal_prompt,
             cancellation,
@@ -519,6 +526,32 @@ pub fn agent_respond_permission(
     ApiResult::ok(PermissionResponded { resolved })
 }
 
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ElicitationResponseRequest {
+    pub request_id: String,
+    /// accept | decline | cancel
+    pub action: String,
+    /// Field id → string value (accept only).
+    #[serde(default)]
+    pub content: Option<std::collections::BTreeMap<String, String>>,
+}
+
+/// Answer a pending ACP form elicitation (`elicitation/create`).
+#[tauri::command]
+pub fn agent_respond_elicitation(
+    gate: State<'_, ElicitationGate>,
+    request: ElicitationResponseRequest,
+) -> ApiResult<PermissionResponded> {
+    let answer = match request.action.as_str() {
+        "accept" => ElicitationAnswer::Accept(request.content.unwrap_or_default()),
+        "decline" => ElicitationAnswer::Decline,
+        _ => ElicitationAnswer::Cancel,
+    };
+    let resolved = gate.resolve(&request.request_id, answer);
+    ApiResult::ok(PermissionResponded { resolved })
+}
+
 /// Background ACP start when Chat opens — loads models/context without a user prompt.
 #[tauri::command]
 pub async fn agent_warm(
@@ -570,7 +603,16 @@ pub async fn agent_warm(
 
     let events = AgentEventEmitter::new(window.app_handle().clone(), window.label());
     let agent_id = desc.id.clone();
-    let result = warm_agent(events, desc, request.vault_path, request.model_id, remote).await;
+    let result = warm_agent(
+        events,
+        desc,
+        request.vault_path,
+        request.model_id,
+        request.mode_id,
+        request.collaboration_mode_id,
+        remote,
+    )
+    .await;
     if result.ok {
         warm_gate.clear(&agent_id);
     } else {

--- a/src-tauri/src/features/agent/elicitation.rs
+++ b/src-tauri/src/features/agent/elicitation.rs
@@ -1,0 +1,52 @@
+//! Interactive ACP form elicitation (`elicitation/create`).
+//!
+//! Codex Plan-mode `request_user_input` is bridged by codex-acp as form
+//! elicitation. The Host must advertise `clientCapabilities.elicitation.form`
+//! and answer `elicitation/create` or the adapter returns empty answers.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex};
+use tokio::sync::oneshot;
+
+/// User decision for a pending elicitation.
+#[derive(Debug, Clone)]
+pub enum ElicitationAnswer {
+    /// Accept with field values (property id → string content).
+    Accept(BTreeMap<String, String>),
+    Decline,
+    Cancel,
+}
+
+/// Process-wide table of elicitation requests awaiting a user decision.
+#[derive(Clone, Default)]
+pub struct ElicitationGate {
+    pending: Arc<Mutex<HashMap<String, oneshot::Sender<ElicitationAnswer>>>>,
+}
+
+impl ElicitationGate {
+    pub fn new() -> Self {
+        Self {
+            pending: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn register(&self, request_id: &str) -> oneshot::Receiver<ElicitationAnswer> {
+        let (tx, rx) = oneshot::channel();
+        if let Ok(mut g) = self.pending.lock() {
+            g.insert(request_id.to_string(), tx);
+        }
+        rx
+    }
+
+    pub fn resolve(&self, request_id: &str, answer: ElicitationAnswer) -> bool {
+        let tx = self
+            .pending
+            .lock()
+            .ok()
+            .and_then(|mut g| g.remove(request_id));
+        match tx {
+            Some(tx) => tx.send(answer).is_ok(),
+            None => false,
+        }
+    }
+}

--- a/src-tauri/src/features/agent/mod.rs
+++ b/src-tauri/src/features/agent/mod.rs
@@ -5,6 +5,7 @@ pub mod background_commands;
 pub mod background_tasks;
 pub mod commands;
 pub mod discover;
+pub mod elicitation;
 mod events;
 pub mod models;
 pub mod permission;
@@ -19,6 +20,7 @@ pub use acp::{
     list_acp_sessions, load_acp_session, new_ids, probe_agent, run_once, warm_agent,
     PermissionPolicy,
 };
+pub use elicitation::ElicitationGate;
 pub use events::AgentEventEmitter;
 pub use permission::PermissionGate;
 pub use registry::AgentRegistry;

--- a/src-tauri/src/features/agent/mod.rs
+++ b/src-tauri/src/features/agent/mod.rs
@@ -1,6 +1,7 @@
 pub mod acp;
 #[cfg(test)]
 mod acp_tests;
+pub mod ask_user;
 pub mod background_commands;
 pub mod background_tasks;
 pub mod commands;
@@ -20,6 +21,7 @@ pub use acp::{
     list_acp_sessions, load_acp_session, new_ids, probe_agent, run_once, warm_agent,
     PermissionPolicy,
 };
+pub use ask_user::AskUserGate;
 pub use elicitation::ElicitationGate;
 pub use events::AgentEventEmitter;
 pub use permission::PermissionGate;

--- a/src-tauri/src/features/agent/models.rs
+++ b/src-tauri/src/features/agent/models.rs
@@ -275,6 +275,12 @@ pub struct RunOnceRequest {
     /// Preferred model id from ACP session config (category: model). Applied after session/new.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_id: Option<String>,
+    /// Preferred ACP permission/sandbox mode (category: mode), e.g. read-only / agent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode_id: Option<String>,
+    /// Preferred Codex-style collaboration mode (`collaboration_mode`), e.g. default / plan.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collaboration_mode_id: Option<String>,
     /// Preferred ACP reasoning effort (category: thought_level). Applied after session/new.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,
@@ -387,6 +393,38 @@ pub struct AgentFastModeEvent {
     pub enabled: bool,
 }
 
+/// One value from an ACP select-style session config option.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentModeChoice {
+    pub id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// ACP permission/sandbox mode selector (category: mode), e.g. Read-only / Agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentModesEvent {
+    pub session_id: String,
+    pub agent_id: String,
+    pub config_id: String,
+    pub current_id: String,
+    pub modes: Vec<AgentModeChoice>,
+}
+
+/// Collaboration mode selector (Codex `collaboration_mode`: Default / Plan).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCollaborationEvent {
+    pub session_id: String,
+    pub agent_id: String,
+    pub config_id: String,
+    pub current_id: String,
+    pub modes: Vec<AgentModeChoice>,
+}
+
 /// ACP tool call create/update for UI (`Tool` element).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -488,6 +526,12 @@ pub struct WarmRequest {
     pub vault_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_id: Option<String>,
+    /// Preferred ACP permission/sandbox mode (category: mode).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode_id: Option<String>,
+    /// Preferred collaboration mode (`collaboration_mode`: default / plan).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collaboration_mode_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/features/agent/models.rs
+++ b/src-tauri/src/features/agent/models.rs
@@ -275,9 +275,6 @@ pub struct RunOnceRequest {
     /// Preferred model id from ACP session config (category: model). Applied after session/new.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_id: Option<String>,
-    /// Preferred ACP permission/sandbox mode (category: mode), e.g. read-only / agent.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub mode_id: Option<String>,
     /// Preferred Codex-style collaboration mode (`collaboration_mode`), e.g. default / plan.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub collaboration_mode_id: Option<String>,
@@ -403,17 +400,6 @@ pub struct AgentModeChoice {
     pub description: Option<String>,
 }
 
-/// ACP permission/sandbox mode selector (category: mode), e.g. Read-only / Agent.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AgentModesEvent {
-    pub session_id: String,
-    pub agent_id: String,
-    pub config_id: String,
-    pub current_id: String,
-    pub modes: Vec<AgentModeChoice>,
-}
-
 /// Collaboration mode selector (Codex `collaboration_mode`: Default / Plan).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -526,9 +512,6 @@ pub struct WarmRequest {
     pub vault_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_id: Option<String>,
-    /// Preferred ACP permission/sandbox mode (category: mode).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub mode_id: Option<String>,
     /// Preferred collaboration mode (`collaboration_mode`: default / plan).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub collaboration_mode_id: Option<String>,

--- a/src-tauri/src/features/agent/registry.rs
+++ b/src-tauri/src/features/agent/registry.rs
@@ -21,13 +21,14 @@ impl AgentRegistry {
     pub fn load() -> Self {
         let path = config_path();
         let mut state = read_state(&path).unwrap_or_default();
-        let migrated = migrate_legacy_codex_agents(&mut state);
+        let migrated_codex = migrate_legacy_codex_agents(&mut state);
+        let migrated_env = migrate_catalog_env_defaults(&mut state);
         state.enabled = true;
-        if migrated {
+        if migrated_codex || migrated_env {
             if let Err(error) = persist(&path, &state) {
                 log::error!(
                     target: "agentero::agent",
-                    "failed to persist Codex registration migration: {error}"
+                    "failed to persist agent registration migration: {error}"
                 );
             }
         }
@@ -210,7 +211,17 @@ impl AgentRegistry {
                     || (a.command == info.command && a.args == info.args)
             }) {
                 let needs_refresh = existing.command != info.command || existing.args != info.args;
-                if !needs_refresh {
+                // Fill missing catalog env keys (e.g. OPENCODE_ENABLE_QUESTION_TOOL)
+                // without overwriting user values.
+                let mut merged_env = existing.env.clone();
+                let mut env_changed = false;
+                for (key, value) in &env {
+                    if !merged_env.contains_key(key) {
+                        merged_env.insert(key.clone(), value.clone());
+                        env_changed = true;
+                    }
+                }
+                if !needs_refresh && !env_changed {
                     if set_default {
                         self.set_default(Some(existing.id.clone()))?;
                         return self.get(&existing.id);
@@ -224,7 +235,7 @@ impl AgentRegistry {
                     template: Some(template_from_id(template_id)),
                     command: info.command,
                     args: info.args,
-                    env,
+                    env: merged_env,
                     set_default,
                 })?;
                 return self.get(&agent.id);
@@ -483,10 +494,35 @@ impl AgentRegistry {
     }
 }
 
+/// Default env injected when registering a catalog template (or refreshing it).
 fn catalog_env(
-    _info: &crate::features::agent::models::AgentTemplateInfo,
+    info: &crate::features::agent::models::AgentTemplateInfo,
 ) -> HashMap<String, String> {
-    HashMap::new()
+    let mut env = HashMap::new();
+    // OpenCode ACP disables the built-in `question` tool unless this is set
+    // (`OPENCODE_CLIENT=acp` + enableQuestionTool gate in OpenCode itself).
+    if info.id == AgentTemplate::Opencode.as_str() {
+        env.insert("OPENCODE_ENABLE_QUESTION_TOOL".to_string(), "1".to_string());
+    }
+    env
+}
+
+/// Merge missing catalog env keys into existing registrations (never overwrite).
+fn migrate_catalog_env_defaults(state: &mut AgentRegistryState) -> bool {
+    let mut changed = false;
+    for agent in &mut state.agents {
+        let template_id = agent.template.as_str();
+        let Some(info) = template_info(template_id) else {
+            continue;
+        };
+        for (key, value) in catalog_env(&info) {
+            if let std::collections::hash_map::Entry::Vacant(e) = agent.env.entry(key) {
+                e.insert(value);
+                changed = true;
+            }
+        }
+    }
+    changed
 }
 
 fn migrate_legacy_codex_agents(state: &mut AgentRegistryState) -> bool {

--- a/src-tauri/src/features/agent/templates.rs
+++ b/src-tauri/src/features/agent/templates.rs
@@ -23,7 +23,7 @@ pub fn builtin_templates() -> Vec<AgentTemplateInfo> {
         AgentTemplateInfo {
             id: AgentTemplate::Opencode.as_str().to_string(),
             name: "OpenCode".to_string(),
-            description: "Multi-provider coding agent with native ACP (`opencode acp`)."
+            description: "Multi-provider coding agent with native ACP (`opencode acp`). Enables the question tool via OPENCODE_ENABLE_QUESTION_TOOL."
                 .to_string(),
             command: "opencode".to_string(),
             args: vec!["acp".to_string()],

--- a/src-tauri/src/features/bridge/host.rs
+++ b/src-tauri/src/features/bridge/host.rs
@@ -936,6 +936,7 @@ async fn dispatch_agent_rpc(
                 app.state::<AgentRunController>(),
                 app.state::<PermissionGate>(),
                 app.state::<crate::features::agent::ElicitationGate>(),
+                app.state::<crate::features::agent::AskUserGate>(),
                 app.state::<std::sync::Arc<RemoteRegistry>>(),
                 request,
             )
@@ -962,6 +963,14 @@ async fn dispatch_agent_rpc(
                 serde_json::from_value(params)?;
             api_result_data(crate::features::agent::commands::agent_respond_elicitation(
                 app.state::<crate::features::agent::ElicitationGate>(),
+                request,
+            ))
+        }
+        "agent_respond_ask_user" => {
+            let request: crate::features::agent::commands::AskUserResponseRequest =
+                serde_json::from_value(params)?;
+            api_result_data(crate::features::agent::commands::agent_respond_ask_user(
+                app.state::<crate::features::agent::AskUserGate>(),
                 request,
             ))
         }

--- a/src-tauri/src/features/bridge/host.rs
+++ b/src-tauri/src/features/bridge/host.rs
@@ -935,6 +935,7 @@ async fn dispatch_agent_rpc(
                 app.state::<AgentRegistry>(),
                 app.state::<AgentRunController>(),
                 app.state::<PermissionGate>(),
+                app.state::<crate::features::agent::ElicitationGate>(),
                 app.state::<std::sync::Arc<RemoteRegistry>>(),
                 request,
             )
@@ -953,6 +954,14 @@ async fn dispatch_agent_rpc(
             let request: PermissionResponseRequest = serde_json::from_value(params)?;
             api_result_data(crate::features::agent::commands::agent_respond_permission(
                 app.state::<PermissionGate>(),
+                request,
+            ))
+        }
+        "agent_respond_elicitation" => {
+            let request: crate::features::agent::commands::ElicitationResponseRequest =
+                serde_json::from_value(params)?;
+            api_result_data(crate::features::agent::commands::agent_respond_elicitation(
+                app.state::<crate::features::agent::ElicitationGate>(),
                 request,
             ))
         }

--- a/src/components/agent/agent-ask-user-surface.tsx
+++ b/src/components/agent/agent-ask-user-surface.tsx
@@ -1,6 +1,6 @@
 /**
  * Structured ask-user UI (elicitation / Grok ext / tool-promote).
- * Renders *above* the composer resize handle so only the prompt shell is resizable.
+ * While active, replaces the bottom composer (mutually exclusive with free-text input).
  */
 import { useMemo } from "react";
 import { AskUserQuestionForm } from "@/components/agent/ask-user-question-form";
@@ -14,6 +14,29 @@ import {
 	type ToolAskUserRequest,
 } from "@/lib/agent/chat-state";
 import { cn } from "@/lib/core/utils";
+
+/** True when the panel should show a questionnaire and hide the composer. */
+export function isAskUserSurfaceActive(input: {
+	elicitationRequest: ElicitationRequest | null;
+	askUserRequest: AskUserRequest | null;
+	toolAskUserRequest: ToolAskUserRequest | null;
+}): boolean {
+	if (
+		input.elicitationRequest &&
+		questionsFromElicitationFields(input.elicitationRequest.fields).length > 0
+	) {
+		return true;
+	}
+	if (
+		input.askUserRequest &&
+		questionsFromAskUserDtos(input.askUserRequest.questions).length > 0
+	) {
+		return true;
+	}
+	return Boolean(
+		input.toolAskUserRequest && input.toolAskUserRequest.questions.length > 0,
+	);
+}
 
 export function AgentAskUserSurface({
 	elicitationRequest,
@@ -62,9 +85,10 @@ export function AgentAskUserSurface({
 
 	if (!showElicitation && !showGrokAsk && !showToolAsk) return null;
 
-	const shellClass = cn("shrink-0 bg-muted/10 px-3 pb-1 pt-0", className);
+	// Docked at panel bottom while composer is hidden — a bit more bottom inset.
+	const shellClass = cn("shrink-0 bg-muted/10 px-3 pb-3 pt-0", className);
 	const cardClass =
-		"rounded-xl border border-border  bg-muted/20 px-3 pb-3 pt-1";
+		"rounded-xl border border-border bg-muted/20 px-3 pb-3 pt-1";
 
 	if (showElicitation && elicitationRequest) {
 		const msg = elicitationRequest.message?.trim() ?? "";

--- a/src/components/agent/agent-ask-user-surface.tsx
+++ b/src/components/agent/agent-ask-user-surface.tsx
@@ -1,0 +1,159 @@
+/**
+ * Structured ask-user UI (elicitation / Grok ext / tool-promote).
+ * Renders *above* the composer resize handle so only the prompt shell is resizable.
+ */
+import { useMemo } from "react";
+import { AskUserQuestionForm } from "@/components/agent/ask-user-question-form";
+import type { AskUserRequest, ElicitationRequest } from "@/lib/agent";
+import { respondAskUser, respondElicitation } from "@/lib/agent/api";
+import {
+	elicitationContentFromAnswers,
+	formatAskUserAnswers,
+	questionsFromAskUserDtos,
+	questionsFromElicitationFields,
+	type ToolAskUserRequest,
+} from "@/lib/agent/chat-state";
+import { cn } from "@/lib/core/utils";
+
+export function AgentAskUserSurface({
+	elicitationRequest,
+	onElicitationResolved,
+	askUserRequest,
+	onAskUserResolved,
+	toolAskUserRequest,
+	onToolAskUserResolved,
+	onAnswerToolAskUser,
+	disabled = false,
+	className,
+}: {
+	elicitationRequest: ElicitationRequest | null;
+	onElicitationResolved: () => void;
+	askUserRequest: AskUserRequest | null;
+	onAskUserResolved: () => void;
+	toolAskUserRequest: ToolAskUserRequest | null;
+	onToolAskUserResolved: () => void;
+	onAnswerToolAskUser: (answer: string) => Promise<boolean>;
+	disabled?: boolean;
+	className?: string;
+}) {
+	const elicitationQuestions = useMemo(
+		() =>
+			elicitationRequest
+				? questionsFromElicitationFields(elicitationRequest.fields)
+				: [],
+		[elicitationRequest],
+	);
+	const askUserQuestions = useMemo(
+		() =>
+			askUserRequest ? questionsFromAskUserDtos(askUserRequest.questions) : [],
+		[askUserRequest],
+	);
+
+	// Priority: form elicitation > Grok ext > tool promote (one form only).
+	const showElicitation =
+		Boolean(elicitationRequest) && elicitationQuestions.length > 0;
+	const showGrokAsk =
+		!showElicitation && Boolean(askUserRequest) && askUserQuestions.length > 0;
+	const showToolAsk =
+		!showElicitation &&
+		!showGrokAsk &&
+		Boolean(toolAskUserRequest) &&
+		(toolAskUserRequest?.questions.length ?? 0) > 0;
+
+	if (!showElicitation && !showGrokAsk && !showToolAsk) return null;
+
+	const shellClass = cn("shrink-0 bg-muted/10 px-3 pb-1 pt-0", className);
+	const cardClass =
+		"rounded-xl border border-border  bg-muted/20 px-3 pb-3 pt-1";
+
+	if (showElicitation && elicitationRequest) {
+		const msg = elicitationRequest.message?.trim() ?? "";
+		const showMessage = msg.length > 0 && !/^input\s+requested\.?$/i.test(msg);
+		return (
+			<div className={shellClass}>
+				<div className={cardClass}>
+					{showMessage ? <p className="mb-2 text-sm leading-5">{msg}</p> : null}
+					<AskUserQuestionForm
+						key={elicitationRequest.requestId}
+						questions={elicitationQuestions}
+						disabled={disabled}
+						onSubmit={async (answers) => {
+							const content = elicitationContentFromAnswers(
+								elicitationQuestions,
+								answers,
+							);
+							await respondElicitation({
+								requestId: elicitationRequest.requestId,
+								action: "accept",
+								content,
+							});
+							onElicitationResolved();
+							return true;
+						}}
+						onCancel={() => {
+							void respondElicitation({
+								requestId: elicitationRequest.requestId,
+								action: "cancel",
+							}).finally(() => onElicitationResolved());
+						}}
+					/>
+				</div>
+			</div>
+		);
+	}
+
+	if (showGrokAsk && askUserRequest) {
+		return (
+			<div className={shellClass}>
+				<div className={cardClass}>
+					<AskUserQuestionForm
+						key={askUserRequest.requestId}
+						questions={askUserQuestions}
+						disabled={disabled}
+						onSubmit={async (answers) => {
+							await respondAskUser({
+								requestId: askUserRequest.requestId,
+								action: "accept",
+								answers,
+							});
+							onAskUserResolved();
+							return true;
+						}}
+						onCancel={() => {
+							void respondAskUser({
+								requestId: askUserRequest.requestId,
+								action: "cancel",
+							}).finally(() => onAskUserResolved());
+						}}
+					/>
+				</div>
+			</div>
+		);
+	}
+
+	if (showToolAsk && toolAskUserRequest) {
+		return (
+			<div className={shellClass}>
+				<div className={cardClass}>
+					<AskUserQuestionForm
+						key={toolAskUserRequest.toolCallId}
+						questions={toolAskUserRequest.questions}
+						disabled={disabled}
+						onSubmit={async (answers) => {
+							const text = formatAskUserAnswers(
+								toolAskUserRequest.questions,
+								answers,
+							);
+							return onAnswerToolAskUser(text);
+						}}
+						onCancel={() => {
+							onToolAskUserResolved();
+						}}
+					/>
+				</div>
+			</div>
+		);
+	}
+
+	return null;
+}

--- a/src/components/agent/agent-composer.tsx
+++ b/src/components/agent/agent-composer.tsx
@@ -314,7 +314,7 @@ export function AgentComposer({
 	slashActiveIndex,
 	onAttachSlashCommand,
 	onSlashActiveIndexChange,
-	// Model / mode / collaboration / effort / usage / fast
+	// Model / collaboration (session mode) / effort / usage / fast
 	modelSelectorOpen,
 	onModelSelectorOpenChange,
 	models,
@@ -325,10 +325,6 @@ export function AgentComposer({
 	warming,
 	onPickModel,
 	onToggleFavorite,
-	modeOptions,
-	modeId,
-	selectedModeName,
-	onPickMode,
 	collaborationOptions,
 	collaborationModeId,
 	selectedCollaborationName,
@@ -406,10 +402,6 @@ export function AgentComposer({
 	warming: boolean;
 	onPickModel: (id: string) => void;
 	onToggleFavorite: (id: string) => void;
-	modeOptions: AgentModeChoice[];
-	modeId: string | null;
-	selectedModeName: string | null;
-	onPickMode: (id: string) => void;
 	collaborationOptions: AgentModeChoice[];
 	collaborationModeId: string | null;
 	selectedCollaborationName: string | null;
@@ -1220,62 +1212,14 @@ export function AgentComposer({
 											<DropdownMenuItem
 												key={mode.id}
 												className={cn(
-													"flex flex-col items-start gap-0.5 rounded-md",
+													"flex items-center justify-between gap-2 rounded-md",
 													collaborationModeId === mode.id && "bg-muted",
 												)}
 												onSelect={() => onPickCollaborationMode(mode.id)}
 											>
-												<span className="flex w-full items-center justify-between gap-2">
-													<span className="truncate">{mode.name}</span>
-													{collaborationModeId === mode.id ? (
-														<CheckIcon className="size-3.5 shrink-0 text-muted-foreground" />
-													) : null}
-												</span>
-												{mode.description ? (
-													<span className="text-muted-foreground text-xs leading-snug">
-														{mode.description}
-													</span>
-												) : null}
-											</DropdownMenuItem>
-										))}
-									</DropdownMenuContent>
-								</DropdownMenu>
-							) : null}
-							{!compact && modeOptions.length > 0 ? (
-								<DropdownMenu>
-									<DropdownMenuTrigger asChild>
-										<PromptInputButton
-											type="button"
-											className="h-7 max-w-[min(10rem,100%)] gap-1 px-1.5 text-xs font-medium text-foreground"
-											tooltip={t("composer.modeTooltip")}
-										>
-											<span className="truncate">
-												{t("composer.mode.label")}:{" "}
-												{selectedModeName ?? modeId ?? t("composer.mode.label")}
-											</span>
-											<ChevronDown className="size-3 shrink-0 opacity-70" />
-										</PromptInputButton>
-									</DropdownMenuTrigger>
-									<DropdownMenuContent align="start" className="min-w-36 p-1">
-										{modeOptions.map((mode) => (
-											<DropdownMenuItem
-												key={mode.id}
-												className={cn(
-													"flex flex-col items-start gap-0.5 rounded-md",
-													modeId === mode.id && "bg-muted",
-												)}
-												onSelect={() => onPickMode(mode.id)}
-											>
-												<span className="flex w-full items-center justify-between gap-2">
-													<span className="truncate">{mode.name}</span>
-													{modeId === mode.id ? (
-														<CheckIcon className="size-3.5 shrink-0 text-muted-foreground" />
-													) : null}
-												</span>
-												{mode.description ? (
-													<span className="text-muted-foreground text-xs leading-snug">
-														{mode.description}
-													</span>
+												<span className="truncate">{mode.name}</span>
+												{collaborationModeId === mode.id ? (
+													<CheckIcon className="size-3.5 shrink-0 text-muted-foreground" />
 												) : null}
 											</DropdownMenuItem>
 										))}

--- a/src/components/agent/agent-composer.tsx
+++ b/src/components/agent/agent-composer.tsx
@@ -11,8 +11,9 @@ import {
 	Zap,
 } from "lucide-react";
 import type { KeyboardEvent, DragEvent as ReactDragEvent } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { AskUserQuestionForm } from "@/components/agent/ask-user-question-form";
 import { ContextPathIcon } from "@/components/agent/context-path-icon";
 import type { QueuedPrompt } from "@/components/agent/types";
 import {
@@ -68,11 +69,19 @@ import {
 } from "@/components/ui/popover";
 import type {
 	AgentEffortChoice,
+	AgentModeChoice,
 	AgentModelChoice,
 	AgentSkill,
+	ElicitationRequest,
 	PromptImage,
 } from "@/lib/agent";
-import { SUGGESTION_KEYS, SUGGESTION_WORKFLOW } from "@/lib/agent/chat-state";
+import { respondElicitation } from "@/lib/agent/api";
+import {
+	elicitationContentFromAnswers,
+	questionsFromElicitationFields,
+	SUGGESTION_KEYS,
+	SUGGESTION_WORKFLOW,
+} from "@/lib/agent/chat-state";
 import { mentionPathHasChildren } from "@/lib/agent/mention";
 import {
 	COMPOSER_IMAGE_ACCEPT,
@@ -313,7 +322,7 @@ export function AgentComposer({
 	slashActiveIndex,
 	onAttachSlashCommand,
 	onSlashActiveIndexChange,
-	// Model / effort / usage / fast
+	// Model / mode / collaboration / effort / usage / fast
 	modelSelectorOpen,
 	onModelSelectorOpenChange,
 	models,
@@ -324,6 +333,14 @@ export function AgentComposer({
 	warming,
 	onPickModel,
 	onToggleFavorite,
+	modeOptions,
+	modeId,
+	selectedModeName,
+	onPickMode,
+	collaborationOptions,
+	collaborationModeId,
+	selectedCollaborationName,
+	onPickCollaborationMode,
 	effortOptionsInDisplayOrder,
 	reasoningEffort,
 	onReasoningEffortChange,
@@ -336,6 +353,9 @@ export function AgentComposer({
 	onCancelRun,
 	messageQueue,
 	onRemoveQueuedMessage,
+	// Form elicitation (Codex request_user_input) — same UI as AskUserQuestion
+	elicitationRequest,
+	onElicitationResolved,
 	// Follow-up suggestions
 	onSendSuggestion,
 }: {
@@ -397,6 +417,14 @@ export function AgentComposer({
 	warming: boolean;
 	onPickModel: (id: string) => void;
 	onToggleFavorite: (id: string) => void;
+	modeOptions: AgentModeChoice[];
+	modeId: string | null;
+	selectedModeName: string | null;
+	onPickMode: (id: string) => void;
+	collaborationOptions: AgentModeChoice[];
+	collaborationModeId: string | null;
+	selectedCollaborationName: string | null;
+	onPickCollaborationMode: (id: string) => void;
 	effortOptionsInDisplayOrder: AgentEffortChoice[];
 	reasoningEffort: string | null;
 	onReasoningEffortChange: (id: string) => void;
@@ -406,6 +434,8 @@ export function AgentComposer({
 	fastEnabled: boolean;
 	onFastEnabledToggle: () => void;
 	onCancelRun: () => void;
+	elicitationRequest: ElicitationRequest | null;
+	onElicitationResolved: () => void;
 	onSendSuggestion: (label: string, workflow?: string) => void;
 }) {
 	const { t } = useTranslation("agent");
@@ -414,6 +444,13 @@ export function AgentComposer({
 	// Attachments live inside PromptInput; base gate ignores them (see ComposerSubmitControl).
 	const canSubmitBase = hasComposerText || hasVisualDrafts;
 	const composerMenuOpen = showMentionMenu || showSkillMenu || showSlashMenu;
+	const elicitationQuestions = useMemo(
+		() =>
+			elicitationRequest
+				? questionsFromElicitationFields(elicitationRequest.fields)
+				: [],
+		[elicitationRequest],
+	);
 	// Nested enter/leave counter so moving over chips/textarea does not flicker the drop ring.
 	const fileDragDepthRef = useRef(0);
 	const [isFileDragOver, setIsFileDragOver] = useState(false);
@@ -472,13 +509,21 @@ export function AgentComposer({
 		};
 	}, [isFileDragOver, resetFileDragHighlight]);
 
+	const hasElicitation =
+		Boolean(elicitationRequest) && elicitationQuestions.length > 0;
+	// Questionnaire needs room; grow the fixed composer so the card can scroll.
+	const shellHeightPx =
+		heightPx && hasElicitation
+			? Math.max(heightPx, Math.min(420, Math.round(heightPx * 1.85)))
+			: heightPx;
+
 	return (
 		<div
 			className={cn(
 				"flex shrink-0 flex-col overflow-hidden border-t bg-muted/10",
 				compact ? "gap-1.5 p-2" : "gap-2 p-3",
 			)}
-			style={heightPx ? { height: heightPx } : undefined}
+			style={shellHeightPx ? { height: shellHeightPx } : undefined}
 		>
 			{linesLength > 0 && !activeTabIsRunning && !compact ? (
 				<Suggestions>
@@ -543,6 +588,49 @@ export function AgentComposer({
 						</QueueSectionContent>
 					</QueueSection>
 				</Queue>
+			) : null}
+			{elicitationRequest && elicitationQuestions.length > 0 ? (
+				<div
+					className={cn(
+						// Cap height inside the fixed composer; scroll body so options are reachable.
+						"min-h-0 max-h-[min(55%,22rem)] shrink overflow-y-auto overscroll-contain rounded-xl border border-border bg-muted/20",
+						compact ? "p-2" : "p-3",
+					)}
+				>
+					{(() => {
+						const msg = elicitationRequest.message?.trim() ?? "";
+						// Codex uses a generic "Input requested" when batching questions.
+						const showMessage =
+							msg.length > 0 && !/^input\s+requested\.?$/i.test(msg);
+						return showMessage ? (
+							<p className="mb-2 text-sm leading-5">{msg}</p>
+						) : null;
+					})()}
+					<AskUserQuestionForm
+						key={elicitationRequest.requestId}
+						questions={elicitationQuestions}
+						disabled={switching}
+						onSubmit={async (answers) => {
+							const content = elicitationContentFromAnswers(
+								elicitationQuestions,
+								answers,
+							);
+							await respondElicitation({
+								requestId: elicitationRequest.requestId,
+								action: "accept",
+								content,
+							});
+							onElicitationResolved();
+							return true;
+						}}
+						onCancel={() => {
+							void respondElicitation({
+								requestId: elicitationRequest.requestId,
+								action: "cancel",
+							}).finally(() => onElicitationResolved());
+						}}
+					/>
+				</div>
 			) : null}
 			<div className="relative min-h-0 flex-1">
 				<PromptInput
@@ -1180,6 +1268,90 @@ export function AgentComposer({
 									</ModelSelectorContent>
 								</ModelSelector>
 							)}
+							{!compact && collaborationOptions.length > 0 ? (
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild>
+										<PromptInputButton
+											type="button"
+											className="h-7 max-w-[min(10rem,100%)] gap-1 px-1.5 text-xs font-medium text-foreground"
+											tooltip={t("composer.collaborationTooltip")}
+										>
+											<span className="truncate">
+												{t("composer.collaboration.label")}:{" "}
+												{selectedCollaborationName ??
+													collaborationModeId ??
+													t("composer.collaboration.label")}
+											</span>
+											<ChevronDown className="size-3 shrink-0 opacity-70" />
+										</PromptInputButton>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent align="start" className="min-w-36 p-1">
+										{collaborationOptions.map((mode) => (
+											<DropdownMenuItem
+												key={mode.id}
+												className={cn(
+													"flex flex-col items-start gap-0.5 rounded-md",
+													collaborationModeId === mode.id && "bg-muted",
+												)}
+												onSelect={() => onPickCollaborationMode(mode.id)}
+											>
+												<span className="flex w-full items-center justify-between gap-2">
+													<span className="truncate">{mode.name}</span>
+													{collaborationModeId === mode.id ? (
+														<CheckIcon className="size-3.5 shrink-0 text-muted-foreground" />
+													) : null}
+												</span>
+												{mode.description ? (
+													<span className="text-muted-foreground text-xs leading-snug">
+														{mode.description}
+													</span>
+												) : null}
+											</DropdownMenuItem>
+										))}
+									</DropdownMenuContent>
+								</DropdownMenu>
+							) : null}
+							{!compact && modeOptions.length > 0 ? (
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild>
+										<PromptInputButton
+											type="button"
+											className="h-7 max-w-[min(10rem,100%)] gap-1 px-1.5 text-xs font-medium text-foreground"
+											tooltip={t("composer.modeTooltip")}
+										>
+											<span className="truncate">
+												{t("composer.mode.label")}:{" "}
+												{selectedModeName ?? modeId ?? t("composer.mode.label")}
+											</span>
+											<ChevronDown className="size-3 shrink-0 opacity-70" />
+										</PromptInputButton>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent align="start" className="min-w-36 p-1">
+										{modeOptions.map((mode) => (
+											<DropdownMenuItem
+												key={mode.id}
+												className={cn(
+													"flex flex-col items-start gap-0.5 rounded-md",
+													modeId === mode.id && "bg-muted",
+												)}
+												onSelect={() => onPickMode(mode.id)}
+											>
+												<span className="flex w-full items-center justify-between gap-2">
+													<span className="truncate">{mode.name}</span>
+													{modeId === mode.id ? (
+														<CheckIcon className="size-3.5 shrink-0 text-muted-foreground" />
+													) : null}
+												</span>
+												{mode.description ? (
+													<span className="text-muted-foreground text-xs leading-snug">
+														{mode.description}
+													</span>
+												) : null}
+											</DropdownMenuItem>
+										))}
+									</DropdownMenuContent>
+								</DropdownMenu>
+							) : null}
 							{!compact && effortOptionsInDisplayOrder.length > 0 ? (
 								<DropdownMenu>
 									<DropdownMenuTrigger asChild>

--- a/src/components/agent/agent-composer.tsx
+++ b/src/components/agent/agent-composer.tsx
@@ -11,9 +11,8 @@ import {
 	Zap,
 } from "lucide-react";
 import type { KeyboardEvent, DragEvent as ReactDragEvent } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { AskUserQuestionForm } from "@/components/agent/ask-user-question-form";
 import { ContextPathIcon } from "@/components/agent/context-path-icon";
 import type { QueuedPrompt } from "@/components/agent/types";
 import {
@@ -72,16 +71,9 @@ import type {
 	AgentModeChoice,
 	AgentModelChoice,
 	AgentSkill,
-	ElicitationRequest,
 	PromptImage,
 } from "@/lib/agent";
-import { respondElicitation } from "@/lib/agent/api";
-import {
-	elicitationContentFromAnswers,
-	questionsFromElicitationFields,
-	SUGGESTION_KEYS,
-	SUGGESTION_WORKFLOW,
-} from "@/lib/agent/chat-state";
+import { SUGGESTION_KEYS, SUGGESTION_WORKFLOW } from "@/lib/agent/chat-state";
 import { mentionPathHasChildren } from "@/lib/agent/mention";
 import {
 	COMPOSER_IMAGE_ACCEPT,
@@ -353,9 +345,6 @@ export function AgentComposer({
 	onCancelRun,
 	messageQueue,
 	onRemoveQueuedMessage,
-	// Form elicitation (Codex request_user_input) — same UI as AskUserQuestion
-	elicitationRequest,
-	onElicitationResolved,
 	// Follow-up suggestions
 	onSendSuggestion,
 }: {
@@ -434,8 +423,6 @@ export function AgentComposer({
 	fastEnabled: boolean;
 	onFastEnabledToggle: () => void;
 	onCancelRun: () => void;
-	elicitationRequest: ElicitationRequest | null;
-	onElicitationResolved: () => void;
 	onSendSuggestion: (label: string, workflow?: string) => void;
 }) {
 	const { t } = useTranslation("agent");
@@ -444,13 +431,6 @@ export function AgentComposer({
 	// Attachments live inside PromptInput; base gate ignores them (see ComposerSubmitControl).
 	const canSubmitBase = hasComposerText || hasVisualDrafts;
 	const composerMenuOpen = showMentionMenu || showSkillMenu || showSlashMenu;
-	const elicitationQuestions = useMemo(
-		() =>
-			elicitationRequest
-				? questionsFromElicitationFields(elicitationRequest.fields)
-				: [],
-		[elicitationRequest],
-	);
 	// Nested enter/leave counter so moving over chips/textarea does not flicker the drop ring.
 	const fileDragDepthRef = useRef(0);
 	const [isFileDragOver, setIsFileDragOver] = useState(false);
@@ -509,21 +489,14 @@ export function AgentComposer({
 		};
 	}, [isFileDragOver, resetFileDragHighlight]);
 
-	const hasElicitation =
-		Boolean(elicitationRequest) && elicitationQuestions.length > 0;
-	// Questionnaire needs room; grow the fixed composer so the card can scroll.
-	const shellHeightPx =
-		heightPx && hasElicitation
-			? Math.max(heightPx, Math.min(420, Math.round(heightPx * 1.85)))
-			: heightPx;
-
 	return (
 		<div
 			className={cn(
+				// Only the prompt shell is height-bound (resize handle is above this in the panel).
 				"flex shrink-0 flex-col overflow-hidden border-t bg-muted/10",
 				compact ? "gap-1.5 p-2" : "gap-2 p-3",
 			)}
-			style={shellHeightPx ? { height: shellHeightPx } : undefined}
+			style={heightPx ? { height: heightPx } : undefined}
 		>
 			{linesLength > 0 && !activeTabIsRunning && !compact ? (
 				<Suggestions>
@@ -588,49 +561,6 @@ export function AgentComposer({
 						</QueueSectionContent>
 					</QueueSection>
 				</Queue>
-			) : null}
-			{elicitationRequest && elicitationQuestions.length > 0 ? (
-				<div
-					className={cn(
-						// Cap height inside the fixed composer; scroll body so options are reachable.
-						"min-h-0 max-h-[min(55%,22rem)] shrink overflow-y-auto overscroll-contain rounded-xl border border-border bg-muted/20",
-						compact ? "p-2" : "p-3",
-					)}
-				>
-					{(() => {
-						const msg = elicitationRequest.message?.trim() ?? "";
-						// Codex uses a generic "Input requested" when batching questions.
-						const showMessage =
-							msg.length > 0 && !/^input\s+requested\.?$/i.test(msg);
-						return showMessage ? (
-							<p className="mb-2 text-sm leading-5">{msg}</p>
-						) : null;
-					})()}
-					<AskUserQuestionForm
-						key={elicitationRequest.requestId}
-						questions={elicitationQuestions}
-						disabled={switching}
-						onSubmit={async (answers) => {
-							const content = elicitationContentFromAnswers(
-								elicitationQuestions,
-								answers,
-							);
-							await respondElicitation({
-								requestId: elicitationRequest.requestId,
-								action: "accept",
-								content,
-							});
-							onElicitationResolved();
-							return true;
-						}}
-						onCancel={() => {
-							void respondElicitation({
-								requestId: elicitationRequest.requestId,
-								action: "cancel",
-							}).finally(() => onElicitationResolved());
-						}}
-					/>
-				</div>
 			) : null}
 			<div className="relative min-h-0 flex-1">
 				<PromptInput

--- a/src/components/agent/agent-panel.tsx
+++ b/src/components/agent/agent-panel.tsx
@@ -220,10 +220,6 @@ export const AgentPanel = memo(function AgentPanel({
 		warming,
 		pickModel,
 		toggleFavorite,
-		modeOptions,
-		modeId,
-		selectedModeName,
-		pickMode,
 		collaborationOptions,
 		collaborationModeId,
 		selectedCollaborationName,
@@ -417,10 +413,6 @@ export const AgentPanel = memo(function AgentPanel({
 								warming={warming}
 								onPickModel={pickModel}
 								onToggleFavorite={toggleFavorite}
-								modeOptions={modeOptions}
-								modeId={modeId}
-								selectedModeName={selectedModeName}
-								onPickMode={pickMode}
 								collaborationOptions={collaborationOptions}
 								collaborationModeId={collaborationModeId}
 								selectedCollaborationName={selectedCollaborationName}

--- a/src/components/agent/agent-panel.tsx
+++ b/src/components/agent/agent-panel.tsx
@@ -216,6 +216,14 @@ export const AgentPanel = memo(function AgentPanel({
 		warming,
 		pickModel,
 		toggleFavorite,
+		modeOptions,
+		modeId,
+		selectedModeName,
+		pickMode,
+		collaborationOptions,
+		collaborationModeId,
+		selectedCollaborationName,
+		pickCollaborationMode,
 		effortOptionsInDisplayOrder,
 		reasoningEffort,
 		setReasoningEffort,
@@ -227,6 +235,8 @@ export const AgentPanel = memo(function AgentPanel({
 		cancelCurrentRun,
 		permissionRequest,
 		setPermissionRequest,
+		elicitationRequest,
+		setElicitationRequest,
 		switchingRef,
 		submittingRef,
 	} = panel;
@@ -376,6 +386,14 @@ export const AgentPanel = memo(function AgentPanel({
 						warming={warming}
 						onPickModel={pickModel}
 						onToggleFavorite={toggleFavorite}
+						modeOptions={modeOptions}
+						modeId={modeId}
+						selectedModeName={selectedModeName}
+						onPickMode={pickMode}
+						collaborationOptions={collaborationOptions}
+						collaborationModeId={collaborationModeId}
+						selectedCollaborationName={selectedCollaborationName}
+						onPickCollaborationMode={pickCollaborationMode}
 						effortOptionsInDisplayOrder={effortOptionsInDisplayOrder}
 						reasoningEffort={reasoningEffort}
 						onReasoningEffortChange={setReasoningEffort}
@@ -385,6 +403,8 @@ export const AgentPanel = memo(function AgentPanel({
 						fastEnabled={fastEnabled}
 						onFastEnabledToggle={() => setFastEnabled((current) => !current)}
 						onCancelRun={() => void cancelCurrentRun()}
+						elicitationRequest={elicitationRequest}
+						onElicitationResolved={() => setElicitationRequest(null)}
 						onSendSuggestion={sendSuggestion}
 					/>
 				</div>

--- a/src/components/agent/agent-panel.tsx
+++ b/src/components/agent/agent-panel.tsx
@@ -3,7 +3,10 @@ import type {
 	PointerEvent as ReactPointerEvent,
 } from "react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
-import { AgentAskUserSurface } from "@/components/agent/agent-ask-user-surface";
+import {
+	AgentAskUserSurface,
+	isAskUserSurfaceActive,
+} from "@/components/agent/agent-ask-user-surface";
 import { AgentComposer } from "@/components/agent/agent-composer";
 import { SidebarHistoryTrailing } from "@/components/agent/agent-history";
 import { AgentPermissionDialog } from "@/components/agent/agent-permission-dialog";
@@ -247,6 +250,13 @@ export const AgentPanel = memo(function AgentPanel({
 		submittingRef,
 	} = panel;
 
+	// Questionnaire and free-text composer are mutually exclusive.
+	const askUserActive = isAskUserSurfaceActive({
+		elicitationRequest,
+		askUserRequest,
+		toolAskUserRequest,
+	});
+
 	const sendSuggestion = (label: string, workflow?: string) => {
 		void submitComposer(label, workflow);
 	};
@@ -303,7 +313,7 @@ export const AgentPanel = memo(function AgentPanel({
 						onOpenSource={onOpenSource}
 					/>
 
-					{/* Questionnaire lives above the resize handle — only the prompt shell resizes. */}
+					{/* Questionnaire replaces the composer until submit/cancel. */}
 					<AgentAskUserSurface
 						elicitationRequest={elicitationRequest}
 						onElicitationResolved={() => setElicitationRequest(null)}
@@ -315,113 +325,121 @@ export const AgentPanel = memo(function AgentPanel({
 						disabled={switching}
 					/>
 
-					<button
-						type="button"
-						aria-label={t("composer.resizeHandle")}
-						title={t("composer.resizeHandle")}
-						className="group relative h-2 shrink-0 cursor-row-resize touch-none bg-muted/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-						onPointerDown={onComposerResizePointerDown}
-						onKeyDown={onComposerResizeKeyDown}
-					>
-						<div className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-1/2 h-px w-12 rounded-full bg-border transition-colors group-hover:bg-foreground/35 group-active:bg-foreground/45" />
-					</button>
+					{!askUserActive ? (
+						<>
+							<button
+								type="button"
+								aria-label={t("composer.resizeHandle")}
+								title={t("composer.resizeHandle")}
+								className="group relative h-2 shrink-0 cursor-row-resize touch-none bg-muted/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+								onPointerDown={onComposerResizePointerDown}
+								onKeyDown={onComposerResizeKeyDown}
+							>
+								<div className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-1/2 h-px w-12 rounded-full bg-border transition-colors group-hover:bg-foreground/35 group-active:bg-foreground/45" />
+							</button>
 
-					<AgentComposer
-						autoFocus={autoFocus}
-						heightPx={composerHeightPx}
-						compact={composerCompact}
-						linesLength={lines.length}
-						activeTabIsRunning={activeTabIsRunning}
-						switching={switching}
-						submitting={submitting}
-						composerText={composerText}
-						onComposerTextChange={(text) => {
-							onComposerTextChangeFromUser(text);
-							setComposerMenuDismissed(false);
-							setMentionActiveIndex(0);
-							setSkillActiveIndex(0);
-							setSlashActiveIndex(0);
-						}}
-						onSubmit={async (text, images) => {
-							if (switchingRef.current || submittingRef.current) {
-								// Keep PromptInput attachments when the submit is rejected.
-								throw new Error("composer busy");
-							}
-							const ok = await submitComposer(text, undefined, images);
-							if (!ok) {
-								// Preserve pasted/picked images when send early-returns (e.g. no agent).
-								throw new Error("composer submit rejected");
-							}
-						}}
-						onComposerKeyDown={handleComposerMenuKeyDown}
-						onComposerDragOver={handleComposerDragOver}
-						onComposerDrop={handleComposerDrop}
-						onDismissComposerMenu={() => setComposerMenuDismissed(true)}
-						messageQueue={messageQueue}
-						onRemoveQueuedMessage={removeQueuedMessage}
-						currentFilePath={currentFilePath}
-						currentFileLabel={currentFileLabel}
-						mentionChipPaths={mentionChipPaths}
-						selectionChips={selectionChips}
-						onRemoveSelection={removeSelection}
-						visualDrafts={visualDrafts}
-						onRemoveVisualDraft={removeVisualDraft}
-						directoryPathSet={directoryPathSet}
-						paperPathSet={paperPathSet}
-						labelForPath={labelForPath}
-						onRemoveContextPath={removeContextPath}
-						selectedSkills={selectedSkills}
-						onRemoveSkill={(skillId) =>
-							setSelectedSkillIds((prev) => prev.filter((id) => id !== skillId))
-						}
-						showMentionMenu={showMentionMenu}
-						mentionBrowseRoot={mentionBrowseRoot}
-						mentionOptions={mentionOptions}
-						mentionActiveIndex={mentionActiveIndex}
-						mentionCandidates={mentionCandidates}
-						onLeaveMentionFolder={leaveMentionFolder}
-						onEnterMentionFolder={enterMentionFolder}
-						onAttachMention={attachMention}
-						onMentionActiveIndexChange={setMentionActiveIndex}
-						showSkillMenu={showSkillMenu}
-						skillOptions={skillOptions}
-						skillActiveIndex={skillActiveIndex}
-						onAttachSkill={attachSkill}
-						onSkillActiveIndexChange={setSkillActiveIndex}
-						showSlashMenu={showSlashMenu}
-						slashOptions={slashOptions}
-						slashActiveIndex={slashActiveIndex}
-						onAttachSlashCommand={attachSlashCommand}
-						onSlashActiveIndexChange={setSlashActiveIndex}
-						modelSelectorOpen={modelSelectorOpen}
-						onModelSelectorOpenChange={setModelSelectorOpen}
-						models={models}
-						groupedModels={groupedModels}
-						modelId={modelId}
-						selectedModelName={selectedModelName}
-						favoriteIds={favoriteIds}
-						warming={warming}
-						onPickModel={pickModel}
-						onToggleFavorite={toggleFavorite}
-						modeOptions={modeOptions}
-						modeId={modeId}
-						selectedModeName={selectedModeName}
-						onPickMode={pickMode}
-						collaborationOptions={collaborationOptions}
-						collaborationModeId={collaborationModeId}
-						selectedCollaborationName={selectedCollaborationName}
-						onPickCollaborationMode={pickCollaborationMode}
-						effortOptionsInDisplayOrder={effortOptionsInDisplayOrder}
-						reasoningEffort={reasoningEffort}
-						onReasoningEffortChange={setReasoningEffort}
-						formatEffort={formatEffort}
-						activeUsage={activeUsage}
-						fastAvailable={fastAvailable}
-						fastEnabled={fastEnabled}
-						onFastEnabledToggle={() => setFastEnabled((current) => !current)}
-						onCancelRun={() => void cancelCurrentRun()}
-						onSendSuggestion={sendSuggestion}
-					/>
+							<AgentComposer
+								autoFocus={autoFocus}
+								heightPx={composerHeightPx}
+								compact={composerCompact}
+								linesLength={lines.length}
+								activeTabIsRunning={activeTabIsRunning}
+								switching={switching}
+								submitting={submitting}
+								composerText={composerText}
+								onComposerTextChange={(text) => {
+									onComposerTextChangeFromUser(text);
+									setComposerMenuDismissed(false);
+									setMentionActiveIndex(0);
+									setSkillActiveIndex(0);
+									setSlashActiveIndex(0);
+								}}
+								onSubmit={async (text, images) => {
+									if (switchingRef.current || submittingRef.current) {
+										// Keep PromptInput attachments when the submit is rejected.
+										throw new Error("composer busy");
+									}
+									const ok = await submitComposer(text, undefined, images);
+									if (!ok) {
+										// Preserve pasted/picked images when send early-returns (e.g. no agent).
+										throw new Error("composer submit rejected");
+									}
+								}}
+								onComposerKeyDown={handleComposerMenuKeyDown}
+								onComposerDragOver={handleComposerDragOver}
+								onComposerDrop={handleComposerDrop}
+								onDismissComposerMenu={() => setComposerMenuDismissed(true)}
+								messageQueue={messageQueue}
+								onRemoveQueuedMessage={removeQueuedMessage}
+								currentFilePath={currentFilePath}
+								currentFileLabel={currentFileLabel}
+								mentionChipPaths={mentionChipPaths}
+								selectionChips={selectionChips}
+								onRemoveSelection={removeSelection}
+								visualDrafts={visualDrafts}
+								onRemoveVisualDraft={removeVisualDraft}
+								directoryPathSet={directoryPathSet}
+								paperPathSet={paperPathSet}
+								labelForPath={labelForPath}
+								onRemoveContextPath={removeContextPath}
+								selectedSkills={selectedSkills}
+								onRemoveSkill={(skillId) =>
+									setSelectedSkillIds((prev) =>
+										prev.filter((id) => id !== skillId),
+									)
+								}
+								showMentionMenu={showMentionMenu}
+								mentionBrowseRoot={mentionBrowseRoot}
+								mentionOptions={mentionOptions}
+								mentionActiveIndex={mentionActiveIndex}
+								mentionCandidates={mentionCandidates}
+								onLeaveMentionFolder={leaveMentionFolder}
+								onEnterMentionFolder={enterMentionFolder}
+								onAttachMention={attachMention}
+								onMentionActiveIndexChange={setMentionActiveIndex}
+								showSkillMenu={showSkillMenu}
+								skillOptions={skillOptions}
+								skillActiveIndex={skillActiveIndex}
+								onAttachSkill={attachSkill}
+								onSkillActiveIndexChange={setSkillActiveIndex}
+								showSlashMenu={showSlashMenu}
+								slashOptions={slashOptions}
+								slashActiveIndex={slashActiveIndex}
+								onAttachSlashCommand={attachSlashCommand}
+								onSlashActiveIndexChange={setSlashActiveIndex}
+								modelSelectorOpen={modelSelectorOpen}
+								onModelSelectorOpenChange={setModelSelectorOpen}
+								models={models}
+								groupedModels={groupedModels}
+								modelId={modelId}
+								selectedModelName={selectedModelName}
+								favoriteIds={favoriteIds}
+								warming={warming}
+								onPickModel={pickModel}
+								onToggleFavorite={toggleFavorite}
+								modeOptions={modeOptions}
+								modeId={modeId}
+								selectedModeName={selectedModeName}
+								onPickMode={pickMode}
+								collaborationOptions={collaborationOptions}
+								collaborationModeId={collaborationModeId}
+								selectedCollaborationName={selectedCollaborationName}
+								onPickCollaborationMode={pickCollaborationMode}
+								effortOptionsInDisplayOrder={effortOptionsInDisplayOrder}
+								reasoningEffort={reasoningEffort}
+								onReasoningEffortChange={setReasoningEffort}
+								formatEffort={formatEffort}
+								activeUsage={activeUsage}
+								fastAvailable={fastAvailable}
+								fastEnabled={fastEnabled}
+								onFastEnabledToggle={() =>
+									setFastEnabled((current) => !current)
+								}
+								onCancelRun={() => void cancelCurrentRun()}
+								onSendSuggestion={sendSuggestion}
+							/>
+						</>
+					) : null}
 				</div>
 			</div>
 

--- a/src/components/agent/agent-panel.tsx
+++ b/src/components/agent/agent-panel.tsx
@@ -3,6 +3,7 @@ import type {
 	PointerEvent as ReactPointerEvent,
 } from "react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { AgentAskUserSurface } from "@/components/agent/agent-ask-user-surface";
 import { AgentComposer } from "@/components/agent/agent-composer";
 import { SidebarHistoryTrailing } from "@/components/agent/agent-history";
 import { AgentPermissionDialog } from "@/components/agent/agent-permission-dialog";
@@ -237,6 +238,11 @@ export const AgentPanel = memo(function AgentPanel({
 		setPermissionRequest,
 		elicitationRequest,
 		setElicitationRequest,
+		askUserRequest,
+		setAskUserRequest,
+		toolAskUserRequest,
+		setToolAskUserRequest,
+		answerToolAskUser,
 		switchingRef,
 		submittingRef,
 	} = panel;
@@ -294,8 +300,19 @@ export const AgentPanel = memo(function AgentPanel({
 						onResendEdited={(lineId) => void resendEditedMessage(lineId)}
 						onStartEditing={startEditingMessage}
 						onSendSuggestion={sendSuggestion}
-						onAnswerQuestion={submitComposer}
 						onOpenSource={onOpenSource}
+					/>
+
+					{/* Questionnaire lives above the resize handle — only the prompt shell resizes. */}
+					<AgentAskUserSurface
+						elicitationRequest={elicitationRequest}
+						onElicitationResolved={() => setElicitationRequest(null)}
+						askUserRequest={askUserRequest}
+						onAskUserResolved={() => setAskUserRequest(null)}
+						toolAskUserRequest={toolAskUserRequest}
+						onToolAskUserResolved={() => setToolAskUserRequest(null)}
+						onAnswerToolAskUser={answerToolAskUser}
+						disabled={switching}
 					/>
 
 					<button
@@ -403,8 +420,6 @@ export const AgentPanel = memo(function AgentPanel({
 						fastEnabled={fastEnabled}
 						onFastEnabledToggle={() => setFastEnabled((current) => !current)}
 						onCancelRun={() => void cancelCurrentRun()}
-						elicitationRequest={elicitationRequest}
-						onElicitationResolved={() => setElicitationRequest(null)}
 						onSendSuggestion={sendSuggestion}
 					/>
 				</div>

--- a/src/components/agent/ask-user-question-form.tsx
+++ b/src/components/agent/ask-user-question-form.tsx
@@ -1,9 +1,9 @@
 /**
  * Shared AskUserQuestion UI (AI Elements Suggestion chips).
- * Used by:
- * - ACP tool cards (Codex / Claude / OpenCode / Grok-shaped rawInput)
- * - ACP form elicitation (Codex request_user_input) above the composer
- * - Grok ext / tool-promoted asks in the composer
+ * Used by AgentAskUserSurface (bottom dock; replaces free-text composer while open):
+ * - ACP tool promote (Codex / Claude / OpenCode / Grok-shaped rawInput)
+ * - ACP form elicitation (Codex request_user_input)
+ * - Grok ext `_x.ai/ask_user_question`
  *
  * Multi-question UX is paginated: one question per page, prev/next, Submit on last.
  * Options + optional free-text "Other" stay on the same page.

--- a/src/components/agent/ask-user-question-form.tsx
+++ b/src/components/agent/ask-user-question-form.tsx
@@ -1,20 +1,60 @@
 /**
  * Shared AskUserQuestion UI (AI Elements Suggestion chips).
  * Used by:
- * - ACP tool cards with variant AskUserQuestion
+ * - ACP tool cards (Codex / Claude / OpenCode / Grok-shaped rawInput)
  * - ACP form elicitation (Codex request_user_input) above the composer
+ * - Grok ext / tool-promoted asks in the composer
  *
  * Multi-question UX is paginated: one question per page, prev/next, Submit on last.
  * Options + optional free-text "Other" stay on the same page.
+ * Multi-select (Claude/OpenCode/Grok) toggles chips; answers join with ", ".
+ *
+ * Keyboard (when focus is on the form, not the free-text input):
+ * - ↑ / ↓  move option focus
+ * - Space  select / toggle focused option
+ * - Enter  confirm focused option and go next (or submit on last)
+ * - ← / →  previous / next question
  */
-import { Check, ChevronLeft, ChevronRight } from "lucide-react";
-import { useState } from "react";
+import {
+	Check,
+	ChevronDown,
+	ChevronLeft,
+	ChevronRight,
+	ChevronUp,
+} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Suggestion } from "@/components/ai-elements/suggestion";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { AskUserQuestion } from "@/lib/agent/chat-state";
 import { cn } from "@/lib/core/utils";
+
+/** Multi-select answers are joined for the follow-up turn / elicitation text. */
+const MULTI_JOIN = ", ";
+
+function selectedLabels(
+	question: AskUserQuestion,
+	answer: string | undefined,
+): string[] {
+	const value = answer?.trim() ?? "";
+	if (!value) return [];
+	if (!question.multiSelect) return [value];
+	// Prefer exact option-label matching so labels with commas still work.
+	const labels = question.options.map((option) => option.label);
+	const picked: string[] = [];
+	let rest = value;
+	for (const label of labels) {
+		const parts = rest.split(MULTI_JOIN);
+		if (parts.includes(label)) {
+			picked.push(label);
+			rest = parts.filter((part) => part !== label).join(MULTI_JOIN);
+		}
+	}
+	// Remaining free-text Other (if any).
+	if (rest.trim()) picked.push(rest.trim());
+	return picked;
+}
 
 function isAnswerComplete(
 	question: AskUserQuestion,
@@ -29,6 +69,34 @@ function isAnswerComplete(
 	// Free-text only page.
 	if (question.required === false) return true;
 	return Boolean(value);
+}
+
+function isTextFieldTarget(target: EventTarget | null): boolean {
+	if (!(target instanceof HTMLElement)) return false;
+	const tag = target.tagName;
+	return tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable;
+}
+
+/** Apply option pick into answers (pure) for Enter confirm path. */
+function withOptionSelected(
+	questions: AskUserQuestion[],
+	answers: string[],
+	questionIndex: number,
+	label: string,
+): string[] {
+	const q = questions[questionIndex];
+	const next = [...answers];
+	if (!q) return next;
+	if (q.multiSelect) {
+		const existing = selectedLabels(q, answers[questionIndex]).filter((item) =>
+			q.options.some((option) => option.label === item),
+		);
+		const toggled = existing.includes(label) ? existing : [...existing, label];
+		next[questionIndex] = toggled.join(MULTI_JOIN);
+	} else {
+		next[questionIndex] = label;
+	}
+	return next;
 }
 
 export function AskUserQuestionForm({
@@ -56,37 +124,87 @@ export function AskUserQuestionForm({
 	const [page, setPage] = useState(0);
 	const [sending, setSending] = useState(false);
 	const [submitted, setSubmitted] = useState(false);
-
-	if (!questions.length) return null;
+	/** Keyboard focus among options on the current page. */
+	const [focusOption, setFocusOption] = useState(0);
+	/** Collapsed: only the question stem row (and cancel). */
+	const [collapsed, setCollapsed] = useState(false);
+	const rootRef = useRef<HTMLDivElement>(null);
 
 	const total = questions.length;
-	const index = Math.min(page, total - 1);
+	const index = total > 0 ? Math.min(page, total - 1) : 0;
 	const question = questions[index];
-	if (!question) return null;
+	const optionCount = question?.options.length ?? 0;
+	const busy = disabled || sending || submitted;
+
+	// Re-seed keyboard option focus when flipping pages (not when answers change).
+	// biome-ignore lint/correctness/useExhaustiveDependencies: optionCount re-seeds when option list length changes
+	useEffect(() => {
+		setFocusOption(0);
+	}, [index, optionCount]);
+
+	// Autofocus the form so arrow keys work without an extra click.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: re-focus when page index changes
+	useEffect(() => {
+		if (busy || total === 0 || collapsed) return;
+		const node = rootRef.current;
+		if (!node) return;
+		if (isTextFieldTarget(document.activeElement)) return;
+		node.focus({ preventScroll: true });
+	}, [busy, collapsed, index, total]);
+
+	if (!questions.length || !question) return null;
 
 	const isFirst = index === 0;
 	const isLast = index === total - 1;
 	const multi = total > 1;
 	const currentAnswer = answers[index] ?? "";
 	const otherDraft = otherDrafts[index] ?? "";
-	const selectedOption =
-		question.options.find((option) => option.label === currentAnswer)?.label ??
-		null;
+	const picked = selectedLabels(question, currentAnswer);
 	const showOtherInput =
 		Boolean(question.allowOther) || question.options.length === 0;
 	const currentReady = isAnswerComplete(question, currentAnswer);
 	const allReady = questions.every((q, i) => isAnswerComplete(q, answers[i]));
-	const busy = disabled || sending || submitted;
+	// -1 = free-text mode (no option keyboard-focused).
+	const safeFocus =
+		focusOption < 0 || optionCount === 0
+			? -1
+			: Math.min(focusOption, optionCount - 1);
 
 	const setOption = (questionIndex: number, label: string) => {
-		setAnswers((current) => {
-			const next = [...current];
-			next[questionIndex] = label;
-			return next;
-		});
+		const q = questions[questionIndex];
 		setOtherDrafts((current) => {
 			const next = [...current];
 			next[questionIndex] = "";
+			return next;
+		});
+		setAnswers((current) => {
+			const next = [...current];
+			if (q?.multiSelect) {
+				const existing = selectedLabels(q, current[questionIndex]).filter(
+					(item) => q.options.some((option) => option.label === item),
+				);
+				const toggled = existing.includes(label)
+					? existing.filter((item) => item !== label)
+					: [...existing, label];
+				next[questionIndex] = toggled.join(MULTI_JOIN);
+			} else {
+				next[questionIndex] = label;
+			}
+			return next;
+		});
+	};
+
+	/**
+	 * User moved into free-text "Other": drop option selection + keyboard focus
+	 * so Enter does not confirm the previously highlighted option.
+	 */
+	const clearOptionSelectionForFreeText = (questionIndex: number) => {
+		setFocusOption(-1);
+		setAnswers((current) => {
+			const next = [...current];
+			const other = otherDrafts[questionIndex]?.trim() ?? "";
+			// Keep free-text draft as the page answer; drop option labels.
+			next[questionIndex] = other;
 			return next;
 		});
 	};
@@ -122,205 +240,225 @@ export function AskUserQuestionForm({
 		}
 	};
 
-	const doSubmit = () => {
-		if (!allReady || busy) return;
+	const doSubmit = (finalAnswers?: string[]) => {
+		const payload = finalAnswers ?? answers;
+		if (!questions.every((q, i) => isAnswerComplete(q, payload[i])) || busy)
+			return;
 		setSending(true);
-		void onSubmit(answers).then((sent) => {
+		void onSubmit(payload).then((sent) => {
 			setSending(false);
 			setSubmitted(sent);
 		});
 	};
 
-	return (
-		<div className={cn("space-y-3", className)}>
-			{title ? (
-				<p className="text-muted-foreground text-xs font-medium tracking-wide">
-					{title}
-				</p>
-			) : null}
+	/** Enter: select focused option (ensure on), then next page or submit. */
+	const confirmFocusedAndAdvance = () => {
+		if (busy) return;
+		// Free-text mode: never force an option on Enter.
+		if (safeFocus < 0 || optionCount === 0) {
+			if (isLast) doSubmit();
+			else goNext();
+			return;
+		}
+		const label = question.options[safeFocus]?.label;
+		let nextAnswers = answers;
+		if (label) {
+			nextAnswers = withOptionSelected(questions, answers, index, label);
+			setOtherDrafts((current) => {
+				const next = [...current];
+				next[index] = "";
+				return next;
+			});
+			setAnswers(nextAnswers);
+		}
 
-			{multi ? (
-				<p className="text-muted-foreground text-xs tabular-nums">
-					{t("askUserQuestion.progress", {
-						current: index + 1,
-						total,
-					})}
-				</p>
-			) : null}
+		if (isLast) {
+			doSubmit(nextAnswers);
+			return;
+		}
+		if (isAnswerComplete(question, nextAnswers[index])) {
+			setPage((p) => Math.min(total - 1, p + 1));
+		}
+	};
 
-			<div
-				key={question.id ?? `${index}-${question.question}`}
-				className="space-y-2"
+	const onFormKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+		if (busy) return;
+		if (event.nativeEvent.isComposing) return;
+		// Free-text field keeps its own keys.
+		if (isTextFieldTarget(event.target)) return;
+
+		const key = event.key;
+		if (key === "ArrowDown" || key === "ArrowUp") {
+			if (optionCount === 0) return;
+			event.preventDefault();
+			event.stopPropagation();
+			setFocusOption((prev) => {
+				// Leaving free-text mode: land on first / last option.
+				if (prev < 0) {
+					return key === "ArrowDown" ? 0 : optionCount - 1;
+				}
+				const cur = Math.min(prev, optionCount - 1);
+				if (key === "ArrowDown") return (cur + 1) % optionCount;
+				return (cur - 1 + optionCount) % optionCount;
+			});
+			return;
+		}
+
+		if (key === " " || key === "Spacebar") {
+			if (optionCount === 0 || safeFocus < 0) return;
+			event.preventDefault();
+			event.stopPropagation();
+			const label = question.options[safeFocus]?.label;
+			if (label) setOption(index, label);
+			return;
+		}
+
+		if (key === "Enter") {
+			event.preventDefault();
+			event.stopPropagation();
+			if (optionCount > 0 && safeFocus >= 0) {
+				confirmFocusedAndAdvance();
+			} else if (isLast) {
+				doSubmit();
+			} else {
+				goNext();
+			}
+			return;
+		}
+
+		if (key === "ArrowLeft") {
+			if (!multi || isFirst) return;
+			event.preventDefault();
+			event.stopPropagation();
+			goPrev();
+			return;
+		}
+
+		if (key === "ArrowRight") {
+			if (!multi || isLast) return;
+			event.preventDefault();
+			event.stopPropagation();
+			goNext();
+		}
+	};
+
+	const navButtons = multi ? (
+		<>
+			<Button
+				type="button"
+				size="sm"
+				variant="outline"
+				disabled={isFirst || busy}
+				aria-label={t("askUserQuestion.prev")}
+				onClick={goPrev}
 			>
-				<p className="text-sm leading-5">{question.question}</p>
-				{question.options.length > 0 ? (
-					<div className="flex flex-col gap-1.5" role="listbox">
-						{question.options.map((option) => {
-							const selected =
-								selectedOption === option.label && !otherDraft.trim();
-							return (
-								<Suggestion
-									key={option.label}
-									suggestion={option.label}
-									role="option"
-									aria-selected={selected}
-									aria-pressed={selected}
-									disabled={busy}
-									variant="outline"
-									className={cn(
-										"h-auto w-full justify-start gap-2.5 whitespace-normal rounded-lg border px-3 py-2.5 text-left shadow-none transition-colors",
-										selected
-											? "border-primary bg-primary/15 text-foreground ring-2 ring-primary/45 hover:bg-primary/20 hover:text-foreground"
-											: "border-border/80 bg-background/60 hover:bg-muted/50",
-									)}
-									onClick={(answer) => {
-										setOption(index, answer);
-										// Multi-choice: advance after pick when more pages remain
-										// and no free-text Other on this page (Other may still be filled).
-										if (multi && !isLast && !busy && !question.allowOther) {
-											setPage((p) => Math.min(total - 1, p + 1));
-										}
-									}}
-								>
-									<span
-										className={cn(
-											"mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border",
-											selected
-												? "border-primary bg-primary text-primary-foreground"
-												: "border-muted-foreground/35 bg-transparent",
-										)}
-										aria-hidden
-									>
-										{selected ? (
-											<Check className="size-2.5 stroke-[3]" />
-										) : null}
-									</span>
-									<span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
-										<span
-											className={cn(
-												"text-sm",
-												selected ? "font-semibold" : "font-medium",
-											)}
-										>
-											{option.label}
-										</span>
-										{option.description ? (
-											<span
-												className={cn(
-													"text-xs leading-snug",
-													selected
-														? "text-foreground/75"
-														: "text-muted-foreground",
-												)}
-											>
-												{option.description}
-											</span>
-										) : null}
-									</span>
-								</Suggestion>
-							);
-						})}
-					</div>
-				) : null}
-				{showOtherInput ? (
-					<div
-						className={cn(
-							"rounded-lg transition-[box-shadow,border-color,background-color]",
-							question.options.length > 0 && otherDraft.trim()
-								? "ring-2 ring-primary/45"
-								: null,
-						)}
-					>
-						<Input
-							value={
-								question.options.length > 0 ? otherDraft : (currentAnswer ?? "")
-							}
-							disabled={busy}
-							placeholder={t("askUserQuestion.freeTextPlaceholder")}
-							className={cn(
-								question.options.length > 0 && otherDraft.trim()
-									? "border-primary bg-primary/10"
-									: null,
-							)}
-							onChange={(event) => {
-								const text = event.target.value;
-								if (question.options.length > 0) {
-									setOtherText(index, text);
-								} else {
-									setAnswers((current) => {
-										const next = [...current];
-										next[index] = text;
-										return next;
-									});
-								}
-							}}
-							onKeyDown={(event) => {
-								if (event.key !== "Enter" || event.nativeEvent.isComposing)
-									return;
-								event.preventDefault();
-								if (isLast) doSubmit();
-								else goNext();
-							}}
-						/>
-					</div>
-				) : null}
+				<ChevronLeft className="size-3.5" />
+				{t("askUserQuestion.prev")}
+			</Button>
+			{isLast ? (
+				<Button
+					type="button"
+					size="sm"
+					disabled={!allReady || busy}
+					onClick={() => doSubmit()}
+				>
+					{submitted
+						? t("askUserQuestion.submitted")
+						: t("askUserQuestion.submit")}
+				</Button>
+			) : (
+				<Button
+					type="button"
+					size="sm"
+					disabled={!currentReady || busy}
+					aria-label={t("askUserQuestion.next")}
+					onClick={goNext}
+				>
+					{t("askUserQuestion.next")}
+					<ChevronRight className="size-3.5" />
+				</Button>
+			)}
+		</>
+	) : (
+		<Button
+			type="button"
+			size="sm"
+			disabled={!allReady || busy}
+			onClick={() => doSubmit()}
+		>
+			{submitted ? t("askUserQuestion.submitted") : t("askUserQuestion.submit")}
+		</Button>
+	);
+
+	return (
+		// Keyboard host for the questionnaire (not a semantic fieldset — nested controls).
+		// biome-ignore lint/a11y/useSemanticElements: roving-focus host, not a form fieldset
+		<div
+			ref={rootRef}
+			className={cn("space-y-2 outline-none", className)}
+			tabIndex={busy || collapsed ? -1 : 0}
+			role="group"
+			aria-label={question.question}
+			onKeyDown={collapsed ? undefined : onFormKeyDown}
+		>
+			{/* Top-center collapse control (no top border on the card shell). */}
+			<div className="flex justify-center">
+				<button
+					type="button"
+					className={cn(
+						"group flex h-5 w-14 items-center justify-center rounded-full",
+						"text-muted-foreground/70 transition-colors hover:bg-muted/60 hover:text-muted-foreground",
+						"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+					)}
+					aria-expanded={!collapsed}
+					aria-label={
+						collapsed
+							? t("askUserQuestion.expand")
+							: t("askUserQuestion.collapse")
+					}
+					title={
+						collapsed
+							? t("askUserQuestion.expand")
+							: t("askUserQuestion.collapse")
+					}
+					onClick={() => setCollapsed((c) => !c)}
+				>
+					{collapsed ? (
+						<ChevronUp className="size-3.5" aria-hidden />
+					) : (
+						<ChevronDown className="size-3.5" aria-hidden />
+					)}
+				</button>
 			</div>
 
-			<div className="flex flex-wrap items-center gap-2">
-				{multi ? (
-					<>
-						<Button
-							type="button"
-							size="sm"
-							variant="outline"
-							disabled={isFirst || busy}
-							aria-label={t("askUserQuestion.prev")}
-							onClick={goPrev}
-						>
-							<ChevronLeft className="size-3.5" />
-							{t("askUserQuestion.prev")}
-						</Button>
-						{isLast ? (
-							<Button
-								type="button"
-								size="sm"
-								disabled={!allReady || busy}
-								onClick={doSubmit}
-							>
-								{submitted
-									? t("askUserQuestion.submitted")
-									: t("askUserQuestion.submit")}
-							</Button>
-						) : (
-							<Button
-								type="button"
-								size="sm"
-								disabled={!currentReady || busy}
-								aria-label={t("askUserQuestion.next")}
-								onClick={goNext}
-							>
-								{t("askUserQuestion.next")}
-								<ChevronRight className="size-3.5" />
-							</Button>
-						)}
-					</>
-				) : (
-					<Button
-						type="button"
-						size="sm"
-						disabled={!allReady || busy}
-						onClick={doSubmit}
-					>
-						{submitted
-							? t("askUserQuestion.submitted")
-							: t("askUserQuestion.submit")}
-					</Button>
-				)}
+			{/* Header: optional title + progress/stem; Cancel top-right */}
+			<div className="flex items-start gap-2">
+				<div className="min-w-0 flex-1 space-y-1">
+					{title && !collapsed ? (
+						<p className="text-muted-foreground text-xs font-medium tracking-wide">
+							{title}
+						</p>
+					) : null}
+					<div className="flex items-baseline gap-2">
+						{multi ? (
+							<span className="shrink-0 text-muted-foreground text-xs tabular-nums">
+								{t("askUserQuestion.progress", {
+									current: index + 1,
+									total,
+								})}
+							</span>
+						) : null}
+						<p className="min-w-0 flex-1 text-sm leading-5">
+							{question.question}
+						</p>
+					</div>
+				</div>
 				{onCancel && !submitted ? (
 					<Button
 						type="button"
 						size="sm"
 						variant="ghost"
+						className="h-7 shrink-0 px-2 text-muted-foreground"
 						disabled={busy}
 						onClick={onCancel}
 					>
@@ -328,6 +466,175 @@ export function AskUserQuestionForm({
 					</Button>
 				) : null}
 			</div>
+
+			{collapsed ? null : (
+				<div
+					key={question.id ?? `${index}-${question.question}`}
+					className="space-y-2"
+				>
+					{question.options.length > 0 ? (
+						<div
+							className="flex flex-col gap-1.5"
+							role="listbox"
+							aria-label={question.question}
+							aria-multiselectable={question.multiSelect ? true : undefined}
+						>
+							{question.options.map((option, optionIndex) => {
+								const selected =
+									picked.includes(option.label) && !otherDraft.trim();
+								const focused = safeFocus >= 0 && optionIndex === safeFocus;
+								return (
+									<Suggestion
+										key={option.label}
+										suggestion={option.label}
+										role="option"
+										aria-selected={selected}
+										aria-pressed={selected}
+										disabled={busy}
+										variant="outline"
+										tabIndex={-1}
+										className={cn(
+											"h-auto w-full justify-start gap-2.5 whitespace-normal rounded-lg border px-3 py-2.5 text-left shadow-none transition-colors",
+											selected
+												? "border-primary bg-primary/15 text-foreground ring-2 ring-primary/45 hover:bg-primary/20 hover:text-foreground"
+												: "border-border/80 bg-background/60 hover:bg-muted/50",
+											// Keyboard focus ring (distinct from selected state).
+											focused && !selected
+												? "ring-2 ring-ring/60 border-ring/50"
+												: null,
+											focused && selected
+												? "ring-offset-1 ring-offset-background"
+												: null,
+										)}
+										onClick={(answer) => {
+											setFocusOption(optionIndex);
+											setOption(index, answer);
+											// Single-select + multi-page: advance after pick when no Other.
+											// Multi-select stays so the user can pick more chips.
+											if (
+												!question.multiSelect &&
+												multi &&
+												!isLast &&
+												!busy &&
+												!question.allowOther
+											) {
+												setPage((p) => Math.min(total - 1, p + 1));
+											}
+											rootRef.current?.focus({ preventScroll: true });
+										}}
+									>
+										<span
+											className={cn(
+												"mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border",
+												selected
+													? "border-primary bg-primary text-primary-foreground"
+													: "border-muted-foreground/35 bg-transparent",
+											)}
+											aria-hidden
+										>
+											{selected ? (
+												<Check className="size-2.5 stroke-[3]" />
+											) : null}
+										</span>
+										<span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
+											<span
+												className={cn(
+													"text-sm",
+													selected ? "font-semibold" : "font-medium",
+												)}
+											>
+												{option.label}
+											</span>
+											{option.description ? (
+												<span
+													className={cn(
+														"text-xs leading-snug",
+														selected
+															? "text-foreground/75"
+															: "text-muted-foreground",
+													)}
+												>
+													{option.description}
+												</span>
+											) : null}
+										</span>
+									</Suggestion>
+								);
+							})}
+						</div>
+					) : null}
+					{showOtherInput ? (
+						<div
+							className={cn(
+								"rounded-lg transition-[box-shadow,border-color,background-color]",
+								question.options.length > 0 && otherDraft.trim()
+									? "ring-2 ring-primary/45"
+									: null,
+							)}
+						>
+							<Input
+								value={
+									question.options.length > 0
+										? otherDraft
+										: (currentAnswer ?? "")
+								}
+								disabled={busy}
+								placeholder={t("askUserQuestion.freeTextPlaceholder")}
+								className={cn(
+									question.options.length > 0 && otherDraft.trim()
+										? "border-primary bg-primary/10"
+										: null,
+								)}
+								onFocus={() => {
+									// Typing a custom answer: drop option highlight / selection.
+									if (question.options.length > 0) {
+										clearOptionSelectionForFreeText(index);
+									}
+								}}
+								onChange={(event) => {
+									const text = event.target.value;
+									if (question.options.length > 0) {
+										// Ensure free-text mode even if focus events were skipped.
+										if (focusOption >= 0) setFocusOption(-1);
+										setOtherText(index, text);
+									} else {
+										setAnswers((current) => {
+											const next = [...current];
+											next[index] = text;
+											return next;
+										});
+									}
+								}}
+								onKeyDown={(event) => {
+									if (event.key !== "Enter" || event.nativeEvent.isComposing)
+										return;
+									event.preventDefault();
+									event.stopPropagation();
+									// Only free-text / current answers — never confirm option focus.
+									if (isLast) doSubmit();
+									else goNext();
+								}}
+							/>
+						</div>
+					) : null}
+				</div>
+			)}
+
+			{collapsed ? null : (
+				/* Footer: keyboard hints left · nav / submit right */
+				<div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+					<p className="min-w-0 flex-1 text-muted-foreground text-[11px] leading-snug">
+						{t(
+							multi
+								? "askUserQuestion.keyboardHintMulti"
+								: "askUserQuestion.keyboardHint",
+						)}
+					</p>
+					<div className="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-2">
+						{navButtons}
+					</div>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/src/components/agent/ask-user-question-form.tsx
+++ b/src/components/agent/ask-user-question-form.tsx
@@ -1,0 +1,333 @@
+/**
+ * Shared AskUserQuestion UI (AI Elements Suggestion chips).
+ * Used by:
+ * - ACP tool cards with variant AskUserQuestion
+ * - ACP form elicitation (Codex request_user_input) above the composer
+ *
+ * Multi-question UX is paginated: one question per page, prev/next, Submit on last.
+ * Options + optional free-text "Other" stay on the same page.
+ */
+import { Check, ChevronLeft, ChevronRight } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Suggestion } from "@/components/ai-elements/suggestion";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { AskUserQuestion } from "@/lib/agent/chat-state";
+import { cn } from "@/lib/core/utils";
+
+function isAnswerComplete(
+	question: AskUserQuestion,
+	answer: string | undefined,
+): boolean {
+	const value = answer?.trim() ?? "";
+	if (question.options.length > 0) {
+		// Option selected, or free-text Other when allowed.
+		if (value) return true;
+		return question.required === false;
+	}
+	// Free-text only page.
+	if (question.required === false) return true;
+	return Boolean(value);
+}
+
+export function AskUserQuestionForm({
+	questions,
+	disabled = false,
+	title,
+	className,
+	onSubmit,
+	onCancel,
+}: {
+	questions: AskUserQuestion[];
+	disabled?: boolean;
+	/** Optional heading above the questions (composer card). */
+	title?: string;
+	className?: string;
+	/** Selected labels (or free-text) in question order. Returns true when accepted. */
+	onSubmit: (answers: string[]) => Promise<boolean>;
+	onCancel?: () => void;
+}) {
+	const { t } = useTranslation("agent");
+	/** Effective answer per question: option label or free-text Other. */
+	const [answers, setAnswers] = useState<string[]>([]);
+	/** Free-text draft when question has options + allowOther (may mirror answers). */
+	const [otherDrafts, setOtherDrafts] = useState<string[]>([]);
+	const [page, setPage] = useState(0);
+	const [sending, setSending] = useState(false);
+	const [submitted, setSubmitted] = useState(false);
+
+	if (!questions.length) return null;
+
+	const total = questions.length;
+	const index = Math.min(page, total - 1);
+	const question = questions[index];
+	if (!question) return null;
+
+	const isFirst = index === 0;
+	const isLast = index === total - 1;
+	const multi = total > 1;
+	const currentAnswer = answers[index] ?? "";
+	const otherDraft = otherDrafts[index] ?? "";
+	const selectedOption =
+		question.options.find((option) => option.label === currentAnswer)?.label ??
+		null;
+	const showOtherInput =
+		Boolean(question.allowOther) || question.options.length === 0;
+	const currentReady = isAnswerComplete(question, currentAnswer);
+	const allReady = questions.every((q, i) => isAnswerComplete(q, answers[i]));
+	const busy = disabled || sending || submitted;
+
+	const setOption = (questionIndex: number, label: string) => {
+		setAnswers((current) => {
+			const next = [...current];
+			next[questionIndex] = label;
+			return next;
+		});
+		setOtherDrafts((current) => {
+			const next = [...current];
+			next[questionIndex] = "";
+			return next;
+		});
+	};
+
+	const setOtherText = (questionIndex: number, text: string) => {
+		setOtherDrafts((current) => {
+			const next = [...current];
+			next[questionIndex] = text;
+			return next;
+		});
+		setAnswers((current) => {
+			const next = [...current];
+			// Free-text wins over option when non-empty; clearing free-text keeps prior option if any.
+			if (text.trim()) {
+				next[questionIndex] = text;
+			} else {
+				const q = questions[questionIndex];
+				const prev = current[questionIndex];
+				const stillOption = q?.options.some((o) => o.label === prev);
+				next[questionIndex] = stillOption ? (prev ?? "") : "";
+			}
+			return next;
+		});
+	};
+
+	const goPrev = () => {
+		if (!isFirst && !busy) setPage((p) => Math.max(0, p - 1));
+	};
+
+	const goNext = () => {
+		if (!isLast && currentReady && !busy) {
+			setPage((p) => Math.min(total - 1, p + 1));
+		}
+	};
+
+	const doSubmit = () => {
+		if (!allReady || busy) return;
+		setSending(true);
+		void onSubmit(answers).then((sent) => {
+			setSending(false);
+			setSubmitted(sent);
+		});
+	};
+
+	return (
+		<div className={cn("space-y-3", className)}>
+			{title ? (
+				<p className="text-muted-foreground text-xs font-medium tracking-wide">
+					{title}
+				</p>
+			) : null}
+
+			{multi ? (
+				<p className="text-muted-foreground text-xs tabular-nums">
+					{t("askUserQuestion.progress", {
+						current: index + 1,
+						total,
+					})}
+				</p>
+			) : null}
+
+			<div
+				key={question.id ?? `${index}-${question.question}`}
+				className="space-y-2"
+			>
+				<p className="text-sm leading-5">{question.question}</p>
+				{question.options.length > 0 ? (
+					<div className="flex flex-col gap-1.5" role="listbox">
+						{question.options.map((option) => {
+							const selected =
+								selectedOption === option.label && !otherDraft.trim();
+							return (
+								<Suggestion
+									key={option.label}
+									suggestion={option.label}
+									role="option"
+									aria-selected={selected}
+									aria-pressed={selected}
+									disabled={busy}
+									variant="outline"
+									className={cn(
+										"h-auto w-full justify-start gap-2.5 whitespace-normal rounded-lg border px-3 py-2.5 text-left shadow-none transition-colors",
+										selected
+											? "border-primary bg-primary/15 text-foreground ring-2 ring-primary/45 hover:bg-primary/20 hover:text-foreground"
+											: "border-border/80 bg-background/60 hover:bg-muted/50",
+									)}
+									onClick={(answer) => {
+										setOption(index, answer);
+										// Multi-choice: advance after pick when more pages remain
+										// and no free-text Other on this page (Other may still be filled).
+										if (multi && !isLast && !busy && !question.allowOther) {
+											setPage((p) => Math.min(total - 1, p + 1));
+										}
+									}}
+								>
+									<span
+										className={cn(
+											"mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border",
+											selected
+												? "border-primary bg-primary text-primary-foreground"
+												: "border-muted-foreground/35 bg-transparent",
+										)}
+										aria-hidden
+									>
+										{selected ? (
+											<Check className="size-2.5 stroke-[3]" />
+										) : null}
+									</span>
+									<span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
+										<span
+											className={cn(
+												"text-sm",
+												selected ? "font-semibold" : "font-medium",
+											)}
+										>
+											{option.label}
+										</span>
+										{option.description ? (
+											<span
+												className={cn(
+													"text-xs leading-snug",
+													selected
+														? "text-foreground/75"
+														: "text-muted-foreground",
+												)}
+											>
+												{option.description}
+											</span>
+										) : null}
+									</span>
+								</Suggestion>
+							);
+						})}
+					</div>
+				) : null}
+				{showOtherInput ? (
+					<div
+						className={cn(
+							"rounded-lg transition-[box-shadow,border-color,background-color]",
+							question.options.length > 0 && otherDraft.trim()
+								? "ring-2 ring-primary/45"
+								: null,
+						)}
+					>
+						<Input
+							value={
+								question.options.length > 0 ? otherDraft : (currentAnswer ?? "")
+							}
+							disabled={busy}
+							placeholder={t("askUserQuestion.freeTextPlaceholder")}
+							className={cn(
+								question.options.length > 0 && otherDraft.trim()
+									? "border-primary bg-primary/10"
+									: null,
+							)}
+							onChange={(event) => {
+								const text = event.target.value;
+								if (question.options.length > 0) {
+									setOtherText(index, text);
+								} else {
+									setAnswers((current) => {
+										const next = [...current];
+										next[index] = text;
+										return next;
+									});
+								}
+							}}
+							onKeyDown={(event) => {
+								if (event.key !== "Enter" || event.nativeEvent.isComposing)
+									return;
+								event.preventDefault();
+								if (isLast) doSubmit();
+								else goNext();
+							}}
+						/>
+					</div>
+				) : null}
+			</div>
+
+			<div className="flex flex-wrap items-center gap-2">
+				{multi ? (
+					<>
+						<Button
+							type="button"
+							size="sm"
+							variant="outline"
+							disabled={isFirst || busy}
+							aria-label={t("askUserQuestion.prev")}
+							onClick={goPrev}
+						>
+							<ChevronLeft className="size-3.5" />
+							{t("askUserQuestion.prev")}
+						</Button>
+						{isLast ? (
+							<Button
+								type="button"
+								size="sm"
+								disabled={!allReady || busy}
+								onClick={doSubmit}
+							>
+								{submitted
+									? t("askUserQuestion.submitted")
+									: t("askUserQuestion.submit")}
+							</Button>
+						) : (
+							<Button
+								type="button"
+								size="sm"
+								disabled={!currentReady || busy}
+								aria-label={t("askUserQuestion.next")}
+								onClick={goNext}
+							>
+								{t("askUserQuestion.next")}
+								<ChevronRight className="size-3.5" />
+							</Button>
+						)}
+					</>
+				) : (
+					<Button
+						type="button"
+						size="sm"
+						disabled={!allReady || busy}
+						onClick={doSubmit}
+					>
+						{submitted
+							? t("askUserQuestion.submitted")
+							: t("askUserQuestion.submit")}
+					</Button>
+				)}
+				{onCancel && !submitted ? (
+					<Button
+						type="button"
+						size="sm"
+						variant="ghost"
+						disabled={busy}
+						onClick={onCancel}
+					>
+						{t("askUserQuestion.cancel")}
+					</Button>
+				) : null}
+			</div>
+		</div>
+	);
+}

--- a/src/components/agent/chat-transcript.tsx
+++ b/src/components/agent/chat-transcript.tsx
@@ -82,7 +82,7 @@ import {
 import { stripPromptEnvelopeForDisplay } from "@/lib/agent/prompt-display";
 import { normalizeAgentSourcePath } from "@/lib/agent/sources";
 
-/** Compact note: interactive form lives in the composer, not inside the tool card. */
+/** Compact note: interactive form is docked below, not inside the tool card. */
 function AskUserToolPendingNote() {
 	const { t } = useTranslation("agent");
 	return (

--- a/src/components/agent/chat-transcript.tsx
+++ b/src/components/agent/chat-transcript.tsx
@@ -1,6 +1,7 @@
 import { CopyIcon, Pencil } from "lucide-react";
-import { type RefObject, useState } from "react";
+import type { RefObject } from "react";
 import { useTranslation } from "react-i18next";
+import { AskUserQuestionForm } from "@/components/agent/ask-user-question-form";
 import {
 	ChatAttachedImages,
 	ChatVisualAnnotations,
@@ -91,74 +92,18 @@ function AskUserQuestionTool({
 	disabled: boolean;
 	onAnswer: (answer: string) => Promise<boolean>;
 }) {
-	const { t } = useTranslation("agent");
 	const questions = parseAskUserQuestions(input);
-	const [answers, setAnswers] = useState<string[]>([]);
-	const [sending, setSending] = useState(false);
-	const [submitted, setSubmitted] = useState(false);
-
 	if (!questions) return null;
-	const ready =
-		answers.length === questions.length && answers.every((answer) => answer);
 
 	return (
 		<ToolContent>
-			<div className="space-y-4">
-				{questions.map((question, questionIndex) => (
-					<div key={question.question} className="space-y-2">
-						<p className="text-sm leading-5">{question.question}</p>
-						<div className="flex flex-col gap-1.5">
-							{question.options.map((option) => {
-								const selected = answers[questionIndex] === option.label;
-								return (
-									<Suggestion
-										key={option.label}
-										suggestion={option.label}
-										aria-pressed={selected}
-										disabled={disabled || sending || submitted}
-										variant={selected ? "secondary" : "outline"}
-										className="h-auto w-full justify-start whitespace-normal rounded-md px-3 py-2 text-left"
-										onClick={(answer) =>
-											setAnswers((current) => {
-												const next = [...current];
-												next[questionIndex] = answer;
-												return next;
-											})
-										}
-									>
-										<span className="flex min-w-0 flex-col items-start gap-0.5">
-											<span>{option.label}</span>
-											{option.description ? (
-												<span className="text-muted-foreground text-xs">
-													{option.description}
-												</span>
-											) : null}
-										</span>
-									</Suggestion>
-								);
-							})}
-						</div>
-					</div>
-				))}
-				<Button
-					type="button"
-					size="sm"
-					disabled={!ready || disabled || sending || submitted}
-					onClick={() => {
-						setSending(true);
-						void onAnswer(formatAskUserAnswers(questions, answers)).then(
-							(sent) => {
-								setSending(false);
-								setSubmitted(sent);
-							},
-						);
-					}}
-				>
-					{submitted
-						? t("askUserQuestion.submitted")
-						: t("askUserQuestion.submit")}
-				</Button>
-			</div>
+			<AskUserQuestionForm
+				questions={questions}
+				disabled={disabled}
+				onSubmit={(answers) =>
+					onAnswer(formatAskUserAnswers(questions, answers))
+				}
+			/>
 		</ToolContent>
 	);
 }

--- a/src/components/agent/chat-transcript.tsx
+++ b/src/components/agent/chat-transcript.tsx
@@ -1,7 +1,6 @@
 import { CopyIcon, Pencil } from "lucide-react";
 import type { RefObject } from "react";
 import { useTranslation } from "react-i18next";
-import { AskUserQuestionForm } from "@/components/agent/ask-user-question-form";
 import {
 	ChatAttachedImages,
 	ChatVisualAnnotations,
@@ -74,7 +73,7 @@ import {
 	agentTextFromParts,
 	type ChatLine,
 	copyText,
-	formatAskUserAnswers,
+	isPendingAskUserToolStatus,
 	parseAskUserQuestions,
 	SUGGESTION_KEYS,
 	SUGGESTION_WORKFLOW,
@@ -83,27 +82,14 @@ import {
 import { stripPromptEnvelopeForDisplay } from "@/lib/agent/prompt-display";
 import { normalizeAgentSourcePath } from "@/lib/agent/sources";
 
-function AskUserQuestionTool({
-	input,
-	disabled,
-	onAnswer,
-}: {
-	input: unknown;
-	disabled: boolean;
-	onAnswer: (answer: string) => Promise<boolean>;
-}) {
-	const questions = parseAskUserQuestions(input);
-	if (!questions) return null;
-
+/** Compact note: interactive form lives in the composer, not inside the tool card. */
+function AskUserToolPendingNote() {
+	const { t } = useTranslation("agent");
 	return (
 		<ToolContent>
-			<AskUserQuestionForm
-				questions={questions}
-				disabled={disabled}
-				onSubmit={(answers) =>
-					onAnswer(formatAskUserAnswers(questions, answers))
-				}
-			/>
+			<p className="text-xs text-muted-foreground">
+				{t("askUserQuestion.pendingInComposer")}
+			</p>
 		</ToolContent>
 	);
 }
@@ -126,7 +112,6 @@ export function ChatTranscript({
 	onResendEdited,
 	onStartEditing,
 	onSendSuggestion,
-	onAnswerQuestion,
 	onOpenSource,
 }: {
 	lines: ChatLine[];
@@ -153,7 +138,6 @@ export function ChatTranscript({
 	onResendEdited: (lineId: string) => void;
 	onStartEditing: (lineId: string, text: string) => void;
 	onSendSuggestion: (label: string, workflow?: string) => void;
-	onAnswerQuestion: (answer: string) => Promise<boolean>;
 	/** Open a vault path / paper (or external URL) from Sources / inline citation. */
 	onOpenSource?: (source: string) => void;
 }) {
@@ -408,28 +392,21 @@ export function ChatTranscript({
 														const askUserQuestion = parseAskUserQuestions(
 															tool.input,
 														);
+														// Interactive form is owned by the composer; transcript
+														// only shows a compact tool row (and a short pending note).
+														const askPending =
+															Boolean(askUserQuestion) &&
+															isPendingAskUserToolStatus(tool.status);
 														return (
-															<Tool
-																key={partKey}
-																defaultOpen={Boolean(askUserQuestion)}
-															>
+															<Tool key={partKey} defaultOpen={askPending}>
 																<ToolHeader
 																	title={tool.title || t("tool.defaultTitle")}
 																	type={`tool-${tool.kind}`}
 																	state={state}
 																/>
-																{askUserQuestion ? (
-																	<AskUserQuestionTool
-																		input={tool.input}
-																		disabled={
-																			switching ||
-																			submitting ||
-																			(tool.status !== "pending" &&
-																				tool.status !== "in_progress")
-																		}
-																		onAnswer={onAnswerQuestion}
-																	/>
-																) : (
+																{askPending ? (
+																	<AskUserToolPendingNote />
+																) : askUserQuestion ? null : (
 																	<ToolContent>
 																		{tool.input !== undefined ? (
 																			<ToolInput input={tool.input} />

--- a/src/components/agent/use-agent-panel.ts
+++ b/src/components/agent/use-agent-panel.ts
@@ -24,6 +24,7 @@ import { useSessionComposerState } from "@/hooks/use-session-composer-state";
 import {
 	type AgentEffortChoice,
 	type AgentListResponse,
+	type AgentModeChoice,
 	type AgentModelChoice,
 	type AgentPlanEvent,
 	type AgentResultPayload,
@@ -32,31 +33,39 @@ import {
 	type AgentToolEvent,
 	type CatalogScanResponse,
 	cancelAgentRun,
+	type ElicitationRequest,
 	ensureCatalogAgent,
 	listAgentSkills,
 	listAgents,
+	listenAgentCollaboration,
 	listenAgentCommands,
 	listenAgentCompleted,
 	listenAgentEffort,
 	listenAgentFailed,
 	listenAgentFastMode,
 	listenAgentModels,
+	listenAgentModes,
 	listenAgentPlan,
 	listenAgentStream,
 	listenAgentTool,
 	listenAgentUsage,
 	listSessions,
+	loadCollaborationPref,
 	loadModelCatalog,
 	loadModelFavorites,
 	loadModelPref,
+	loadModePref,
 	loadSession,
 	type PermissionRequest,
 	type PromptImage,
+	respondElicitation,
 	respondPermission,
 	runOnce,
+	saveCollaborationPref,
 	saveModelCatalog,
 	saveModelFavorites,
 	saveModelPref,
+	saveModePref,
 	scanCatalog,
 	setDefaultAgent,
 	warmAgent,
@@ -294,6 +303,14 @@ export function useAgentPanel({
 	const [agentListenersReady, setAgentListenersReady] = useState(false);
 	const [submitting, setSubmitting] = useState(false);
 	const [skills, setSkills] = useState<AgentSkill[]>([]);
+	const [modeOptions, setModeOptions] = useState<AgentModeChoice[]>([]);
+	const [modeId, setModeId] = useState<string | null>(null);
+	const [collaborationOptions, setCollaborationOptions] = useState<
+		AgentModeChoice[]
+	>([]);
+	const [collaborationModeId, setCollaborationModeId] = useState<string | null>(
+		null,
+	);
 	const [effortOptions, setEffortOptions] = useState<AgentEffortChoice[]>([]);
 	const [reasoningEffort, setReasoningEffort] = useState<string | null>(null);
 	const [fastAvailable, setFastAvailable] = useState(false);
@@ -410,6 +427,56 @@ export function useAgentPanel({
 				// Nested setState: keep free-form selection visible in the picker.
 				setModels(ensureModelsInclude(catalogModels, [next, prevId]));
 				return next;
+			});
+		},
+		[],
+	);
+
+	const applyModesEvent = useCallback(
+		(ev: { agentId: string; currentId: string; modes: AgentModeChoice[] }) => {
+			const cur = selectedAgentIdRef.current;
+			if (cur && cur !== ev.agentId) return;
+			if (!ev.modes.length) {
+				setModeOptions([]);
+				setModeId(null);
+				return;
+			}
+			const pref = loadModePref(ev.agentId)?.trim() || null;
+			const current = ev.currentId?.trim() || null;
+			const validPref =
+				pref && ev.modes.some((mode) => mode.id === pref) ? pref : null;
+			setModeOptions(ev.modes);
+			setModeId((prev) => {
+				const prevId = prev?.trim() || null;
+				if (prevId && ev.modes.some((mode) => mode.id === prevId)) {
+					return prevId;
+				}
+				return validPref || current || ev.modes[0]?.id || null;
+			});
+		},
+		[],
+	);
+
+	const applyCollaborationEvent = useCallback(
+		(ev: { agentId: string; currentId: string; modes: AgentModeChoice[] }) => {
+			const cur = selectedAgentIdRef.current;
+			if (cur && cur !== ev.agentId) return;
+			if (!ev.modes.length) {
+				setCollaborationOptions([]);
+				setCollaborationModeId(null);
+				return;
+			}
+			const pref = loadCollaborationPref(ev.agentId)?.trim() || null;
+			const current = ev.currentId?.trim() || null;
+			const validPref =
+				pref && ev.modes.some((mode) => mode.id === pref) ? pref : null;
+			setCollaborationOptions(ev.modes);
+			setCollaborationModeId((prev) => {
+				const prevId = prev?.trim() || null;
+				if (prevId && ev.modes.some((mode) => mode.id === prevId)) {
+					return prevId;
+				}
+				return validPref || current || ev.modes[0]?.id || null;
 			});
 		},
 		[],
@@ -581,6 +648,10 @@ export function useAgentPanel({
 			setModels([]);
 			setModelId(null);
 			setFavoriteIds([]);
+			setModeOptions([]);
+			setModeId(null);
+			setCollaborationOptions([]);
+			setCollaborationModeId(null);
 			setEffortOptions([]);
 			setReasoningEffort(null);
 			setFastAvailable(false);
@@ -589,6 +660,10 @@ export function useAgentPanel({
 			setUsageBySession({});
 			return;
 		}
+		setModeOptions([]);
+		setModeId(loadModePref(selectedAgentId));
+		setCollaborationOptions([]);
+		setCollaborationModeId(loadCollaborationPref(selectedAgentId));
 		setEffortOptions([]);
 		setReasoningEffort(null);
 		setFastAvailable(false);
@@ -627,6 +702,8 @@ export function useAgentPanel({
 			agentId: string;
 			vaultPath: string | null;
 			modelId?: string;
+			modeId?: string;
+			collaborationModeId?: string;
 			generation: number;
 			/** Apply models/usage only when still the intended warm target. */
 			stillValid: () => boolean;
@@ -643,6 +720,8 @@ export function useAgentPanel({
 					agentId: args.agentId,
 					vaultPath: args.vaultPath ?? undefined,
 					modelId: args.modelId,
+					modeId: args.modeId,
+					collaborationModeId: args.collaborationModeId,
 				});
 				if (args.generation !== warmGenRef.current || !args.stillValid()) {
 					return;
@@ -678,6 +757,8 @@ export function useAgentPanel({
 			agentId,
 			vaultPath: requestVaultPath,
 			modelId: loadModelPref(agentId) ?? undefined,
+			modeId: loadModePref(agentId) ?? undefined,
+			collaborationModeId: loadCollaborationPref(agentId) ?? undefined,
 			generation: gen,
 			stillValid: () =>
 				!cancelled &&
@@ -1117,6 +1198,12 @@ export function useAgentPanel({
 			const uModels = await listenAgentModels((ev) => {
 				applyModelsEvent(ev);
 			});
+			const uModes = await listenAgentModes((ev) => {
+				applyModesEvent(ev);
+			});
+			const uCollab = await listenAgentCollaboration((ev) => {
+				applyCollaborationEvent(ev);
+			});
 			const uEffort = await listenAgentEffort((ev) => {
 				applyEffortEvent(ev);
 			});
@@ -1151,6 +1238,8 @@ export function useAgentPanel({
 				uUsage();
 				uCommands();
 				uModels();
+				uModes();
+				uCollab();
 				uEffort();
 				uFast();
 				u2();
@@ -1164,6 +1253,8 @@ export function useAgentPanel({
 				uUsage,
 				uCommands,
 				uModels,
+				uModes,
+				uCollab,
 				uEffort,
 				uFast,
 				u2,
@@ -1177,8 +1268,10 @@ export function useAgentPanel({
 			for (const u of unsubs) u();
 		};
 	}, [
+		applyCollaborationEvent,
 		applyEffortEvent,
 		applyFastModeEvent,
+		applyModesEvent,
 		applyModelsEvent,
 		applyPlanEvent,
 		applyStreamEvent,
@@ -1567,6 +1660,42 @@ export function useAgentPanel({
 		}
 	};
 
+	const selectedModeName = useMemo(() => {
+		if (!modeId) return null;
+		return modeOptions.find((mode) => mode.id === modeId)?.name ?? modeId;
+	}, [modeId, modeOptions]);
+
+	const selectedCollaborationName = useMemo(() => {
+		if (!collaborationModeId) return null;
+		return (
+			collaborationOptions.find((mode) => mode.id === collaborationModeId)
+				?.name ?? collaborationModeId
+		);
+	}, [collaborationModeId, collaborationOptions]);
+
+	const pickMode = useCallback(
+		(id: string) => {
+			const next = id.trim();
+			if (!next || !modeOptions.some((mode) => mode.id === next)) return;
+			setModeId(next);
+			if (!selectedAgentId) return;
+			saveModePref(selectedAgentId, next);
+		},
+		[modeOptions, selectedAgentId],
+	);
+
+	const pickCollaborationMode = useCallback(
+		(id: string) => {
+			const next = id.trim();
+			if (!next || !collaborationOptions.some((mode) => mode.id === next))
+				return;
+			setCollaborationModeId(next);
+			if (!selectedAgentId) return;
+			saveCollaborationPref(selectedAgentId, next);
+		},
+		[collaborationOptions, selectedAgentId],
+	);
+
 	const selectedSkills = useMemo(
 		() =>
 			selectedSkillIds
@@ -1606,6 +1735,9 @@ export function useAgentPanel({
 			agentId,
 			vaultPath: requestVaultPath,
 			modelId: next,
+			modeId: loadModePref(agentId) ?? modeId ?? undefined,
+			collaborationModeId:
+				loadCollaborationPref(agentId) ?? collaborationModeId ?? undefined,
 			generation,
 			stillValid: () =>
 				selectedAgentIdRef.current === agentId &&
@@ -1690,6 +1822,9 @@ export function useAgentPanel({
 	// Forward ACP permission requests (ask mode) to the user for an explicit decision.
 	const [permissionRequest, setPermissionRequest] =
 		useState<PermissionRequest | null>(null);
+	// Codex Plan-mode request_user_input → form elicitation.
+	const [elicitationRequest, setElicitationRequest] =
+		useState<ElicitationRequest | null>(null);
 
 	const permissionRequestRef = useRef(permissionRequest);
 	permissionRequestRef.current = permissionRequest;
@@ -1699,6 +1834,22 @@ export function useAgentPanel({
 		void respondPermission(req.requestId, null);
 		setPermissionRequest(null);
 	});
+
+	const elicitationRequestRef = useRef(elicitationRequest);
+	elicitationRequestRef.current = elicitationRequest;
+	useOverlayRegistration(
+		"agent-elicitation",
+		elicitationRequest !== null,
+		() => {
+			const req = elicitationRequestRef.current;
+			if (!req) return;
+			void respondElicitation({
+				requestId: req.requestId,
+				action: "cancel",
+			});
+			setElicitationRequest(null);
+		},
+	);
 
 	useEffect(() => {
 		if (!isTauri()) return;
@@ -1710,6 +1861,24 @@ export function useAgentPanel({
 			unsub = await listen<PermissionRequest>(
 				"agent:permission-request",
 				({ payload }) => setPermissionRequest(payload),
+			);
+		})();
+		return () => {
+			cancelled = true;
+			unsub?.();
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!isTauri()) return;
+		let unsub: (() => void) | undefined;
+		let cancelled = false;
+		void (async () => {
+			const { listen } = await import("@tauri-apps/api/event");
+			if (cancelled) return;
+			unsub = await listen<ElicitationRequest>(
+				"agent:elicitation-request",
+				({ payload }) => setElicitationRequest(payload),
 			);
 		})();
 		return () => {
@@ -1988,6 +2157,15 @@ export function useAgentPanel({
 				workflow: workflow ?? "free",
 				target: workflowTarget,
 				modelId: resolvedModelId,
+				modeId:
+					modeId && modeOptions.some((mode) => mode.id === modeId)
+						? modeId
+						: undefined,
+				collaborationModeId:
+					collaborationModeId &&
+					collaborationOptions.some((mode) => mode.id === collaborationModeId)
+						? collaborationModeId
+						: undefined,
 				reasoningEffort: reasoningEffort ?? undefined,
 				fastMode: fastAvailable ? fastEnabled : undefined,
 				skillIds: resolvedSkillIds,
@@ -3234,6 +3412,14 @@ export function useAgentPanel({
 		warming,
 		pickModel,
 		toggleFavorite,
+		modeOptions,
+		modeId,
+		selectedModeName,
+		pickMode,
+		collaborationOptions,
+		collaborationModeId,
+		selectedCollaborationName,
+		pickCollaborationMode,
 		effortOptionsInDisplayOrder,
 		reasoningEffort,
 		setReasoningEffort,
@@ -3246,6 +3432,9 @@ export function useAgentPanel({
 		// Permission
 		permissionRequest,
 		setPermissionRequest,
+		// Form elicitation (request_user_input)
+		elicitationRequest,
+		setElicitationRequest,
 		// Refs used by composer submit race guards
 		switchingRef,
 		submittingRef,

--- a/src/components/agent/use-agent-panel.ts
+++ b/src/components/agent/use-agent-panel.ts
@@ -45,7 +45,6 @@ import {
 	listenAgentFailed,
 	listenAgentFastMode,
 	listenAgentModels,
-	listenAgentModes,
 	listenAgentPlan,
 	listenAgentStream,
 	listenAgentTool,
@@ -55,7 +54,6 @@ import {
 	loadModelCatalog,
 	loadModelFavorites,
 	loadModelPref,
-	loadModePref,
 	loadSession,
 	type PermissionRequest,
 	type PromptImage,
@@ -67,7 +65,6 @@ import {
 	saveModelCatalog,
 	saveModelFavorites,
 	saveModelPref,
-	saveModePref,
 	scanCatalog,
 	setDefaultAgent,
 	warmAgent,
@@ -308,8 +305,6 @@ export function useAgentPanel({
 	const [agentListenersReady, setAgentListenersReady] = useState(false);
 	const [submitting, setSubmitting] = useState(false);
 	const [skills, setSkills] = useState<AgentSkill[]>([]);
-	const [modeOptions, setModeOptions] = useState<AgentModeChoice[]>([]);
-	const [modeId, setModeId] = useState<string | null>(null);
 	const [collaborationOptions, setCollaborationOptions] = useState<
 		AgentModeChoice[]
 	>([]);
@@ -432,31 +427,6 @@ export function useAgentPanel({
 				// Nested setState: keep free-form selection visible in the picker.
 				setModels(ensureModelsInclude(catalogModels, [next, prevId]));
 				return next;
-			});
-		},
-		[],
-	);
-
-	const applyModesEvent = useCallback(
-		(ev: { agentId: string; currentId: string; modes: AgentModeChoice[] }) => {
-			const cur = selectedAgentIdRef.current;
-			if (cur && cur !== ev.agentId) return;
-			if (!ev.modes.length) {
-				setModeOptions([]);
-				setModeId(null);
-				return;
-			}
-			const pref = loadModePref(ev.agentId)?.trim() || null;
-			const current = ev.currentId?.trim() || null;
-			const validPref =
-				pref && ev.modes.some((mode) => mode.id === pref) ? pref : null;
-			setModeOptions(ev.modes);
-			setModeId((prev) => {
-				const prevId = prev?.trim() || null;
-				if (prevId && ev.modes.some((mode) => mode.id === prevId)) {
-					return prevId;
-				}
-				return validPref || current || ev.modes[0]?.id || null;
 			});
 		},
 		[],
@@ -653,8 +623,6 @@ export function useAgentPanel({
 			setModels([]);
 			setModelId(null);
 			setFavoriteIds([]);
-			setModeOptions([]);
-			setModeId(null);
 			setCollaborationOptions([]);
 			setCollaborationModeId(null);
 			setEffortOptions([]);
@@ -665,8 +633,6 @@ export function useAgentPanel({
 			setUsageBySession({});
 			return;
 		}
-		setModeOptions([]);
-		setModeId(loadModePref(selectedAgentId));
 		setCollaborationOptions([]);
 		setCollaborationModeId(loadCollaborationPref(selectedAgentId));
 		setEffortOptions([]);
@@ -707,7 +673,6 @@ export function useAgentPanel({
 			agentId: string;
 			vaultPath: string | null;
 			modelId?: string;
-			modeId?: string;
 			collaborationModeId?: string;
 			generation: number;
 			/** Apply models/usage only when still the intended warm target. */
@@ -725,7 +690,6 @@ export function useAgentPanel({
 					agentId: args.agentId,
 					vaultPath: args.vaultPath ?? undefined,
 					modelId: args.modelId,
-					modeId: args.modeId,
 					collaborationModeId: args.collaborationModeId,
 				});
 				if (args.generation !== warmGenRef.current || !args.stillValid()) {
@@ -762,7 +726,6 @@ export function useAgentPanel({
 			agentId,
 			vaultPath: requestVaultPath,
 			modelId: loadModelPref(agentId) ?? undefined,
-			modeId: loadModePref(agentId) ?? undefined,
 			collaborationModeId: loadCollaborationPref(agentId) ?? undefined,
 			generation: gen,
 			stillValid: () =>
@@ -822,7 +785,7 @@ export function useAgentPanel({
 		[isChatOwnedSession, updateSessionLines],
 	);
 
-	// OpenCode / Claude / Codex tool-shaped ask → composer form (not transcript).
+	// OpenCode / Claude / Codex tool-shaped ask → bottom form surface (not transcript).
 	// Declared before applyToolEvent so the promote path can set it.
 	const [toolAskUserRequest, setToolAskUserRequest] =
 		useState<ToolAskUserRequest | null>(null);
@@ -849,8 +812,8 @@ export function useAgentPanel({
 				return next;
 			});
 
-			// Promote pending ask-user tools to the composer (single interactive surface).
-			// Composer priority: elicitation > Grok ext > tool; listeners clear tool on host asks.
+			// Promote pending ask-user tools to the bottom surface (hides free-text composer).
+			// Surface priority: elicitation > Grok ext > tool; listeners clear tool on host asks.
 			const questions = parseAskUserQuestions(ev.input);
 			const pending = isPendingAskUserToolStatus(ev.status);
 			if (questions && pending) {
@@ -1226,9 +1189,6 @@ export function useAgentPanel({
 			const uModels = await listenAgentModels((ev) => {
 				applyModelsEvent(ev);
 			});
-			const uModes = await listenAgentModes((ev) => {
-				applyModesEvent(ev);
-			});
 			const uCollab = await listenAgentCollaboration((ev) => {
 				applyCollaborationEvent(ev);
 			});
@@ -1266,7 +1226,6 @@ export function useAgentPanel({
 				uUsage();
 				uCommands();
 				uModels();
-				uModes();
 				uCollab();
 				uEffort();
 				uFast();
@@ -1281,7 +1240,6 @@ export function useAgentPanel({
 				uUsage,
 				uCommands,
 				uModels,
-				uModes,
 				uCollab,
 				uEffort,
 				uFast,
@@ -1299,7 +1257,6 @@ export function useAgentPanel({
 		applyCollaborationEvent,
 		applyEffortEvent,
 		applyFastModeEvent,
-		applyModesEvent,
 		applyModelsEvent,
 		applyPlanEvent,
 		applyStreamEvent,
@@ -1688,11 +1645,6 @@ export function useAgentPanel({
 		}
 	};
 
-	const selectedModeName = useMemo(() => {
-		if (!modeId) return null;
-		return modeOptions.find((mode) => mode.id === modeId)?.name ?? modeId;
-	}, [modeId, modeOptions]);
-
 	const selectedCollaborationName = useMemo(() => {
 		if (!collaborationModeId) return null;
 		return (
@@ -1700,17 +1652,6 @@ export function useAgentPanel({
 				?.name ?? collaborationModeId
 		);
 	}, [collaborationModeId, collaborationOptions]);
-
-	const pickMode = useCallback(
-		(id: string) => {
-			const next = id.trim();
-			if (!next || !modeOptions.some((mode) => mode.id === next)) return;
-			setModeId(next);
-			if (!selectedAgentId) return;
-			saveModePref(selectedAgentId, next);
-		},
-		[modeOptions, selectedAgentId],
-	);
 
 	const pickCollaborationMode = useCallback(
 		(id: string) => {
@@ -1763,7 +1704,6 @@ export function useAgentPanel({
 			agentId,
 			vaultPath: requestVaultPath,
 			modelId: next,
-			modeId: loadModePref(agentId) ?? modeId ?? undefined,
 			collaborationModeId:
 				loadCollaborationPref(agentId) ?? collaborationModeId ?? undefined,
 			generation,
@@ -2237,10 +2177,6 @@ export function useAgentPanel({
 				workflow: workflow ?? "free",
 				target: workflowTarget,
 				modelId: resolvedModelId,
-				modeId:
-					modeId && modeOptions.some((mode) => mode.id === modeId)
-						? modeId
-						: undefined,
 				collaborationModeId:
 					collaborationModeId &&
 					collaborationOptions.some((mode) => mode.id === collaborationModeId)
@@ -3531,10 +3467,6 @@ export function useAgentPanel({
 		warming,
 		pickModel,
 		toggleFavorite,
-		modeOptions,
-		modeId,
-		selectedModeName,
-		pickMode,
 		collaborationOptions,
 		collaborationModeId,
 		selectedCollaborationName,

--- a/src/components/agent/use-agent-panel.ts
+++ b/src/components/agent/use-agent-panel.ts
@@ -31,6 +31,7 @@ import {
 	type AgentSkill,
 	type AgentStreamEvent,
 	type AgentToolEvent,
+	type AskUserRequest,
 	type CatalogScanResponse,
 	cancelAgentRun,
 	type ElicitationRequest,
@@ -58,6 +59,7 @@ import {
 	loadSession,
 	type PermissionRequest,
 	type PromptImage,
+	respondAskUser,
 	respondElicitation,
 	respondPermission,
 	runOnce,
@@ -93,14 +95,17 @@ import {
 	errorChatLine,
 	errorText,
 	isBackgroundWorkflowHistoryTitle,
+	isPendingAskUserToolStatus,
 	mapToolStatus,
 	nextLineId,
 	nextPartId,
 	type PendingSessionEvent,
 	type PendingTerminalEvent,
+	parseAskUserQuestions,
 	providerSessionIdForHistoryLoad,
 	resolveSelected,
 	shouldDeferSessionEvent,
+	type ToolAskUserRequest,
 	upsertChatSessionTurn,
 	upsertPlanPart,
 } from "@/lib/agent/chat-state";
@@ -817,6 +822,11 @@ export function useAgentPanel({
 		[isChatOwnedSession, updateSessionLines],
 	);
 
+	// OpenCode / Claude / Codex tool-shaped ask → composer form (not transcript).
+	// Declared before applyToolEvent so the promote path can set it.
+	const [toolAskUserRequest, setToolAskUserRequest] =
+		useState<ToolAskUserRequest | null>(null);
+
 	const applyToolEvent = useCallback(
 		(ev: AgentToolEvent) => {
 			if (!isChatOwnedSession(ev.sessionId)) return;
@@ -838,6 +848,24 @@ export function useAgentPanel({
 				};
 				return next;
 			});
+
+			// Promote pending ask-user tools to the composer (single interactive surface).
+			// Composer priority: elicitation > Grok ext > tool; listeners clear tool on host asks.
+			const questions = parseAskUserQuestions(ev.input);
+			const pending = isPendingAskUserToolStatus(ev.status);
+			if (questions && pending) {
+				setToolAskUserRequest({
+					toolCallId: ev.toolCallId,
+					sessionId: ev.sessionId,
+					questions,
+				});
+				return;
+			}
+			if (questions && !pending) {
+				setToolAskUserRequest((prev) =>
+					prev?.toolCallId === ev.toolCallId ? null : prev,
+				);
+			}
 		},
 		[isChatOwnedSession, updateSessionLines],
 	);
@@ -1825,6 +1853,10 @@ export function useAgentPanel({
 	// Codex Plan-mode request_user_input → form elicitation.
 	const [elicitationRequest, setElicitationRequest] =
 		useState<ElicitationRequest | null>(null);
+	// Grok `_x.ai/ask_user_question` extension method.
+	const [askUserRequest, setAskUserRequest] = useState<AskUserRequest | null>(
+		null,
+	);
 
 	const permissionRequestRef = useRef(permissionRequest);
 	permissionRequestRef.current = permissionRequest;
@@ -1848,6 +1880,28 @@ export function useAgentPanel({
 				action: "cancel",
 			});
 			setElicitationRequest(null);
+		},
+	);
+
+	const askUserRequestRef = useRef(askUserRequest);
+	askUserRequestRef.current = askUserRequest;
+	useOverlayRegistration("agent-ask-user", askUserRequest !== null, () => {
+		const req = askUserRequestRef.current;
+		if (!req) return;
+		void respondAskUser({
+			requestId: req.requestId,
+			action: "cancel",
+		});
+		setAskUserRequest(null);
+	});
+
+	const toolAskUserRequestRef = useRef(toolAskUserRequest);
+	toolAskUserRequestRef.current = toolAskUserRequest;
+	useOverlayRegistration(
+		"agent-tool-ask-user",
+		toolAskUserRequest !== null,
+		() => {
+			setToolAskUserRequest(null);
 		},
 	);
 
@@ -1878,7 +1932,33 @@ export function useAgentPanel({
 			if (cancelled) return;
 			unsub = await listen<ElicitationRequest>(
 				"agent:elicitation-request",
-				({ payload }) => setElicitationRequest(payload),
+				({ payload }) => {
+					// Prefer host elicitation over tool-card promote.
+					setToolAskUserRequest(null);
+					setElicitationRequest(payload);
+				},
+			);
+		})();
+		return () => {
+			cancelled = true;
+			unsub?.();
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!isTauri()) return;
+		let unsub: (() => void) | undefined;
+		let cancelled = false;
+		void (async () => {
+			const { listen } = await import("@tauri-apps/api/event");
+			if (cancelled) return;
+			unsub = await listen<AskUserRequest>(
+				"agent:ask-user-request",
+				({ payload }) => {
+					// Grok ext is the authoritative respond path; drop tool-promote duplicate.
+					setToolAskUserRequest(null);
+					setAskUserRequest(payload);
+				},
 			);
 		})();
 		return () => {
@@ -2509,6 +2589,41 @@ export function useAgentPanel({
 		return send(textRaw, { workflow, images });
 	};
 
+	/**
+	 * Answer a tool-shaped ask-user form (OpenCode `question`, Claude AskUserQuestion, …).
+	 *
+	 * The agent turn is usually still `running` (blocked on the tool). Normal
+	 * composer submit would only enqueue and never drain until the run ends —
+	 * a deadlock. Cancel the stuck turn so the answer can send immediately
+	 * (same net effect as enqueue + stop, without the extra click).
+	 * Grok ext / elicitation use dedicated respond paths and do not need this.
+	 */
+	const answerToolAskUser = async (answer: string): Promise<boolean> => {
+		if (switchingRef.current || submittingRef.current) return false;
+		resetPromptHistoryBrowse();
+		const text = answer.trim();
+		if (!text) return false;
+
+		setToolAskUserRequest(null);
+
+		if (!activeTabIsRunning) {
+			return send(text);
+		}
+
+		// Queue first so cancel → idle drains it; then free the blocked run.
+		const enqueued = enqueueMessage(text);
+		if (!enqueued) return false;
+		const sessionId = activeTabId;
+		if (!sessionId || !isTauri()) return true;
+		try {
+			await cancelAgentRun(sessionId);
+		} catch (error) {
+			// Leave the queued answer; user can still stop the run manually.
+			setLines((prev) => [...prev, errorChatLine(errorText(error))]);
+		}
+		return true;
+	};
+
 	const removeQueuedMessage = useCallback((id: string) => {
 		setMessageQueue((prev) => {
 			const next = prev.filter((item) => item.id !== id);
@@ -2685,6 +2800,10 @@ export function useAgentPanel({
 		if (!sessionId || !isTauri()) return;
 		try {
 			await cancelAgentRun(sessionId);
+			// Drop promoted tool-ask form for this turn.
+			setToolAskUserRequest((prev) =>
+				prev?.sessionId === sessionId ? null : prev,
+			);
 		} catch (error) {
 			setLines((prev) => [...prev, errorChatLine(errorText(error))]);
 		}
@@ -3435,6 +3554,13 @@ export function useAgentPanel({
 		// Form elicitation (request_user_input)
 		elicitationRequest,
 		setElicitationRequest,
+		// Grok ask-user extension
+		askUserRequest,
+		setAskUserRequest,
+		// Tool-shaped ask promoted to composer
+		toolAskUserRequest,
+		setToolAskUserRequest,
+		answerToolAskUser,
 		// Refs used by composer submit race guards
 		switchingRef,
 		submittingRef,

--- a/src/i18n/locales/en/agent.json
+++ b/src/i18n/locales/en/agent.json
@@ -17,6 +17,11 @@
 			"rejectAlways": "Always reject"
 		}
 	},
+	"elicitation": {
+		"title": "Agent needs your input",
+		"submit": "Submit answers",
+		"cancel": "Cancel"
+	},
 	"missing": " (missing)",
 	"switchAgent": "Switch ACP agent",
 	"suggestions": {
@@ -92,6 +97,14 @@
 		"mentionEmptyFolder": "No items in this folder",
 		"fast": "Fast",
 		"fastToggle": "Toggle Fast mode",
+		"collaborationTooltip": "Collaboration mode (Plan enables request_user_input)",
+		"collaboration": {
+			"label": "Collab"
+		},
+		"modeTooltip": "Permission / sandbox mode (when the agent supports it)",
+		"mode": {
+			"label": "Access"
+		},
 		"effortTooltip": "Select reasoning effort",
 		"effort": {
 			"label": "Effort",
@@ -123,8 +136,13 @@
 		"failed": "Tool failed"
 	},
 	"askUserQuestion": {
-		"submit": "Submit answers",
-		"submitted": "Answers submitted"
+		"submit": "Submit",
+		"submitted": "Submitted",
+		"cancel": "Cancel",
+		"prev": "Back",
+		"next": "Next",
+		"progress": "{{current}} / {{total}}",
+		"freeTextPlaceholder": "Type your answer"
 	},
 	"citation": {
 		"vaultPath": "Vault path referenced by agent"

--- a/src/i18n/locales/en/agent.json
+++ b/src/i18n/locales/en/agent.json
@@ -143,7 +143,7 @@
 		"next": "Next",
 		"progress": "{{current}} / {{total}}",
 		"freeTextPlaceholder": "Type your answer",
-		"pendingInComposer": "Answer in the input area below",
+		"pendingInComposer": "Answer in the questionnaire below",
 		"keyboardHint": "↑↓ options · Space select · Enter confirm",
 		"keyboardHintMulti": "↑↓ options · Space select · Enter next · ←→ pages",
 		"collapse": "Collapse questionnaire",

--- a/src/i18n/locales/en/agent.json
+++ b/src/i18n/locales/en/agent.json
@@ -97,13 +97,9 @@
 		"mentionEmptyFolder": "No items in this folder",
 		"fast": "Fast",
 		"fastToggle": "Toggle Fast mode",
-		"collaborationTooltip": "Collaboration mode (Plan enables request_user_input)",
+		"collaborationTooltip": "Session mode",
 		"collaboration": {
-			"label": "Collab"
-		},
-		"modeTooltip": "Permission / sandbox mode (when the agent supports it)",
-		"mode": {
-			"label": "Access"
+			"label": "Mode"
 		},
 		"effortTooltip": "Select reasoning effort",
 		"effort": {

--- a/src/i18n/locales/en/agent.json
+++ b/src/i18n/locales/en/agent.json
@@ -142,7 +142,12 @@
 		"prev": "Back",
 		"next": "Next",
 		"progress": "{{current}} / {{total}}",
-		"freeTextPlaceholder": "Type your answer"
+		"freeTextPlaceholder": "Type your answer",
+		"pendingInComposer": "Answer in the input area below",
+		"keyboardHint": "↑↓ options · Space select · Enter confirm",
+		"keyboardHintMulti": "↑↓ options · Space select · Enter next · ←→ pages",
+		"collapse": "Collapse questionnaire",
+		"expand": "Expand questionnaire"
 	},
 	"citation": {
 		"vaultPath": "Vault path referenced by agent"

--- a/src/i18n/locales/zh-CN/agent.json
+++ b/src/i18n/locales/zh-CN/agent.json
@@ -17,6 +17,11 @@
 			"rejectAlways": "始终拒绝"
 		}
 	},
+	"elicitation": {
+		"title": "Agent 需要你的选择",
+		"submit": "提交回答",
+		"cancel": "取消"
+	},
 	"missing": "（缺失）",
 	"switchAgent": "切换 ACP Agent",
 	"suggestions": {
@@ -92,6 +97,14 @@
 		"mentionEmptyFolder": "此文件夹中没有可选项",
 		"fast": "快速",
 		"fastToggle": "切换快速模式",
+		"collaborationTooltip": "协作模式（Plan 下可用 request_user_input）",
+		"collaboration": {
+			"label": "协作"
+		},
+		"modeTooltip": "权限 / 沙箱模式（Agent 支持时显示）",
+		"mode": {
+			"label": "权限"
+		},
 		"effortTooltip": "选择推理强度",
 		"effort": {
 			"label": "推理强度",
@@ -123,8 +136,13 @@
 		"failed": "工具执行失败"
 	},
 	"askUserQuestion": {
-		"submit": "提交回答",
-		"submitted": "回答已提交"
+		"submit": "提交",
+		"submitted": "已提交",
+		"cancel": "取消",
+		"prev": "上一题",
+		"next": "下一题",
+		"progress": "{{current}} / {{total}}",
+		"freeTextPlaceholder": "输入你的回答"
 	},
 	"citation": {
 		"vaultPath": "Agent 引用的知识库路径"

--- a/src/i18n/locales/zh-CN/agent.json
+++ b/src/i18n/locales/zh-CN/agent.json
@@ -97,13 +97,9 @@
 		"mentionEmptyFolder": "此文件夹中没有可选项",
 		"fast": "快速",
 		"fastToggle": "切换快速模式",
-		"collaborationTooltip": "协作模式（Plan 下可用 request_user_input）",
+		"collaborationTooltip": "会话模式",
 		"collaboration": {
-			"label": "协作"
-		},
-		"modeTooltip": "权限 / 沙箱模式（Agent 支持时显示）",
-		"mode": {
-			"label": "权限"
+			"label": "模式"
 		},
 		"effortTooltip": "选择推理强度",
 		"effort": {

--- a/src/i18n/locales/zh-CN/agent.json
+++ b/src/i18n/locales/zh-CN/agent.json
@@ -142,7 +142,12 @@
 		"prev": "上一题",
 		"next": "下一题",
 		"progress": "{{current}} / {{total}}",
-		"freeTextPlaceholder": "输入你的回答"
+		"freeTextPlaceholder": "输入你的回答",
+		"pendingInComposer": "请在下方输入区作答",
+		"keyboardHint": "↑↓ 选项 · Space 勾选 · Enter 确认",
+		"keyboardHintMulti": "↑↓ 选项 · Space 勾选 · Enter 下一题 · ←→ 切题",
+		"collapse": "收起问卷",
+		"expand": "展开问卷"
 	},
 	"citation": {
 		"vaultPath": "Agent 引用的知识库路径"

--- a/src/i18n/locales/zh-CN/agent.json
+++ b/src/i18n/locales/zh-CN/agent.json
@@ -143,7 +143,7 @@
 		"next": "下一题",
 		"progress": "{{current}} / {{total}}",
 		"freeTextPlaceholder": "输入你的回答",
-		"pendingInComposer": "请在下方输入区作答",
+		"pendingInComposer": "请在下方问卷中作答",
 		"keyboardHint": "↑↓ 选项 · Space 勾选 · Enter 确认",
 		"keyboardHintMulti": "↑↓ 选项 · Space 勾选 · Enter 下一题 · ←→ 切题",
 		"collapse": "收起问卷",

--- a/src/lib/agent/api.ts
+++ b/src/lib/agent/api.ts
@@ -255,14 +255,6 @@ export type AgentModeChoice = {
 	description?: string | null;
 };
 
-export type AgentModesEvent = {
-	sessionId: string;
-	agentId: string;
-	configId: string;
-	currentId: string;
-	modes: AgentModeChoice[];
-};
-
 /** Codex collaboration mode (Default / Plan) via config id collaboration_mode. */
 export type AgentCollaborationEvent = {
 	sessionId: string;
@@ -484,8 +476,6 @@ export async function runOnce(request: {
 	target?: string;
 	/** ACP model config value id (from agent:models). */
 	modelId?: string;
-	/** ACP permission/sandbox mode id (from agent:modes), e.g. read-only. */
-	modeId?: string;
 	/** Collaboration mode id (from agent:collaboration), e.g. default / plan. */
 	collaborationModeId?: string;
 	/** ACP reasoning-effort value id (from agent:effort). */
@@ -533,7 +523,6 @@ export async function runOnce(request: {
 			workflow: request.workflow,
 			target: request.target,
 			modelId: request.modelId,
-			modeId: request.modeId,
 			collaborationModeId: request.collaborationModeId,
 			reasoningEffort: request.reasoningEffort,
 			fastMode: request.fastMode,
@@ -632,7 +621,6 @@ export async function warmAgent(request: {
 	agentId?: string;
 	vaultPath?: string;
 	modelId?: string;
-	modeId?: string;
 	collaborationModeId?: string;
 }): Promise<WarmResult> {
 	return invokeAgentApi("agent_warm", {
@@ -640,7 +628,6 @@ export async function warmAgent(request: {
 			agentId: request.agentId,
 			vaultPath: request.vaultPath,
 			modelId: request.modelId,
-			modeId: request.modeId,
 			collaborationModeId: request.collaborationModeId,
 		},
 	});
@@ -715,12 +702,6 @@ export async function listenAgentFastMode(
 	return listenAgentEvent("agent:fast-mode", handler);
 }
 
-export async function listenAgentModes(
-	handler: (e: AgentModesEvent) => void,
-): Promise<UnlistenFn> {
-	return listenAgentEvent("agent:modes", handler);
-}
-
 export async function listenAgentCollaboration(
 	handler: (e: AgentCollaborationEvent) => void,
 ): Promise<UnlistenFn> {
@@ -740,21 +721,6 @@ export function saveModelPref(agentId: string, modelId: string): void {
 	const map = readJsonStorage<Record<string, string>>(MODEL_PREF_KEY, {});
 	map[agentId] = modelId;
 	writeJsonStorage(MODEL_PREF_KEY, map);
-}
-
-const MODE_PREF_KEY = "agentero-agent-mode-pref";
-
-/** Persist last chosen ACP session mode id per agent. */
-export function loadModePref(agentId: string | null): string | null {
-	if (!agentId) return null;
-	const map = readJsonStorage<Record<string, string>>(MODE_PREF_KEY, {});
-	return typeof map[agentId] === "string" ? map[agentId] : null;
-}
-
-export function saveModePref(agentId: string, modeId: string): void {
-	const map = readJsonStorage<Record<string, string>>(MODE_PREF_KEY, {});
-	map[agentId] = modeId;
-	writeJsonStorage(MODE_PREF_KEY, map);
 }
 
 const COLLABORATION_PREF_KEY = "agentero-agent-collaboration-pref";

--- a/src/lib/agent/api.ts
+++ b/src/lib/agent/api.ts
@@ -315,6 +315,33 @@ export type ElicitationRequest = {
 	fields: ElicitationField[];
 };
 
+/** One option in a Grok `_x.ai/ask_user_question` (or similar) request. */
+export type AskUserOptionDto = {
+	label: string;
+	description?: string | null;
+};
+
+/** One question in a Grok ask-user extension request. */
+export type AskUserQuestionDto = {
+	question: string;
+	options: AskUserOptionDto[];
+	multiSelect: boolean;
+	allowOther: boolean;
+};
+
+/**
+ * Grok Build ACP extension `_x.ai/ask_user_question` (Host → UI).
+ * Not form elicitation; answers go back via `agent_respond_ask_user`.
+ */
+export type AskUserRequest = {
+	requestId: string;
+	sessionId: string;
+	toolCallId?: string | null;
+	/** default | plan */
+	mode: string;
+	questions: AskUserQuestionDto[];
+};
+
 /** ACP permission request forwarded to the user in "ask" mode. */
 export type PermissionRequest = {
 	requestId: string;
@@ -572,6 +599,21 @@ export async function respondElicitation(request: {
 			requestId: request.requestId,
 			action: request.action,
 			content: request.content ?? null,
+		},
+	});
+}
+
+/** Answer a pending Grok `_x.ai/ask_user_question` extension request. */
+export async function respondAskUser(request: {
+	requestId: string;
+	action: "accept" | "cancel";
+	answers?: string[];
+}): Promise<void> {
+	await invokeAgentApi<{ resolved: boolean }>("agent_respond_ask_user", {
+		request: {
+			requestId: request.requestId,
+			action: request.action,
+			answers: request.answers ?? null,
 		},
 	});
 }

--- a/src/lib/agent/api.ts
+++ b/src/lib/agent/api.ts
@@ -249,6 +249,29 @@ export type AgentFastModeEvent = {
 	enabled: boolean;
 };
 
+export type AgentModeChoice = {
+	id: string;
+	name: string;
+	description?: string | null;
+};
+
+export type AgentModesEvent = {
+	sessionId: string;
+	agentId: string;
+	configId: string;
+	currentId: string;
+	modes: AgentModeChoice[];
+};
+
+/** Codex collaboration mode (Default / Plan) via config id collaboration_mode. */
+export type AgentCollaborationEvent = {
+	sessionId: string;
+	agentId: string;
+	configId: string;
+	currentId: string;
+	modes: AgentModeChoice[];
+};
+
 export type AgentFailedEvent = {
 	sessionId: string;
 	error: string;
@@ -259,6 +282,37 @@ export type PermissionOption = {
 	name: string;
 	/** allow_once | allow_always | reject_once | reject_always | other */
 	kind: string;
+};
+
+/** One option for a form elicitation select field. */
+export type ElicitationOption = {
+	value: string;
+	title: string;
+	description?: string | null;
+};
+
+/** One field from ACP form elicitation (`elicitation/create`). */
+export type ElicitationField = {
+	id: string;
+	title: string;
+	description?: string | null;
+	required: boolean;
+	/** select | text | boolean | number | other */
+	kind: string;
+	options: ElicitationOption[];
+	/** Codex free-text companion for the same logical question ("Other"). */
+	isOtherAnswer?: boolean;
+	/** Parent select field id when isOtherAnswer. */
+	parentFieldId?: string | null;
+};
+
+/** ACP form elicitation request (Codex request_user_input). */
+export type ElicitationRequest = {
+	requestId: string;
+	sessionId: string;
+	message: string;
+	toolCallId?: string | null;
+	fields: ElicitationField[];
 };
 
 /** ACP permission request forwarded to the user in "ask" mode. */
@@ -403,6 +457,10 @@ export async function runOnce(request: {
 	target?: string;
 	/** ACP model config value id (from agent:models). */
 	modelId?: string;
+	/** ACP permission/sandbox mode id (from agent:modes), e.g. read-only. */
+	modeId?: string;
+	/** Collaboration mode id (from agent:collaboration), e.g. default / plan. */
+	collaborationModeId?: string;
 	/** ACP reasoning-effort value id (from agent:effort). */
 	reasoningEffort?: string;
 	/** ACP fast-mode preference (from agent:fast-mode). */
@@ -448,6 +506,8 @@ export async function runOnce(request: {
 			workflow: request.workflow,
 			target: request.target,
 			modelId: request.modelId,
+			modeId: request.modeId,
+			collaborationModeId: request.collaborationModeId,
 			reasoningEffort: request.reasoningEffort,
 			fastMode: request.fastMode,
 			skillIds: request.skillIds ?? [],
@@ -501,6 +561,21 @@ export async function respondPermission(
 	});
 }
 
+/** Answer a pending ACP form elicitation. */
+export async function respondElicitation(request: {
+	requestId: string;
+	action: "accept" | "decline" | "cancel";
+	content?: Record<string, string>;
+}): Promise<void> {
+	await invokeAgentApi<{ resolved: boolean }>("agent_respond_elicitation", {
+		request: {
+			requestId: request.requestId,
+			action: request.action,
+			content: request.content ?? null,
+		},
+	});
+}
+
 export type WarmResult = {
 	agentId: string;
 	ok: boolean;
@@ -515,12 +590,16 @@ export async function warmAgent(request: {
 	agentId?: string;
 	vaultPath?: string;
 	modelId?: string;
+	modeId?: string;
+	collaborationModeId?: string;
 }): Promise<WarmResult> {
 	return invokeAgentApi("agent_warm", {
 		request: {
 			agentId: request.agentId,
 			vaultPath: request.vaultPath,
 			modelId: request.modelId,
+			modeId: request.modeId,
+			collaborationModeId: request.collaborationModeId,
 		},
 	});
 }
@@ -594,6 +673,18 @@ export async function listenAgentFastMode(
 	return listenAgentEvent("agent:fast-mode", handler);
 }
 
+export async function listenAgentModes(
+	handler: (e: AgentModesEvent) => void,
+): Promise<UnlistenFn> {
+	return listenAgentEvent("agent:modes", handler);
+}
+
+export async function listenAgentCollaboration(
+	handler: (e: AgentCollaborationEvent) => void,
+): Promise<UnlistenFn> {
+	return listenAgentEvent("agent:collaboration", handler);
+}
+
 const MODEL_PREF_KEY = "agentero-agent-model-pref";
 
 /** Persist last chosen model id per agent. */
@@ -607,6 +698,45 @@ export function saveModelPref(agentId: string, modelId: string): void {
 	const map = readJsonStorage<Record<string, string>>(MODEL_PREF_KEY, {});
 	map[agentId] = modelId;
 	writeJsonStorage(MODEL_PREF_KEY, map);
+}
+
+const MODE_PREF_KEY = "agentero-agent-mode-pref";
+
+/** Persist last chosen ACP session mode id per agent. */
+export function loadModePref(agentId: string | null): string | null {
+	if (!agentId) return null;
+	const map = readJsonStorage<Record<string, string>>(MODE_PREF_KEY, {});
+	return typeof map[agentId] === "string" ? map[agentId] : null;
+}
+
+export function saveModePref(agentId: string, modeId: string): void {
+	const map = readJsonStorage<Record<string, string>>(MODE_PREF_KEY, {});
+	map[agentId] = modeId;
+	writeJsonStorage(MODE_PREF_KEY, map);
+}
+
+const COLLABORATION_PREF_KEY = "agentero-agent-collaboration-pref";
+
+/** Persist last chosen collaboration mode (default / plan) per agent. */
+export function loadCollaborationPref(agentId: string | null): string | null {
+	if (!agentId) return null;
+	const map = readJsonStorage<Record<string, string>>(
+		COLLABORATION_PREF_KEY,
+		{},
+	);
+	return typeof map[agentId] === "string" ? map[agentId] : null;
+}
+
+export function saveCollaborationPref(
+	agentId: string,
+	collaborationModeId: string,
+): void {
+	const map = readJsonStorage<Record<string, string>>(
+		COLLABORATION_PREF_KEY,
+		{},
+	);
+	map[agentId] = collaborationModeId;
+	writeJsonStorage(COLLABORATION_PREF_KEY, map);
 }
 
 const MODEL_FAVORITES_KEY = "agentero-agent-model-favorites";

--- a/src/lib/agent/chat-state.ts
+++ b/src/lib/agent/chat-state.ts
@@ -447,7 +447,7 @@ export function mapToolStatus(
 	}
 }
 
-/** True while an ask-user tool still needs a user decision (composer owns the form). */
+/** True while an ask-user tool still needs a user decision (bottom surface owns the form). */
 export function isPendingAskUserToolStatus(
 	status: string | null | undefined,
 ): boolean {

--- a/src/lib/agent/chat-state.ts
+++ b/src/lib/agent/chat-state.ts
@@ -53,6 +53,8 @@ export type AskUserQuestionOption = {
 export type AskUserQuestion = {
 	/** Optional field id (elicitation schema property name). */
 	id?: string;
+	/** Short tab/header label (Claude `header`, OpenCode `header`). */
+	header?: string;
 	question: string;
 	/** Empty options and no allowOther → free-text only. */
 	options: AskUserQuestionOption[];
@@ -60,11 +62,16 @@ export type AskUserQuestion = {
 	required?: boolean;
 	/**
 	 * Show a free-text "Other" input on the same page as options
-	 * (Codex request_user_input companion field).
+	 * (Codex companion field / Claude always-on / OpenCode `custom`).
 	 */
 	allowOther?: boolean;
 	/** Elicitation content key for free-text Other (e.g. `q1__other`). */
 	otherFieldId?: string;
+	/**
+	 * Allow selecting multiple option labels (Claude `multiSelect`,
+	 * OpenCode `multiple`, Grok `multiSelect`). Answers join with ", ".
+	 */
+	multiSelect?: boolean;
 };
 
 /**
@@ -440,6 +447,24 @@ export function mapToolStatus(
 	}
 }
 
+/** True while an ask-user tool still needs a user decision (composer owns the form). */
+export function isPendingAskUserToolStatus(
+	status: string | null | undefined,
+): boolean {
+	const mapped = mapToolStatus(status);
+	return mapped === "pending" || mapped === "in_progress";
+}
+
+/**
+ * Pending tool-shaped ask-user request promoted from transcript → composer.
+ * OpenCode `question` / Claude AskUserQuestion / Codex tool variant, etc.
+ */
+export type ToolAskUserRequest = {
+	toolCallId: string;
+	sessionId: string;
+	questions: AskUserQuestion[];
+};
+
 export function toolPartState(
 	status: ToolUiState["status"],
 ): ToolUIPart["state"] {
@@ -460,8 +485,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Extract the documented Codex AskUserQuestion shape from raw ACP tool input.
- * Other tool calls deliberately return null so they retain the generic JSON UI.
+ * Detect structured "ask user" tool input from multiple agent harnesses.
+ *
+ * Shapes (none are ACP-standard tool schemas — client adapters only):
+ * - **Codex tool**: `{ variant: "AskUserQuestion", questions: [{ question, options }] }`
+ * - **Claude Code**: `{ questions: [{ question, header?, multiSelect?, options }] }`
+ * - **OpenCode `question`**: `{ questions: [{ question, header, options, multiple?, custom? }] }`
+ * - **Grok (when mirrored as tool rawInput)**: same questions array + `multiSelect`
+ *
+ * Unrelated tools return null so they keep the generic JSON UI.
+ * Prefer form elicitation / `x.ai/ask_user_question` when the agent uses those paths.
  */
 export function parseAskUserQuestions(
 	input: unknown,
@@ -474,29 +507,174 @@ export function parseAskUserQuestions(
 			return null;
 		}
 	}
-	if (!isRecord(payload) || payload.variant !== "AskUserQuestion") return null;
+	if (!isRecord(payload)) return null;
+
+	const isCodexVariant = payload.variant === "AskUserQuestion";
+	// Reject clearly non-question tools that happen to nest a questions key
+	// under other primary parameters (heuristic: only Codex variant OR
+	// top-level questions array is the dominant payload).
+	if (!isCodexVariant) {
+		if (payload.variant != null && payload.variant !== "AskUserQuestion") {
+			return null;
+		}
+		// Common non-question tool keys — if present with real work payload, skip.
+		if (
+			payload.command != null ||
+			payload.cmd != null ||
+			payload.filePath != null ||
+			payload.filepath != null ||
+			payload.path != null ||
+			payload.pattern != null ||
+			payload.url != null
+		) {
+			return null;
+		}
+	}
+
 	if (!Array.isArray(payload.questions)) return null;
 
-	const questions = payload.questions.flatMap((value) => {
-		if (!isRecord(value) || typeof value.question !== "string") return [];
-		const question = value.question.trim();
-		if (!question || !Array.isArray(value.options)) return [];
-		const options = value.options.flatMap((option) => {
-			if (!isRecord(option) || typeof option.label !== "string") return [];
+	const parsed = payload.questions.flatMap((value) => {
+		const one = parseOneAskUserQuestion(value, {
+			// Claude always offers Other; OpenCode `custom` defaults true;
+			// Codex tool path typically has fixed options only.
+			defaultAllowOther: !isCodexVariant,
+		});
+		return one ? [one] : [];
+	});
+	if (parsed.length === 0) return null;
+
+	// Claude (and some models) emit free-text as a *separate* questions[] entry
+	// after a multiple-choice page. Fold those into the previous page's Other.
+	const questions = foldFreeTextOnlyIntoPrevious(parsed);
+	return questions.length > 0 ? questions : null;
+}
+
+/** Labels that mean "type your own" — UI already has a free-text field. */
+function isSyntheticOtherOptionLabel(label: string): boolean {
+	const t = label.trim();
+	if (!t) return true;
+	// Exact-ish: Other / 其他 / Type your own answer / …
+	if (/^other(\b|[[:punct:]\s]|$)/i.test(t)) return true;
+	if (/^其他(\b|[[:punct:]\s]|$)/.test(t)) return true;
+	if (
+		/^(type|enter|write)\s+(your\s+)?(own\s+)?(answer|response|text)/i.test(t)
+	)
+		return true;
+	if (/^(自定义|自行输入|输入你的|自由输入)/.test(t)) return true;
+	if (/^or type\b/i.test(t)) return true;
+	return false;
+}
+
+/** Free-text page that is an Other companion, not a real standalone question. */
+function isOtherCompanionAskPage(q: AskUserQuestion): boolean {
+	if (q.options.length > 0) return false;
+	const blob = `${q.header ?? ""} ${q.question}`.toLowerCase();
+	if (
+		/type your own answer|instead of choosing an option|choosing an option above|or type your own|enter your own|please type your own/i.test(
+			blob,
+		)
+	) {
+		return true;
+	}
+	if (isSyntheticOtherOptionLabel(q.question)) return true;
+	if (q.header && isSyntheticOtherOptionLabel(q.header)) return true;
+	return false;
+}
+
+/**
+ * Merge Other free-text companion pages into the previous multi-choice page.
+ * Does **not** fold legitimate free-text questions (e.g. "Anything else?").
+ */
+function foldFreeTextOnlyIntoPrevious(
+	questions: AskUserQuestion[],
+): AskUserQuestion[] {
+	const out: AskUserQuestion[] = [];
+	for (const q of questions) {
+		const prev = out[out.length - 1];
+		if (isOtherCompanionAskPage(q) && prev && prev.options.length > 0) {
+			out[out.length - 1] = {
+				...prev,
+				allowOther: true,
+				// Keep companion field id for elicitation content mapping.
+				otherFieldId: prev.otherFieldId ?? q.id ?? q.otherFieldId,
+			};
+			continue;
+		}
+		out.push(q);
+	}
+	return out;
+}
+
+function parseOneAskUserQuestion(
+	value: unknown,
+	opts: { defaultAllowOther: boolean },
+): AskUserQuestion | null {
+	if (!isRecord(value) || typeof value.question !== "string") return null;
+	const question = value.question.trim();
+	if (!question) return null;
+
+	const header =
+		typeof value.header === "string"
+			? value.header.trim() || undefined
+			: undefined;
+
+	const multiSelect =
+		value.multiSelect === true ||
+		value.multiple === true ||
+		value.multi_select === true;
+
+	// OpenCode: `custom` (default true). Explicit false disables free-text.
+	// Claude: always Other. Codex tool: default false unless we see signals.
+	let allowOther = opts.defaultAllowOther;
+	if (typeof value.custom === "boolean") {
+		allowOther = value.custom;
+	} else if (value.allowOther === true || value.allow_other === true) {
+		allowOther = true;
+	}
+
+	const options: AskUserQuestionOption[] = [];
+	if (Array.isArray(value.options)) {
+		for (const option of value.options) {
+			if (!isRecord(option) || typeof option.label !== "string") continue;
 			const label = option.label.trim();
-			if (!label) return [];
+			if (!label) continue;
+			// Skip synthetic "Other" chips — we render free-text ourselves.
+			// Still set allowOther so the free-text field appears.
+			if (isSyntheticOtherOptionLabel(label)) {
+				allowOther = true;
+				continue;
+			}
 			const description =
 				typeof option.description === "string"
 					? option.description.trim() || undefined
 					: undefined;
-			return [{ label, description }];
-		});
-		return options.length ? [{ question, options }] : [];
-	});
+			const preview =
+				typeof option.preview === "string"
+					? option.preview.trim() || undefined
+					: undefined;
+			options.push({
+				label,
+				description: description ?? preview,
+			});
+		}
+	}
 
-	return questions.length === payload.questions.length && questions.length > 0
-		? questions
-		: null;
+	// Need either selectable options or free-text capability.
+	if (options.length === 0 && !allowOther) return null;
+
+	const id =
+		typeof value.id === "string" && value.id.trim()
+			? value.id.trim()
+			: undefined;
+
+	return {
+		...(id ? { id } : {}),
+		...(header ? { header } : {}),
+		question,
+		options,
+		allowOther: options.length === 0 ? true : allowOther,
+		...(multiSelect ? { multiSelect: true } : {}),
+	};
 }
 
 /** Format selected options as a concise, self-contained follow-up turn. */
@@ -529,8 +707,41 @@ type ElicitationFieldInput = {
 
 /** Codex companion free-text field: `questionId__other` or `questionId__other2`. */
 function parseOtherFieldParentId(fieldId: string): string | null {
-	const match = fieldId.match(/^(.*)__other\d*$/);
+	const match = fieldId.match(/^(.*)__other\d*$/i);
 	return match?.[1] ?? null;
+}
+
+function isTextishElicitationField(field: ElicitationFieldInput): boolean {
+	if (field.kind === "text") return true;
+	if (field.kind === "select" || field.kind === "boolean") return false;
+	return field.options.length === 0;
+}
+
+/**
+ * Codex / Claude free-text "Other" companion (often lacks __other id or meta).
+ * Example description: "Type your own answer instead of choosing an option above (optional)."
+ */
+function isOtherCompanionElicitationField(
+	field: ElicitationFieldInput,
+): boolean {
+	if (field.isOtherAnswer) return true;
+	if (!isTextishElicitationField(field)) return false;
+	if (parseOtherFieldParentId(field.id)) return true;
+	const blob = `${field.title ?? ""} ${field.description ?? ""}`.toLowerCase();
+	if (
+		/type your own answer|instead of choosing an option|choosing an option above|or type your own|enter your own/i.test(
+			blob,
+		)
+	) {
+		return true;
+	}
+	if (/^(other|其他)(\b|[[:punct:]\s]|$)/i.test(field.title.trim())) {
+		return true;
+	}
+	if (/可选|optional/.test(blob) && /own answer|自定义|自行/.test(blob)) {
+		return true;
+	}
+	return false;
 }
 
 function mapFieldOptions(
@@ -541,6 +752,8 @@ function mapFieldOptions(
 	for (const option of field.options) {
 		const label = (option.title || option.value).trim();
 		if (!label) continue;
+		// Skip synthetic Other chips — free-text field is separate.
+		if (isSyntheticOtherOptionLabel(label)) continue;
 		options.push({
 			label,
 			description: option.description?.trim() || undefined,
@@ -551,50 +764,123 @@ function mapFieldOptions(
 }
 
 /**
+ * Map Grok Host `agent:ask-user-request` DTOs into AskUserQuestion pages.
+ */
+export function questionsFromAskUserDtos(
+	items: Array<{
+		question: string;
+		options: Array<{ label: string; description?: string | null }>;
+		multiSelect?: boolean;
+		allowOther?: boolean;
+	}>,
+): AskUserQuestion[] {
+	return items.flatMap((item) => {
+		const question = item.question.trim();
+		if (!question) return [];
+		const options = item.options.flatMap((option) => {
+			const label = option.label.trim();
+			if (!label) return [];
+			const description =
+				typeof option.description === "string"
+					? option.description.trim() || undefined
+					: undefined;
+			return [{ label, description }];
+		});
+		const allowOther = item.allowOther !== false;
+		if (options.length === 0 && !allowOther) return [];
+		return [
+			{
+				question,
+				options,
+				allowOther: options.length === 0 ? true : allowOther,
+				...(item.multiSelect ? { multiSelect: true } : {}),
+			},
+		];
+	});
+}
+
+/**
  * Map ACP form elicitation fields into AskUserQuestion pages.
- * Codex splits each Q into select + optional `*__other` free-text — merge into one page.
+ * Codex / Claude split each Q into select + optional free-text Other — merge into one page.
+ *
+ * Parent linkage (any one is enough):
+ * 1. meta `isOtherAnswer` + `parentFieldId` / `questionId`
+ * 2. field id `questionId__other`
+ * 3. content heuristic ("Type your own answer instead of…") → attach to previous select
+ * 4. leftover free-text-only pages folded into previous select page
  */
 export function questionsFromElicitationFields(
 	fields: ElicitationFieldInput[],
 ): AskUserQuestion[] {
 	const otherByParent = new Map<string, ElicitationFieldInput>();
-	const mains: ElicitationFieldInput[] = [];
+	const consumedOtherIds = new Set<string>();
 
+	// Pass 1: explicit parent (meta or __other id).
 	for (const field of fields) {
+		if (!isTextishElicitationField(field) && !field.isOtherAnswer) continue;
 		const parentFromMeta =
 			field.isOtherAnswer && field.parentFieldId?.trim()
 				? field.parentFieldId.trim()
-				: null;
-		const parentFromId =
-			field.kind === "text" || field.options.length === 0
-				? parseOtherFieldParentId(field.id)
-				: null;
+				: field.parentFieldId?.trim() || null;
+		const parentFromId = parseOtherFieldParentId(field.id);
 		const parentId = parentFromMeta || parentFromId;
-		if (parentId && (field.isOtherAnswer || parentFromId)) {
-			otherByParent.set(parentId, field);
-			continue;
+		if (!parentId) continue;
+		// Prefer first companion per parent; ignore extras.
+		if (otherByParent.has(parentId)) continue;
+		otherByParent.set(parentId, field);
+		consumedOtherIds.add(field.id);
+	}
+
+	// Pass 2: content-based Other without meta — pair with nearest preceding select.
+	for (let i = 0; i < fields.length; i++) {
+		const field = fields[i];
+		if (!field || consumedOtherIds.has(field.id)) continue;
+		if (!isOtherCompanionElicitationField(field)) continue;
+		let parent: ElicitationFieldInput | undefined;
+		for (let j = i - 1; j >= 0; j--) {
+			const cand = fields[j];
+			if (!cand || consumedOtherIds.has(cand.id)) continue;
+			if (mapFieldOptions(cand).length > 0) {
+				parent = cand;
+				break;
+			}
 		}
-		mains.push(field);
+		if (!parent) continue;
+		if (otherByParent.has(parent.id)) continue;
+		otherByParent.set(parent.id, field);
+		consumedOtherIds.add(field.id);
 	}
 
 	const out: AskUserQuestion[] = [];
-	for (const field of mains) {
-		const question = (field.description || field.title).trim();
-		if (!question) continue;
+	for (const field of fields) {
+		if (consumedOtherIds.has(field.id)) continue;
 		const options = mapFieldOptions(field);
 		const other = otherByParent.get(field.id);
-		// Standalone free-text (no options, not an Other companion).
+		// Prefer title for select labels; description is often the long question.
+		// For free-text companions wrongly left as mains, description is boilerplate — skip later fold.
+		const question = (field.description || field.title).trim();
+		if (!question && options.length === 0 && !other) continue;
+
 		const freeTextOnly = options.length === 0 && !other;
+		// Don't use Other boilerplate as a standalone page title if we can fold later.
+		const displayQuestion =
+			freeTextOnly && isOtherCompanionElicitationField(field)
+				? (field.title || question).trim()
+				: question || field.title.trim();
+		if (!displayQuestion && options.length === 0) continue;
+
 		out.push({
 			id: field.id,
-			question,
+			question: displayQuestion || field.id,
 			options,
-			required: field.required !== false,
+			required: field.required !== false && !freeTextOnly,
 			allowOther: Boolean(other) || freeTextOnly,
 			otherFieldId: other?.id ?? (freeTextOnly ? field.id : undefined),
 		});
 	}
-	return out;
+
+	// Pass 3: any free-text-only page still after a select page → merge as Other.
+	return foldFreeTextOnlyIntoPrevious(out);
 }
 
 /**

--- a/src/lib/agent/chat-state.ts
+++ b/src/lib/agent/chat-state.ts
@@ -41,16 +41,30 @@ export type ToolUiState = {
 	output?: unknown;
 };
 
-/** A selectable answer supplied by an ACP AskUserQuestion tool call. */
+/** A selectable answer supplied by an ACP AskUserQuestion / form elicitation. */
 export type AskUserQuestionOption = {
 	label: string;
 	description?: string;
+	/** Stable value for elicitation content (defaults to label). */
+	value?: string;
 };
 
-/** A question supplied by an ACP AskUserQuestion tool call. */
+/** A question supplied by AskUserQuestion tool or form elicitation. */
 export type AskUserQuestion = {
+	/** Optional field id (elicitation schema property name). */
+	id?: string;
 	question: string;
+	/** Empty options and no allowOther → free-text only. */
 	options: AskUserQuestionOption[];
+	/** When false, free-text / other fields may be left blank. Default true. */
+	required?: boolean;
+	/**
+	 * Show a free-text "Other" input on the same page as options
+	 * (Codex request_user_input companion field).
+	 */
+	allowOther?: boolean;
+	/** Elicitation content key for free-text Other (e.g. `q1__other`). */
+	otherFieldId?: string;
 };
 
 /**
@@ -496,6 +510,119 @@ export function formatAskUserAnswers(
 				`Question: ${question.question}\nAnswer: ${answers[index]}`,
 		)
 		.join("\n\n");
+}
+
+type ElicitationFieldInput = {
+	id: string;
+	title: string;
+	description?: string | null;
+	required?: boolean;
+	kind: string;
+	options: Array<{
+		value: string;
+		title: string;
+		description?: string | null;
+	}>;
+	isOtherAnswer?: boolean;
+	parentFieldId?: string | null;
+};
+
+/** Codex companion free-text field: `questionId__other` or `questionId__other2`. */
+function parseOtherFieldParentId(fieldId: string): string | null {
+	const match = fieldId.match(/^(.*)__other\d*$/);
+	return match?.[1] ?? null;
+}
+
+function mapFieldOptions(
+	field: ElicitationFieldInput,
+): AskUserQuestionOption[] {
+	if (field.kind !== "select" && field.kind !== "boolean") return [];
+	const options: AskUserQuestionOption[] = [];
+	for (const option of field.options) {
+		const label = (option.title || option.value).trim();
+		if (!label) continue;
+		options.push({
+			label,
+			description: option.description?.trim() || undefined,
+			value: option.value,
+		});
+	}
+	return options;
+}
+
+/**
+ * Map ACP form elicitation fields into AskUserQuestion pages.
+ * Codex splits each Q into select + optional `*__other` free-text — merge into one page.
+ */
+export function questionsFromElicitationFields(
+	fields: ElicitationFieldInput[],
+): AskUserQuestion[] {
+	const otherByParent = new Map<string, ElicitationFieldInput>();
+	const mains: ElicitationFieldInput[] = [];
+
+	for (const field of fields) {
+		const parentFromMeta =
+			field.isOtherAnswer && field.parentFieldId?.trim()
+				? field.parentFieldId.trim()
+				: null;
+		const parentFromId =
+			field.kind === "text" || field.options.length === 0
+				? parseOtherFieldParentId(field.id)
+				: null;
+		const parentId = parentFromMeta || parentFromId;
+		if (parentId && (field.isOtherAnswer || parentFromId)) {
+			otherByParent.set(parentId, field);
+			continue;
+		}
+		mains.push(field);
+	}
+
+	const out: AskUserQuestion[] = [];
+	for (const field of mains) {
+		const question = (field.description || field.title).trim();
+		if (!question) continue;
+		const options = mapFieldOptions(field);
+		const other = otherByParent.get(field.id);
+		// Standalone free-text (no options, not an Other companion).
+		const freeTextOnly = options.length === 0 && !other;
+		out.push({
+			id: field.id,
+			question,
+			options,
+			required: field.required !== false,
+			allowOther: Boolean(other) || freeTextOnly,
+			otherFieldId: other?.id ?? (freeTextOnly ? field.id : undefined),
+		});
+	}
+	return out;
+}
+
+/**
+ * Build elicitation content map.
+ * Option pick → primary field id; free-text Other → otherFieldId (Codex preference).
+ */
+export function elicitationContentFromAnswers(
+	questions: AskUserQuestion[],
+	answers: string[],
+): Record<string, string> {
+	const content: Record<string, string> = {};
+	for (let i = 0; i < questions.length; i++) {
+		const q = questions[i];
+		const answer = answers[i]?.trim();
+		if (!q || !answer) continue;
+		const matched = q.options.find((option) => option.label === answer);
+		if (matched && q.id) {
+			content[q.id] = matched.value ?? matched.label;
+			continue;
+		}
+		// Free-text / Other (not matching an option label).
+		if (q.otherFieldId) {
+			content[q.otherFieldId] = answer;
+		} else if (q.id) {
+			content[q.id] = answer;
+		}
+	}
+	return content;
 }
 
 export type ToolPatch = {

--- a/test/agent-chat-state.test.ts
+++ b/test/agent-chat-state.test.ts
@@ -15,8 +15,10 @@ import {
 	errorText,
 	formatAskUserAnswers,
 	isBackgroundWorkflowHistoryTitle,
+	isPendingAskUserToolStatus,
 	parseAskUserQuestions,
 	providerSessionIdForHistoryLoad,
+	questionsFromAskUserDtos,
 	questionsFromElicitationFields,
 	resetAgentChatIds,
 	resolveSelected,
@@ -107,7 +109,15 @@ describe("stream / tool / plan parts", () => {
 });
 
 describe("AskUserQuestion tool input", () => {
-	it("parses selectable questions and formats the selected answers", () => {
+	it("treats pending and in_progress as interactive ask-user tool status", () => {
+		expect(isPendingAskUserToolStatus("pending")).toBe(true);
+		expect(isPendingAskUserToolStatus("in_progress")).toBe(true);
+		expect(isPendingAskUserToolStatus(null)).toBe(true);
+		expect(isPendingAskUserToolStatus("completed")).toBe(false);
+		expect(isPendingAskUserToolStatus("failed")).toBe(false);
+	});
+
+	it("parses Codex variant selectable questions and formats answers", () => {
 		const questions = parseAskUserQuestions({
 			variant: "AskUserQuestion",
 			questions: [
@@ -128,11 +138,151 @@ describe("AskUserQuestion tool input", () => {
 					{ label: "Paper", description: "Only the open paper" },
 					{ label: "Vault", description: undefined },
 				],
+				allowOther: false,
 			},
 		]);
 		expect(formatAskUserAnswers(questions ?? [], ["Paper"])).toBe(
 			"Question: Which scope should I use?\nAnswer: Paper",
 		);
+	});
+
+	it("parses Claude AskUserQuestion shape (header + multiSelect + Other)", () => {
+		const questions = parseAskUserQuestions({
+			questions: [
+				{
+					question: "Which authentication method should we use?",
+					header: "Auth method",
+					multiSelect: false,
+					options: [
+						{ label: "OAuth 2.0", description: "Industry standard" },
+						{ label: "JWT", description: "Stateless" },
+					],
+				},
+				{
+					question: "Which features do you want?",
+					header: "Features",
+					multiSelect: true,
+					options: [
+						{ label: "Auto-scaling", description: "Scale out" },
+						{ label: "Monitoring", description: "Metrics" },
+					],
+				},
+			],
+		});
+		expect(questions).toHaveLength(2);
+		expect(questions?.[0]).toMatchObject({
+			question: "Which authentication method should we use?",
+			header: "Auth method",
+			allowOther: true,
+		});
+		expect(questions?.[0]?.multiSelect).toBeUndefined();
+		expect(questions?.[1]).toMatchObject({
+			header: "Features",
+			multiSelect: true,
+			allowOther: true,
+		});
+	});
+
+	it("parses OpenCode question tool shape (multiple + custom)", () => {
+		const questions = parseAskUserQuestions({
+			questions: [
+				{
+					question: "Preferred UI language?",
+					header: "Language",
+					multiple: false,
+					custom: true,
+					options: [
+						{ label: "Chinese", description: "中文" },
+						{ label: "English", description: "EN" },
+						// Synthetic Other is stripped when custom is on.
+						{ label: "Other", description: "Type your own" },
+					],
+				},
+			],
+		});
+		expect(questions).toEqual([
+			{
+				question: "Preferred UI language?",
+				header: "Language",
+				options: [
+					{ label: "Chinese", description: "中文" },
+					{ label: "English", description: "EN" },
+				],
+				allowOther: true,
+			},
+		]);
+	});
+
+	it("parses Grok-shaped multi_select questions", () => {
+		const questions = parseAskUserQuestions({
+			questions: [
+				{
+					question: "Pick targets",
+					multi_select: true,
+					options: [
+						{ label: "A", description: "one", preview: "preview-a" },
+						{ label: "B", description: "two" },
+					],
+				},
+			],
+		});
+		expect(questions?.[0]).toMatchObject({
+			question: "Pick targets",
+			multiSelect: true,
+			allowOther: true,
+		});
+		expect(questions?.[0]?.options[0]?.description).toBe("one");
+	});
+
+	it("folds Claude free-text companion questions into the previous page Other", () => {
+		const questions = parseAskUserQuestions({
+			questions: [
+				{
+					question: "Which language?",
+					header: "Lang",
+					options: [
+						{ label: "中文", description: "Chinese" },
+						{ label: "English", description: "EN" },
+						{ label: "Other", description: "Type your own" },
+					],
+				},
+				// Model-emitted free-text page — must not be a second flip page.
+				{
+					question: "Please type your own answer",
+					header: "Other",
+					options: [],
+				},
+			],
+		});
+		expect(questions).toHaveLength(1);
+		expect(questions?.[0]).toMatchObject({
+			question: "Which language?",
+			allowOther: true,
+		});
+		expect(questions?.[0]?.options.map((o) => o.label)).toEqual([
+			"中文",
+			"English",
+		]);
+	});
+
+	it("strips 其他 / Type your own option labels into allowOther", () => {
+		const questions = parseAskUserQuestions({
+			questions: [
+				{
+					question: "Pick one",
+					options: [
+						{ label: "A" },
+						{ label: "其他" },
+						{ label: "Type your own answer" },
+					],
+				},
+			],
+		});
+		expect(questions).toHaveLength(1);
+		expect(questions?.[0]?.options).toEqual([
+			{ label: "A", description: undefined },
+		]);
+		expect(questions?.[0]?.allowOther).toBe(true);
 	});
 
 	it("leaves malformed or unrelated tools on the generic UI", () => {
@@ -142,6 +292,48 @@ describe("AskUserQuestion tool input", () => {
 		expect(
 			parseAskUserQuestions('{"variant":"AskUserQuestion","questions":[]}'),
 		).toBe(null);
+		// Shell-like payloads must not become ask-user forms.
+		expect(
+			parseAskUserQuestions({
+				command: "ls",
+				questions: [
+					{
+						question: "noop",
+						options: [{ label: "x" }],
+					},
+				],
+			}),
+		).toBe(null);
+	});
+
+	it("maps Grok ask-user DTOs into form pages", () => {
+		const questions = questionsFromAskUserDtos([
+			{
+				question: "Preferred language?",
+				multiSelect: false,
+				allowOther: true,
+				options: [
+					{ label: "Chinese", description: "中文" },
+					{ label: "English" },
+				],
+			},
+			{
+				question: "Pick features",
+				multiSelect: true,
+				allowOther: true,
+				options: [{ label: "A" }, { label: "B" }],
+			},
+		]);
+		expect(questions).toHaveLength(2);
+		expect(questions[0]).toMatchObject({
+			question: "Preferred language?",
+			allowOther: true,
+		});
+		expect(questions[0]?.multiSelect).toBeUndefined();
+		expect(questions[1]).toMatchObject({
+			multiSelect: true,
+			allowOther: true,
+		});
 	});
 
 	it("maps form elicitation fields and merges Codex Other free-text into one page", () => {
@@ -202,6 +394,69 @@ describe("AskUserQuestion tool input", () => {
 		).toEqual({
 			lang__other: "自定义语言",
 			notes: "x",
+		});
+	});
+
+	it("merges elicitation Other without meta (Codex boilerplate description)", () => {
+		// No isOtherAnswer / parentFieldId / __other id — only the stock description.
+		const questions = questionsFromElicitationFields([
+			{
+				id: "q0",
+				title: "Language",
+				description: "Which language?",
+				required: true,
+				kind: "select",
+				options: [
+					{ value: "zh", title: "中文" },
+					{ value: "en", title: "English" },
+				],
+			},
+			{
+				id: "q0_free",
+				title: "q0_free",
+				description:
+					"Type your own answer instead of choosing an option above (optional).",
+				required: false,
+				kind: "text",
+				options: [],
+			},
+			{
+				id: "q1",
+				title: "Scope",
+				description: "Which scope?",
+				required: true,
+				kind: "select",
+				options: [{ value: "paper", title: "Paper" }],
+			},
+			{
+				id: "q1_free",
+				title: "q1_free",
+				description:
+					"Type your own answer instead of choosing an option above (optional).",
+				required: false,
+				kind: "text",
+				options: [],
+			},
+		]);
+		expect(questions).toHaveLength(2);
+		expect(questions[0]).toMatchObject({
+			id: "q0",
+			question: "Which language?",
+			allowOther: true,
+			otherFieldId: "q0_free",
+		});
+		expect(questions[1]).toMatchObject({
+			id: "q1",
+			question: "Which scope?",
+			allowOther: true,
+			otherFieldId: "q1_free",
+		});
+		// Free-text answers write to companion field ids.
+		expect(
+			elicitationContentFromAnswers(questions, ["自定义", "Paper"]),
+		).toEqual({
+			q0_free: "自定义",
+			q1: "paper",
 		});
 	});
 });

--- a/test/agent-chat-state.test.ts
+++ b/test/agent-chat-state.test.ts
@@ -9,6 +9,7 @@ import {
 	buildOptions,
 	type ChatLine,
 	dedupeModelsClient,
+	elicitationContentFromAnswers,
 	ensureModelsInclude,
 	errorChatLine,
 	errorText,
@@ -16,6 +17,7 @@ import {
 	isBackgroundWorkflowHistoryTitle,
 	parseAskUserQuestions,
 	providerSessionIdForHistoryLoad,
+	questionsFromElicitationFields,
 	resetAgentChatIds,
 	resolveSelected,
 	shouldDeferSessionEvent,
@@ -140,6 +142,67 @@ describe("AskUserQuestion tool input", () => {
 		expect(
 			parseAskUserQuestions('{"variant":"AskUserQuestion","questions":[]}'),
 		).toBe(null);
+	});
+
+	it("maps form elicitation fields and merges Codex Other free-text into one page", () => {
+		const questions = questionsFromElicitationFields([
+			{
+				id: "lang",
+				title: "Language",
+				description: "Which language?",
+				required: true,
+				kind: "select",
+				options: [
+					{ value: "zh", title: "中文为主", description: "默认中文" },
+					{ value: "en", title: "英文为主" },
+				],
+			},
+			{
+				id: "lang__other",
+				title: "Other",
+				description:
+					"Type your own answer instead of choosing an option above.",
+				required: false,
+				kind: "text",
+				options: [],
+				isOtherAnswer: true,
+				parentFieldId: "lang",
+			},
+			{
+				id: "notes",
+				title: "Notes",
+				description: "Anything else?",
+				required: false,
+				kind: "text",
+				options: [],
+			},
+		]);
+		expect(questions).toHaveLength(2);
+		expect(questions[0]).toMatchObject({
+			id: "lang",
+			question: "Which language?",
+			allowOther: true,
+			otherFieldId: "lang__other",
+			required: true,
+		});
+		expect(questions[0]?.options).toHaveLength(2);
+		expect(questions[1]).toMatchObject({
+			id: "notes",
+			question: "Anything else?",
+			allowOther: true,
+			otherFieldId: "notes",
+			required: false,
+		});
+		// Option pick → primary id; free-text Other → __other key.
+		expect(elicitationContentFromAnswers(questions, ["中文为主", ""])).toEqual({
+			lang: "zh",
+		});
+		expect(
+			elicitationContentFromAnswers(questions, ["自定义语言", "x"]),
+		).toEqual({
+			lang__other: "自定义语言",
+			notes: "x",
+		});
 	});
 });
 


### PR DESCRIPTION
## 改动概述

- ACP **无统一** ask-user tool 规范：各 harness 的 tool / form elicitation / 私有 ext 经 Client adapter 归一为同一套 `AskUserQuestion` 问卷
- Client `initialize` 声明 `elicitation.form`（Host `unstable_elicitation`）；Codex Plan 下 `request_user_input` 可走 form elicitation
- **Grok**：Host 处理 `_x.ai/ask_user_question` JSON-RPC → `agent:ask-user-request` / `agent_respond_ask_user`；与 tool 镜像去重
- **OpenCode**：spawn 注入 `OPENCODE_ENABLE_QUESTION_TOOL=1`；turn 阻塞 question 时 cancel + drain，作答可立刻发出
- **Claude / Codex tool**：解析 rawInput；Claude Other 伴生页合并进当前题，避免多翻一页
- 单一交互面：`AgentAskUserSurface` 底部问卷；与 free-text **composer 互斥**（提交/取消后恢复）；优先级 elicitation > Grok ext > tool 提升
- 会话「模式」仅保留 Codex `collaboration_mode`（UI 称模式，只显示名称）；**不再**暴露 ACP `category: mode` 沙箱档

Closes #206

## Demo

<img width="1758" height="1118" alt="image" src="https://github.com/user-attachments/assets/d82ce637-5a74-4f6d-af91-3dc1c259a7bc" />

> 提问时隐藏底部 composer; 多个问题将会分页显示

## 背景 / 复盘摘要

在 ACP 下，「向用户结构化提问」没有统一 tool 规范：字段形状与挂载方式（tool call、form elicitation、私有 ext method）因 harness 而异。Agentero 作为 ACP **Client** 收成同一张问卷，主要三层：

1. **打开交互能力** — `initialize` 声明 `elicitation.form` 等；不声明时部分 agent（如 codex-acp `request_user_input`）会空答或走不通表单。
2. **Client adapter 归一** — tool `rawInput` / elicitation fields / Grok DTO → `AskUserQuestion` 页与 `AskUserQuestionForm`。
3. **Harness 特例** — Grok 走 Host JSON-RPC；OpenCode 依赖 spawn env；OpenCode 阻塞 turn 需 cancel+drain。

前端只保留单一交互面；transcript tool 卡不嵌选项，只提示在底部问卷作答。

### 深入阅读

- [docs/backend/agent.md — 结构化提问（多 harness）](https://github.com/poco-ai/Agentero/blob/fix/acp-mode-and-elicitation/docs/backend/agent.md#结构化提问多-harness)
- [docs/frontend/agent.md — 表单 Elicitation / AskUserQuestion](https://github.com/poco-ai/Agentero/blob/fix/acp-mode-and-elicitation/docs/frontend/agent.md#表单-elicitation--askuserquestion同一-ui)
- [docs/architecture.md — Agent 面板](https://github.com/poco-ai/Agentero/blob/fix/acp-mode-and-elicitation/docs/architecture.md#agent-面板)
- [docs/backend/api.md](https://github.com/poco-ai/Agentero/blob/fix/acp-mode-and-elicitation/docs/backend/api.md)（`agent:elicitation-request` / `agent:ask-user-request` 等事件）

## 用户影响

- Agent 发起结构化提问时，底部出现问卷，输入框暂时隐藏；提交或取消后恢复
- 同一会话任意时刻最多一张问卷；tool 卡内不再嵌选项表单
- Composer「模式」对应协作/Plan 轴（有上报时）；Host 全局权限（restricted/ask/auto）仍在设置中
- OpenCode 用户无需手改 env，默认已启用 question tool

## 验证

- [x] 本机实测通过的 harness 组合：
  - **Grok Build**
  - **Codex + GLM**（第三方订阅）
  - **OpenCode**
  - **Claude Code**
  - **Qoder**
- [x] **不保证**其它 harness / adapter 组合有效（ACP adapter 之间差异大，未覆盖的需单独适配或回归）
- [x] `cargo test --lib features::agent::acp::config_option_tests`
- [x] 前端相关 typecheck / lint-staged（提交时 husky）
- [x] CI on PR

## 说明

codex 提示只有在 plan 模式下才能使用询问工具:
<img width="2942" height="1643" alt="image" src="https://github.com/user-attachments/assets/241311f2-0872-4307-acd9-f8701290baab" />

补充 acp 对 `build/plan` 模式的发现和选择能力之后可用.