### PR TITLE
perf(pdf): marks 并发读取、自写回声抑制与注释事件合并

### DIFF
--- a/docs/frontend/pdf.md
+++ b/docs/frontend/pdf.md
@@ -15,7 +15,7 @@ PDFium engine 由窗口共享。默认优先 **worker 引擎**（PDFium WASM 跑
 
 `RenderLayer` 只是瓦片下的底图层，其 scale 另按 `PDF_BASE_LAYER_SCALE_CAP`（1.5）封顶：zoom 超过该值后整页光栅不再重渲染（单 worker 串行渲染下，长文档高倍缩放的整页光栅 + blob 传输是主要开销），清晰层由 `TilingLayer` 承担。瓦片 `tileSize: 1024` + `extraRings: 1`，减少长文档快速滚动时的渲染往返与边缘弹出。
 
-抗抽动（twitch）措施：瓦片 `extraRings: 1` 预渲染视口外圈，减少快速滚动时边缘瓦片延迟弹出；`TilingLayer` patch 在新瓦片集异步光栅到达前保留旧瓦片作拉伸占位（`scale/srcScale` 重映射，1.5s 超时兜底），消除缩放瞬间的空白闪烁；marks 不再定时轮询，改由 Vault 文件监听（`vault:file-changed`，命中 `{paper}/marks/` 前缀，200ms 合并突发）触发刷新，配合激活时与窗口 focus 兜底，读取结果仍做 JSON 指纹比对，内容未变不提交 state，避免整 viewer 重渲染。
+抗抽动（twitch）措施：瓦片 `extraRings: 1` 预渲染视口外圈，减少快速滚动时边缘瓦片延迟弹出；`TilingLayer` patch 在新瓦片集异步光栅到达前保留旧瓦片作拉伸占位（`scale/srcScale` 重映射，1.5s 超时兜底），消除缩放瞬间的空白闪烁；marks 不再定时轮询，改由 Vault 文件监听（`vault:file-changed`，命中 `{paper}/marks/` 前缀，200ms 合并突发）触发刷新，配合激活时与窗口 focus 兜底；应用自身对 `marks/` 的写入会登记路径（3s TTL），其 watcher 回声直接跳过（写入方已更新内存态），mark 文件并发读取，读取结果仍做 JSON 指纹比对，内容未变不提交 state，避免整 viewer 重渲染。高亮派生态（视图模型 / 页边针锚点 / 链接分页图）的 annotation 事件按微任务合并后重建一次，批量导入 n 条不再逐事件 O(n²) 重建。
 
 滚动路径开销（触控板一帧内可触发多次 scroll）另有两处收敛：viewport 滚动指标按动画帧合并后再 `setViewportScrollMetrics`（每次提交都会推出新的 scroller layout 对象，令所有挂载页重渲染）；layout hover 命中框与 Eye 调试框按 `hoverableLayoutRegionsByPage` / `rawLayoutRegionsByPage` 预先分页缓存，页渲染只做 `Map.get`，不再每页重跑一遍全文档 NMS。
 
@@ -77,8 +77,8 @@ PDFium engine 由窗口共享。默认优先 **worker 引擎**（PDFium WASM 跑
 | `src/components/viewer/pdf/cards/` | 划词与 mark 卡片：`selection-menu` / `selection-card`（共用壳）/ `ask-popover` / `translate-card` / `visual-trace-card` / `visual-annotation-editor` / `annotation-editor` / `formula-annotation-card` / `citation-preview` |
 | `src/components/viewer/pdf/viewport/` | 宿主接线：`dockview-viewport`（resize 门控 + 滚动指标按帧提交）/ `wheel-zoom-handler` / `active-card-scroll-sync` |
 | `src/components/viewer/pdf/hooks/use-pdf-cards.ts` | 浮动卡生命周期：打开 / 定位（虚拟化重试）/ hover 收起 |
