### PR TITLE
perf(wiki): 自动保存的 modify 事件不再触发全量 graph 重建

### DIFF
--- a/docs/frontend/markdown.md
+++ b/docs/frontend/markdown.md
@@ -51,7 +51,7 @@ Plate WYSIWYG；用于普通笔记与论文 `NOTES.md`。磁盘上始终是标�
 保存
   → 序列化为 Markdown 文本
   → Host 写盘
-  → watcher → 按需重建 wiki 索引
+  → watcher → 自写回声只刷新嵌入投影，不重建索引；外部变更按需重建 wiki 索引
 ```
 
 ### 显式格式整理

--- a/src/lib/wiki/store.ts
+++ b/src/lib/wiki/store.ts
@@ -1,8 +1,8 @@
 /**
  * Wiki / rename state (zustand vanilla): index revision signal, in-app rename
  * dialog draft, and external-rename repair flow. Also owns the debounced wiki
- * rebuild scheduler and the internal-rename watcher-echo filter (module-level
- * timers replace the old App refs).
+ * rebuild scheduler and the watcher-echo filters (internal rename transactions
+ * and self-writes; module-level timers replace the old App refs).
  */
 
 import { createStore } from "zustand/vanilla";
@@ -113,6 +113,8 @@ export async function rebuildWikiAndNotify(path: string): Promise<void> {
 let wikiRebuildTimer: ReturnType<typeof setTimeout> | null = null;
 /** Watcher paths collected for the current debounced Wiki rebuild. */
 const wikiRebuildPaths = new Set<string>();
+/** Self-write echoes that only refresh mounted embeds, skipping the rebuild. */
+const wikiEchoEmbedPaths = new Set<string>();
 
 /**
  * Markdown files carry references; images and PDFs are canonical targets
@@ -121,18 +123,58 @@ const wikiRebuildPaths = new Set<string>();
  */
 export function scheduleWikiRebuild(absPath: string): void {
 	if (!isWikiTargetPath(absPath)) return;
-	wikiRebuildPaths.add(absPath);
+	// Autosave/⌘S echo: the app already knows about this write, so a full
+	// rebuild would just re-index content it wrote itself (#270).
+	if (isSelfWrittenPath(absPath)) wikiEchoEmbedPaths.add(absPath);
+	else wikiRebuildPaths.add(absPath);
 	if (wikiRebuildTimer) clearTimeout(wikiRebuildTimer);
 	wikiRebuildTimer = setTimeout(() => {
 		wikiRebuildTimer = null;
 		const changedPaths = [...wikiRebuildPaths];
 		wikiRebuildPaths.clear();
+		const echoPaths = [...wikiEchoEmbedPaths];
+		wikiEchoEmbedPaths.clear();
 		const vault = getVaultPath();
 		if (!vault) return;
+		if (changedPaths.length === 0) {
+			notifyWikiEmbedTargets(echoPaths);
+			return;
+		}
 		void rebuildWikiAndNotify(vault).finally(() =>
-			notifyWikiEmbedTargets(changedPaths),
+			notifyWikiEmbedTargets([...changedPaths, ...echoPaths]),
 		);
 	}, 900);
+}
+
+/** Paths this app just wrote to disk; their watcher echoes skip the rebuild. */
+const selfWrittenPaths = new Map<string, number>();
+
+/** Watcher echoes of an app write settle well within this window. */
+const SELF_WRITE_ECHO_TTL_MS = 4000;
+
+/**
+ * Remember a path this app wrote to disk so its watcher echo does not
+ * re-trigger a full Wiki rebuild on every autosave. Only gates the rebuild
+ * trigger; every other watcher consumer still sees the event.
+ */
+export function trackSelfWrittenPath(path: string): void {
+	selfWrittenPaths.set(
+		normalizeTabPath(path),
+		Date.now() + SELF_WRITE_ECHO_TTL_MS,
+	);
+}
+
+function isSelfWrittenPath(absPath: string): boolean {
+	const now = Date.now();
+	const normalized = normalizeTabPath(absPath);
+	for (const [path, expiresAt] of selfWrittenPaths) {
+		if (expiresAt <= now) {
+			selfWrittenPaths.delete(path);
+			continue;
+		}
+		if (normalized === path) return true;
+	}
+	return false;
 }
 
 /** Host watcher paths caused by a committed rename transaction. */

--- a/src/lib/workspace/actions.ts
+++ b/src/lib/workspace/actions.ts
@@ -50,7 +50,7 @@ import {
 	type WikiNavTarget,
 	wikiNavigationDestination,
 } from "@/lib/wiki";
-import { rebuildWikiAndNotify } from "@/lib/wiki/store";
+import { rebuildWikiAndNotify, trackSelfWrittenPath } from "@/lib/wiki/store";
 import { dockHandle } from "@/lib/workspace/dock-registry";
 import {
 	getActiveTabId,
@@ -779,6 +779,9 @@ export function persistFile(
 			}
 			try {
 				await writeVaultFile(path, md);
+				// The watcher echo of this write must not re-trigger a full Wiki
+				// rebuild on every autosave (#270).
+				trackSelfWrittenPath(path);
 				// Advance the owning tab's seed only after the write is confirmed.
 				setTabs((prev) => syncTabSeedsForPath(prev, path, md));
 				return true;

--- a/test/wiki-self-write-echo.test.ts
+++ b/test/wiki-self-write-echo.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getVaultPath } from "@/lib/vault/store";
+import { rebuildWikiIndex } from "@/lib/wiki";
+import { scheduleWikiRebuild, trackSelfWrittenPath } from "@/lib/wiki/store";
+import { subscribeWikiEmbedTarget } from "@/lib/wiki-embed-refresh";
+
+vi.mock("@/lib/wiki", () => ({
+	rebuildWikiIndex: vi.fn(async () => ({ added: 0, removed: 0 })),
+}));
+vi.mock("@/lib/vault/store", () => ({
+	getVaultPath: vi.fn(() => "/vault"),
+}));
+
+describe("wiki self-write echo filter", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+	});
+
+	it("skips the full rebuild for an app-authored write but refreshes embeds", async () => {
+		trackSelfWrittenPath("/vault/notes/Self.md");
+		const embedListener = vi.fn();
+		const unsubscribe = subscribeWikiEmbedTarget(
+			"/vault/notes/Self.md",
+			embedListener,
+		);
+
+		scheduleWikiRebuild("/vault/notes/Self.md");
+		await vi.advanceTimersByTimeAsync(900);
+
+		expect(rebuildWikiIndex).not.toHaveBeenCalled();
+		expect(embedListener).toHaveBeenCalledTimes(1);
+		unsubscribe();
+	});
+
+	it("still rebuilds for external changes", async () => {
+		scheduleWikiRebuild("/vault/notes/External.md");
+		await vi.advanceTimersByTimeAsync(900);
+
+		expect(rebuildWikiIndex).toHaveBeenCalledTimes(1);
+		expect(rebuildWikiIndex).toHaveBeenCalledWith("/vault");
+	});
+
+	it("rebuilds once and refreshes all embeds on a mixed self/external batch", async () => {
+		trackSelfWrittenPath("/vault/notes/SelfBatch.md");
+		const selfListener = vi.fn();
+		const externalListener = vi.fn();
+		const unsubscribeSelf = subscribeWikiEmbedTarget(
+			"/vault/notes/SelfBatch.md",
+			selfListener,
+		);
+		const unsubscribeExternal = subscribeWikiEmbedTarget(
+			"/vault/notes/ExternalBatch.md",
+			externalListener,
+		);
+
+		scheduleWikiRebuild("/vault/notes/SelfBatch.md");
+		scheduleWikiRebuild("/vault/notes/ExternalBatch.md");
+		await vi.advanceTimersByTimeAsync(900);
+
+		expect(rebuildWikiIndex).toHaveBeenCalledTimes(1);
+		expect(selfListener).toHaveBeenCalledTimes(1);
+		expect(externalListener).toHaveBeenCalledTimes(1);
+		unsubscribeSelf();
+		unsubscribeExternal();
+	});
+
+	it("stops suppressing once the self-write TTL expired", async () => {
+		trackSelfWrittenPath("/vault/notes/Expired.md");
+		await vi.advanceTimersByTimeAsync(4500);
+
+		scheduleWikiRebuild("/vault/notes/Expired.md");
+		await vi.advanceTimersByTimeAsync(900);
+
+		expect(rebuildWikiIndex).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not rebuild when no vault is open", async () => {
+		vi.mocked(getVaultPath).mockReturnValueOnce(null);
+
+		scheduleWikiRebuild("/vault/notes/NoVault.md");
+		await vi.advanceTimersByTimeAsync(900);
+
+		expect(rebuildWikiIndex).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- 自动保存写盘 → Host watcher 回声 → 900ms 防抖 → `graph_rebuild` 的回环缺少自写过滤：编辑器每停一次就全量重建一次 Wiki 索引。
- `persistFile` 成功写盘后记录自写路径（模块级 Map，TTL 4s，复用 `trackInternalRenamePaths` 的懒过期模式）；`scheduleWikiRebuild` 对命中自写记录的回声跳过 `graph_rebuild`，仅在同一防抖窗口内刷新已挂载的嵌入投影（`notifyWikiEmbedTargets`），保持嵌入实时更新的既有行为。
- 过滤点只挂在 wiki rebuild 触发入口：编辑器 reseed（`onDiskChange`）、文件树、Library 等其他 watcher 消费者照常收到事件；外部修改、TTL 过期后的事件仍照常触发重建。增量 rebuild 留作后续 issue。

## Test plan
- [x] 新增 `test/wiki-self-write-echo.test.ts`：自写回声跳过 rebuild 但刷新嵌入；外部变更仍 rebuild；混合批次只 rebuild 一次且两类嵌入都刷新；TTL 过期后恢复 rebuild；无 vault 时不 rebuild
- [x] `pnpm exec vitest run` 全量 86 文件 / 685 用例通过
- [x] `pnpm exec tsc --noEmit` 与 `biome check` 通过
- [ ] 手动：编辑笔记连续输入，确认停止输入后不再出现 `graph_rebuild` 调用（日志/性能面板）；外部工具修改 Vault 文件后 Backlinks/Graph 仍正常刷新

Fixes #270