### PR TITLE
perf(agent): 卸载时清理流式 IPC 监听并取消挂起 run

### DIFF
--- a/src/components/agent/use-agent-panel.ts
+++ b/src/components/agent/use-agent-panel.ts
@@ -194,6 +194,13 @@ import {
 } from "@/lib/ui/prompt-recall";
 import { toVaultRelative } from "@/lib/wiki";
 
+/**
+ * Debounce before the Chat-open / agent-switch warm spawns its ACP process.
+ * `warm_agent` has no cancellation path, so every superseded spawn would run
+ * to completion as an orphan; settling the switch first avoids that (Fix #274).
+ */
+const WARM_SPAWN_DEBOUNCE_MS = 300;
+
 export type UseAgentPanelArgs = Pick<
 	AgentPanelProps,
 	| "vaultPath"
@@ -718,23 +725,29 @@ export function useAgentPanel({
 	// When Chat opens (or agent/vault changes), warm ACP in the background for models/context.
 	useEffect(() => {
 		if (!isTauri() || !selectedAgentId || !agentListenersReady) return;
+		// Supersede any in-flight warm immediately (its results are dropped)…
 		const gen = ++warmGenRef.current;
 		let cancelled = false;
-		const agentId = selectedAgentId;
-		const requestVaultPath = vaultPath;
-		void runWarmAgent({
-			agentId,
-			vaultPath: requestVaultPath,
-			modelId: loadModelPref(agentId) ?? undefined,
-			collaborationModeId: loadCollaborationPref(agentId) ?? undefined,
-			generation: gen,
-			stillValid: () =>
-				!cancelled &&
-				selectedAgentIdRef.current === agentId &&
-				vaultPathRef.current === requestVaultPath,
-		});
+		// …but debounce the spawn itself: warm_agent cannot be cancelled, so a
+		// rapid agent/vault switch must not start one ACP process per change.
+		const timer = setTimeout(() => {
+			const agentId = selectedAgentId;
+			const requestVaultPath = vaultPath;
+			void runWarmAgent({
+				agentId,
+				vaultPath: requestVaultPath,
+				modelId: loadModelPref(agentId) ?? undefined,
+				collaborationModeId: loadCollaborationPref(agentId) ?? undefined,
+				generation: gen,
+				stillValid: () =>
+					!cancelled &&
+					selectedAgentIdRef.current === agentId &&
+					vaultPathRef.current === requestVaultPath,
+			});
+		}, WARM_SPAWN_DEBOUNCE_MS);
 		return () => {
 			cancelled = true;
+			clearTimeout(timer);
 		};
 	}, [selectedAgentId, vaultPath, runWarmAgent, agentListenersReady]);
 

--- a/src/components/viewer/pdf/hooks/use-pdf-ask-threads.ts
+++ b/src/components/viewer/pdf/hooks/use-pdf-ask-threads.ts
@@ -30,6 +30,8 @@ import {
 	type RefObject,
 	type SetStateAction,
 	useCallback,
+	useEffect,
+	useRef,
 	useState,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -125,6 +127,28 @@ export function usePdfAskThreads({
 	const { t } = useTranslation("viewer");
 	const [streaming, setStreaming] = useState(false);
 	const [askError, setAskError] = useState<string | null>(null);
+	/** Per-run IPC unlisteners of the in-flight ask turn (null when idle). */
+	const runUnsubsRef = useRef<UnlistenFn[] | null>(null);
+	/** True once the viewer unmounts; guards runs accepted after teardown. */
+	const runDisposedRef = useRef(false);
+
+	// Closing the viewer must not strand the run's IPC listeners (or the run
+	// itself): terminal events never arrive for a hung run, so teardown cannot
+	// rely on the completed/failed handlers alone.
+	useEffect(() => {
+		runDisposedRef.current = false;
+		return () => {
+			runDisposedRef.current = true;
+			const unsubs = runUnsubsRef.current;
+			runUnsubsRef.current = null;
+			if (unsubs) for (const u of unsubs) u();
+			const sid = activeSessionRef.current;
+			if (sid) {
+				activeSessionRef.current = null;
+				void cancelAgentRun(sid).catch(() => undefined);
+			}
+		};
+	}, [activeSessionRef]);
 
 	const persist = useCallback(
 		async (thread: PdfAskThread) => {
@@ -227,6 +251,11 @@ export function usePdfAskThreads({
 					autoApprove: true,
 					hideFromChatHistory: true,
 				});
+				if (runDisposedRef.current) {
+					// Viewer unmounted while the run was being accepted: drop it.
+					void cancelAgentRun(accepted.sessionId).catch(() => undefined);
+					return;
+				}
 				activeSessionRef.current = accepted.sessionId;
 				const withAssistant: PdfAskThread = {
 					...withUser,
@@ -244,8 +273,10 @@ export function usePdfAskThreads({
 				upsertThread(withAssistant);
 				const sessionId = accepted.sessionId;
 				const unsubs: UnlistenFn[] = [];
+				runUnsubsRef.current = unsubs;
 				const cleanup = () => {
 					for (const u of unsubs) u();
+					if (runUnsubsRef.current === unsubs) runUnsubsRef.current = null;
 					if (activeSessionRef.current === sessionId)
 						activeSessionRef.current = null;
 					setStreaming(false);
@@ -312,6 +343,11 @@ export function usePdfAskThreads({
 						cleanup();
 					}),
 				);
+				if (runDisposedRef.current) {
+					// Viewer unmounted while the listeners were being attached.
+					cleanup();
+					return;
+				}
 			} catch (e) {
 				setStreaming(false);
 				setAskError(e instanceof Error ? e.message : t("pdfAsk.agentFailed"));

--- a/src/components/viewer/pdf/hooks/use-pdf-selection-translate.ts
+++ b/src/components/viewer/pdf/hooks/use-pdf-selection-translate.ts
@@ -130,6 +130,30 @@ export function usePdfSelectionTranslate({
 	const [translateError, setTranslateError] = useState<string | null>(null);
 	/** ACP session of the running translate turn (null for provider translate). */
 	const translateSessionRef = useRef<string | null>(null);
+	/** Per-run IPC unlisteners of the in-flight translate turn (null when idle). */
+	const translateUnsubsRef = useRef<UnlistenFn[] | null>(null);
+	/** True once the viewer unmounts; guards runs accepted after teardown. */
+	const translateDisposedRef = useRef(false);
+
+	// Closing the viewer must not strand the run's IPC listeners (or the run
+	// itself): terminal events never arrive for a hung run, so teardown cannot
+	// rely on the completed/failed handlers alone.
+	useEffect(() => {
+		translateDisposedRef.current = false;
+		return () => {
+			translateDisposedRef.current = true;
+			const unsubs = translateUnsubsRef.current;
+			translateUnsubsRef.current = null;
+			if (unsubs) for (const u of unsubs) u();
+			const sid = translateSessionRef.current;
+			if (sid) {
+				translateSessionRef.current = null;
+				if (activeSessionRef.current === sid) activeSessionRef.current = null;
+				void cancelAgentRun(sid).catch(() => undefined);
+			}
+			translateStreamingRef.current = false;
+		};
+	}, [activeSessionRef, translateStreamingRef]);
 
 	const stopTranslateSession = useCallback(() => {
 		const sid = translateSessionRef.current;
@@ -249,12 +273,20 @@ export function usePdfSelectionTranslate({
 							autoApprove: true,
 							hideFromChatHistory: true,
 						});
+						if (translateDisposedRef.current) {
+							// Viewer unmounted while the run was being accepted: drop it.
+							void cancelAgentRun(accepted.sessionId).catch(() => undefined);
+							return;
+						}
 						const sessionId = accepted.sessionId;
 						translateSessionRef.current = sessionId;
 						activeSessionRef.current = sessionId;
 						const unsubs: UnlistenFn[] = [];
+						translateUnsubsRef.current = unsubs;
 						const cleanup = () => {
 							for (const u of unsubs) u();
+							if (translateUnsubsRef.current === unsubs)
+								translateUnsubsRef.current = null;
 							if (translateSessionRef.current === sessionId)
 								translateSessionRef.current = null;
 							if (activeSessionRef.current === sessionId)
@@ -302,6 +334,11 @@ export function usePdfSelectionTranslate({
 								cleanup();
 							}),
 						);
+						if (translateDisposedRef.current) {
+							// Viewer unmounted while the listeners were being attached.
+							cleanup();
+							return;
+						}
 					} catch (e) {
 						const message = e instanceof Error ? e.message : String(e);
 						notifyError(message);


### PR DESCRIPTION
## Summary
- PDF ask/translate 的 per-run agent 监听此前只在 `completed`/`failed` 时清理：关 tab / LRU 逐出时监听器滞留，run 挂起则永久泄漏。现在两个 hook 在卸载时统一 unlisten，并对仍活跃的 session 调 `agent_cancel_run`；同时拦截卸载后才被 accept 的 run（含监听附加期间的竞态复查），避免孤儿进程与迟到监听。
- Chat warm（`use-agent-panel`）的 cleanup 此前只置 `cancelled` 标志，而 Rust 侧 `warm_agent` 无取消路径：快速切换 agent/vault 会每次变更都拉起一个跑到底的 ACP 进程。现改为去抖（300ms）后再 spawn，切换过程中的中间状态不再产生孤儿 warm 进程；generation 作废逻辑保持不变。
- 只改动监听器注册/清理与 warm 调度相关代码，未触碰流式 `setThreads`/`upsertTranslate` 更新逻辑（与并行 PR 解耦）。

## 留作后续（本 PR 不做）
- Rust 侧 `session/prompt` 无超时、全局并发上限（semaphore）：改动面大，单独处理。
- warm 进程本身的终止需要 Rust 侧为 `warm_agent` 增加取消参数，前端暂以去抖避免重复 spawn。
- 关闭 Chat tab/面板时对普通会话 run 的 `agent_cancel_run`：不在本次最小修复范围。

## Test plan
- [x] `pnpm exec tsc --noEmit` 通过
- [x] `pnpm exec biome check`（3 个改动文件）通过
- [x] 相关单测 `pdf-ask` / `translate` / `agent-stream-parse` 全部通过
- [ ] 打开 PDF 划词提问/翻译，流式中关闭 PDF tab：确认无残留 `agent:*` 监听、对应 session 收到 cancel
- [ ] 快速切换 agent/vault：确认只拉起最后一个目标的 warm 进程

Fixes #274