-| `src/components/viewer/pdf/hooks/use-pdf-highlights.ts` | EmbedPDF 标注桥：高亮视图模型、页边针锚点、链接分页图、导入迁移与防抖导出 |
-| `src/components/viewer/pdf/hooks/use-pdf-marks-io.ts` | `marks/` 读取与文件监听刷新（指纹比对后再提交 state） |
+| `src/components/viewer/pdf/hooks/use-pdf-highlights.ts` | EmbedPDF 标注桥：高亮视图模型、页边针锚点、链接分页图、导入迁移与防抖导出；annotation 事件按微任务合并重建 |
+| `src/components/viewer/pdf/hooks/use-pdf-marks-io.ts` | `marks/` 并发读取与文件监听刷新（自写回声跳过；指纹比对后再提交 state） |
 | `src/components/viewer/pdf/hooks/use-pdf-text-selection.ts` | 选区检测、划词菜单状态与复制拦截 |
 | `src/components/viewer/pdf/hooks/use-pdf-ask-threads.ts` | 划词提问工作流：建/续/停、ACP 流监听、`marks/<id>.json` 落盘 |
 | `src/components/viewer/pdf/hooks/use-pdf-selection-translate.ts` | 划词翻译工作流与结果卡状态 |

--- a/src/components/viewer/pdf/hooks/use-pdf-highlights.ts
+++ b/src/components/viewer/pdf/hooks/use-pdf-highlights.ts
@@ -5,7 +5,8 @@
  * bridge between that plugin scope and the React tree.
  *
  * It owns three derived states that share exactly one writer — `rebuildHighlights`,
- * which runs on every annotation event:
+ * which runs once per coalesced annotation-event burst (a batch import emits
+ * one event per annotation):
  * - `highlights`: the view models published to the annotations panel;
  * - `highlightAnchors`: normalized 0–1 rects for gutter-pin placement, computed
  *   here (where the raw objects and page sizes are already in hand) so pin
@@ -165,6 +166,18 @@ export function usePdfHighlights({
 		setCitationLinks(links);
 	}, [annotationCap, docCap, docId, paperKey, onHighlightsChangeRef]);
 
+	// A batch import emits one event per annotation within a single task;
+	// coalesce the burst into one rebuild (n events → O(n²) full walks → O(n)).
+	const rebuildPendingRef = useRef(false);
+	const scheduleRebuild = useCallback(() => {
+		if (rebuildPendingRef.current) return;
+		rebuildPendingRef.current = true;
+		queueMicrotask(() => {
+			rebuildPendingRef.current = false;
+			rebuildHighlights();
+		});
+	}, [rebuildHighlights]);
+
 	const scheduleSave = useCallback(() => {
 		if (!paperAbsPath || !annotationCap) return;
 		if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
@@ -185,12 +198,12 @@ export function usePdfHighlights({
 		if (!annotationCap) return;
 		const scope = annotationCap.forDocument(docId);
 		const off = scope.onAnnotationEvent((event) => {
-			rebuildHighlights();
+			scheduleRebuild();
 			if (event.type !== "loaded" && !importingRef.current) scheduleSave();
 		});
 		rebuildHighlights();
 		return () => off();
-	}, [annotationCap, docId, rebuildHighlights, scheduleSave]);
+	}, [annotationCap, docId, rebuildHighlights, scheduleRebuild, scheduleSave]);
 
 	useEffect(() => {
 		if (importedRef.current || !annotationCap || !docCap || totalPages <= 0)

--- a/src/components/viewer/pdf/hooks/use-pdf-marks-io.ts
+++ b/src/components/viewer/pdf/hooks/use-pdf-marks-io.ts
@@ -5,11 +5,12 @@
  *
  * One hook because all three arrays share a single IO lifecycle: one `list*`
  * fan-out on open, one Vault-watcher subscription, and one publish path to the
- * annotations panel. Listing re-reads every mark file over serial IPC, so the
+ * annotations panel. Listing re-reads every mark file over IPC, so the
  * refresh must stay event-driven (never a timer), is coalesced over a 200 ms
- * burst (one Agent turn rewrites several files), and is fingerprint-guarded:
- * `list*` always returns fresh array identity, and committing an unchanged array
- * re-renders the whole viewer, which makes the pages visibly twitch.
+ * burst (one Agent turn rewrites several files), skips echoes of this app's
+ * own marks/ writes, and is fingerprint-guarded: `list*` always returns fresh
+ * array identity, and committing an unchanged array re-renders the whole
+ * viewer, which makes the pages visibly twitch.
  *
  * Only pure state updaters live here. Anything that writes a mark to disk as
  * part of an ask / translate / visual workflow stays with that workflow, so the
@@ -35,6 +36,7 @@ import { listPdfAskThreads } from "@/lib/pdf/ask";
 import { threadHasUserQuestion } from "@/lib/pdf/ask/schema";
 import type { PdfAskThread } from "@/lib/pdf/ask/types";
 import { marksDir } from "@/lib/pdf/selection";
+import { isRecentSelfWrite } from "@/lib/pdf/selection/marks-io";
 import { listPdfTranslates } from "@/lib/pdf/translate";
 import type { PdfTranslateRecord } from "@/lib/pdf/translate/types";
 import {
@@ -142,10 +144,12 @@ export function usePdfMarksIo({
 	// avoid N× listMarkRaw reads). Covers Agent-panel writes that create ask
 	// threads from 「加入对话」 selections while this tab was open.
 	//
-	// Driven by the Vault watcher: listing re-reads every mark file over serial
-	// IPC, so it must not run on a timer. Results always carry fresh array
-	// identity; only commit state when the content actually changed — otherwise
-	// a refresh re-renders the whole viewer and the pages visibly twitch.
+	// Driven by the Vault watcher: listing re-reads every mark file over IPC,
+	// so it must not run on a timer, and watcher echoes of this app's own
+	// marks/ writes are skipped (the writer already updated state). Results
+	// always carry fresh array identity; only commit state when the content
+	// actually changed — otherwise a refresh re-renders the whole viewer and
+	// the pages visibly twitch.
 	const lastMarksPollRef = useRef("{asks:[],traces:[]}");
 	useEffect(() => {
 		if (!paperAbsPath || !marksLoadedRef.current || !isActive) return;
@@ -198,10 +202,15 @@ export function usePdfMarksIo({
 						if (payload.rename) {
 							paths.push(payload.rename.from, payload.rename.to);
 						}
-						const hit = paths.some((p) =>
+						const marksPaths = paths.filter((p) =>
 							normalizePathKey(p).startsWith(marksKey),
 						);
-						if (hit) scheduleRefresh();
+						if (!marksPaths.length) return;
+						// Our own writes already updated in-memory state; skip
+						// their watcher echo unless an external change landed in
+						// the same batch.
+						if (marksPaths.every((p) => isRecentSelfWrite(p))) return;
+						scheduleRefresh();
 					},
 				);
 			})();

--- a/src/lib/pdf/agent-trace/io.ts
+++ b/src/lib/pdf/agent-trace/io.ts
@@ -16,6 +16,7 @@ import type {
 } from "@/lib/pdf/agent-trace/types";
 import { VISUAL_MARK_KIND } from "@/lib/pdf/agent-trace/types";
 import { createMarkStore } from "@/lib/pdf/marks/io";
+import { markSelfWrite } from "@/lib/pdf/selection/marks-io";
 import { removeVaultPath, writeVaultBytes } from "@/lib/vault";
 
 const store = createMarkStore<PdfVisualSessionTrace>({
@@ -444,6 +445,7 @@ export async function writePdfVisualTrace(
 			prepared.asset.path,
 		);
 		if (!assetPath) throw new Error("invalid visual trace asset path");
+		markSelfWrite(assetPath);
 		await writeVaultBytes(assetPath, prepared.asset.bytes);
 	}
 	await store.write(paperAbsPath, {
@@ -467,6 +469,7 @@ export async function deletePdfVisualTrace(
 		trace?.image?.path &&
 		visualTraceImageAssetPath(paperAbsPath, trace.image.path);
 	if (!assetPath) return;
+	markSelfWrite(assetPath);
 	try {
 		await removeVaultPath(assetPath);
 	} catch {

--- a/src/lib/pdf/highlight/annotation-store.ts
+++ b/src/lib/pdf/highlight/annotation-store.ts
@@ -10,7 +10,11 @@ import {
 	highlightColorFromHex,
 } from "@/lib/pdf/highlight/palette";
 import type { PdfHighlight } from "@/lib/pdf/highlight/types";
-import { ANNOTATIONS_JSON, MARKS_FOLDER } from "@/lib/pdf/selection/marks-io";
+import {
+	ANNOTATIONS_JSON,
+	MARKS_FOLDER,
+	markSelfWrite,
+} from "@/lib/pdf/selection/marks-io";
 import { joinVaultPath, readVaultFile, writeVaultFile } from "@/lib/vault";
 
 /**
@@ -93,10 +97,9 @@ export async function loadAnnotationItems(
 			await saveAnnotationItems(paperAbsPath, items);
 		} else {
 			// Empty file still belongs under marks/ once discovered.
-			await writeVaultFile(
-				annotationsPath(paperAbsPath),
-				`${JSON.stringify([], null, 2)}\n`,
-			);
+			const path = annotationsPath(paperAbsPath);
+			markSelfWrite(path);
+			await writeVaultFile(path, `${JSON.stringify([], null, 2)}\n`);
 		}
 		await removeFileIfExists(legacyAnnotationsPath(paperAbsPath));
 		return items;
@@ -115,10 +118,9 @@ export async function saveAnnotationItems(
 		memoryStore.set(paperAbsPath, next);
 		return;
 	}
-	await writeVaultFile(
-		annotationsPath(paperAbsPath),
-		`${JSON.stringify(next, null, 2)}\n`,
-	);
+	const path = annotationsPath(paperAbsPath);
+	markSelfWrite(path);
+	await writeVaultFile(path, `${JSON.stringify(next, null, 2)}\n`);
 	// Drop legacy root copy if present so marks/ is the only location.
 	await removeFileIfExists(legacyAnnotationsPath(paperAbsPath));
 }

--- a/src/lib/pdf/selection/marks-io.ts
+++ b/src/lib/pdf/selection/marks-io.ts
@@ -13,6 +13,7 @@ import { readDir } from "@tauri-apps/plugin-fs";
 import { isTauri } from "@/lib/core/tauri";
 import {
 	joinVaultPath,
+	normalizePathKey,
 	readVaultFile,
 	removeVaultPath,
 	writeVaultFile,
@@ -38,6 +39,9 @@ export function markPath(paperAbsPath: string, id: string): string {
 	return joinVaultPath(marksDir(paperAbsPath), `${id}.json`);
 }
 
+/** Sentinel for files that failed to read/parse (never a real JSON value). */
+const CORRUPT_MARK = Symbol("marks.corrupt");
+
 /** Read + JSON.parse every per-id `*.json` under `marks/` (skip aggregate + corrupt). */
 export async function listMarkRaw(paperAbsPath: string): Promise<unknown[]> {
 	if (!paperAbsPath || !isTauri()) return [];
@@ -54,16 +58,19 @@ export async function listMarkRaw(paperAbsPath: string): Promise<unknown[]> {
 	} catch {
 		return [];
 	}
-	const out: unknown[] = [];
-	for (const name of names) {
-		try {
-			const raw = await readVaultFile(joinVaultPath(dir, name));
-			out.push(JSON.parse(raw) as unknown);
-		} catch {
-			// skip
-		}
-	}
-	return out;
+	// Each file is an independent IPC round-trip; read them concurrently
+	// instead of serially (refresh cost grew with mark count).
+	const loaded = await Promise.all(
+		names.map(async (name): Promise<unknown> => {
+			try {
+				const raw = await readVaultFile(joinVaultPath(dir, name));
+				return JSON.parse(raw) as unknown;
+			} catch {
+				return CORRUPT_MARK;
+			}
+		}),
+	);
+	return loaded.filter((mark) => mark !== CORRUPT_MARK);
 }
 
 export async function readMarkRaw(
@@ -79,15 +86,39 @@ export async function readMarkRaw(
 	}
 }
 
+/**
+ * Self-write echo suppression: watcher events caused by this app's own
+ * `marks/` writes are pure echo for the marks refresh (the writer already
+ * updated in-memory state), so the marks watcher skips events whose paths are
+ * all recent self-writes. Writers register the path here; the TTL covers the
+ * filesystem-watcher latency between write and event.
+ */
+const SELF_WRITE_TTL_MS = 3000;
+const selfWrites = new Map<string, number>();
+
+/** Register a `marks/` path this app is about to write (echo suppression). */
+export function markSelfWrite(path: string): void {
+	const now = Date.now();
+	selfWrites.set(normalizePathKey(path), now);
+	for (const [key, at] of selfWrites) {
+		if (now - at > SELF_WRITE_TTL_MS) selfWrites.delete(key);
+	}
+}
+
+/** True when `path` was written by this app within the echo TTL. */
+export function isRecentSelfWrite(path: string): boolean {
+	const at = selfWrites.get(normalizePathKey(path));
+	return at !== undefined && Date.now() - at <= SELF_WRITE_TTL_MS;
+}
+
 export async function writeMarkFile(
 	paperAbsPath: string,
 	id: string,
 	payload: unknown,
 ): Promise<void> {
-	await writeVaultFile(
-		markPath(paperAbsPath, id),
-		`${JSON.stringify(payload, null, 2)}\n`,
-	);
+	const path = markPath(paperAbsPath, id);
+	markSelfWrite(path);
+	await writeVaultFile(path, `${JSON.stringify(payload, null, 2)}\n`);
 }
 
 export async function deleteMarkFile(
@@ -95,6 +126,7 @@ export async function deleteMarkFile(
 	id: string,
 ): Promise<void> {
 	if (!isTauri() || !paperAbsPath || !id) return;
+	markSelfWrite(markPath(paperAbsPath, id));
 	try {
 		await removeVaultPath(markPath(paperAbsPath, id));
 	} catch {


### PR DESCRIPTION
## Summary

- `listMarkRaw` 的逐文件串行 IPC（N 次 `await readVaultFile`）改为 `Promise.all` 并发读取，保持文件顺序与跳过损坏文件的语义（`src/lib/pdf/selection/marks-io.ts`）。
- 自写回声抑制：`marks/` 写入方（`writeMarkFile`/`deleteMarkFile`、`annotations.json` 保存与迁移写入、visual 裁剪资产写/删）登记路径（3s TTL），`use-pdf-marks-io` 的 watcher 事件在命中 `marks/` 的路径**全部**为近期自写时跳过 refresh（写入方已更新内存态）；同批含外部变更仍照常刷新。
- annotation 事件批处理：`use-pdf-highlights` 用微任务合并标志位，同一任务内的多个事件（批量导入每条注释各发一个事件）只触发一次 `rebuildHighlights`，批量导入 n 条由 O(n²) 全量遍历降为 O(n)。
- 跳过项：全量 `JSON.stringify({asks,traces})` 指纹未改造。外部写入方（Agent / 手工编辑）改写 mark 文件时不保证更新 `updatedAt`，廉价结构化指纹（id/updatedAt/条数）会漏检内容变更导致 UI 停滞至重新挂载，正确性风险高；且并发读取 + 回声抑制已消除 issue 中的主要放大源，指纹仅在 focus/激活/外部变更时运行。

同步更新 `docs/frontend/pdf.md` 对应行为描述。

## Test plan

- [ ] 打开含大量 ask/visual marks 的论文 PDF，划词提问 / 保存批注 / 框选加入对话：落盘后无整 viewer 重渲染抖动，卡片/高亮即时可见。
- [ ] 批量导入高亮（或打开含大量历史高亮的论文）：注释面板与页边针正常渲染，导入过程主线程占用明显下降。
- [ ] 外部修改 `marks/`（如 Agent 面板写入、手工编辑 mark 文件）：200ms 合并后 viewer 仍能刷新出新内容。
- [ ] 窗口失焦再 focus、切换 dock 激活标签：marks 兜底刷新行为不变。
- [ ] `pnpm exec tsc --noEmit`、`pnpm exec biome check`（改动文件）通过。

Fixes #273