### PR TITLE
perf(pdf): 全文翻译字号拟合缓存与按页分桶

### DIFF
--- a/src/components/viewer/pdf/hooks/use-pdf-layout-translate.ts
+++ b/src/components/viewer/pdf/hooks/use-pdf-layout-translate.ts
@@ -6,10 +6,11 @@
  * and the toolbar button's three-phase label (start → stop → clear).
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { notifyError } from "@/lib/core/notify";
 import {
+	groupLayoutTranslateItemsByPage,
 	type LayoutTranslateItem,
 	type LayoutTranslateJobStatus,
 	listTranslatableLayoutRegions,
@@ -25,11 +26,11 @@ export type UsePdfLayoutTranslateOptions = {
 };
 
 export type PdfLayoutTranslate = {
-	/** Progressive bulk-translate overlays (body text / abstract / header). */
-	layoutTranslateJob: {
-		status: LayoutTranslateJobStatus;
-		items: LayoutTranslateItem[];
-	};
+	/** Progressive bulk-translate overlays (body text / abstract / header), bucketed by page. */
+	layoutTranslateItemsByPage: ReadonlyMap<
+		number,
+		readonly LayoutTranslateItem[]
+	>;
 	layoutTranslateRunning: boolean;
 	/** Running, or finished with overlays still painted. */
 	layoutTranslateActive: boolean;
@@ -149,6 +150,21 @@ export function usePdfLayoutTranslate({
 		};
 	}, [docId]);
 
+	// Bucket once per job update (not per page); unchanged buckets keep their
+	// previous array identity so memoized page overlays bail out while another
+	// page streams.
+	const layoutTranslateByPageRef = useRef<
+		ReadonlyMap<number, readonly LayoutTranslateItem[]>
+	>(new Map());
+	const layoutTranslateItemsByPage = useMemo(() => {
+		const grouped = groupLayoutTranslateItemsByPage(
+			layoutTranslateJob.items,
+			layoutTranslateByPageRef.current,
+		);
+		layoutTranslateByPageRef.current = grouped;
+		return grouped;
+	}, [layoutTranslateJob.items]);
+
 	const layoutTranslateRunning = layoutTranslateJob.status === "running";
 	const layoutTranslateActive =
 		layoutTranslateRunning ||
@@ -160,7 +176,7 @@ export function usePdfLayoutTranslate({
 			: t("pdf.layoutTranslate.start");
 
 	return {
-		layoutTranslateJob,
+		layoutTranslateItemsByPage,
 		layoutTranslateRunning,
 		layoutTranslateActive,
 		layoutTranslateLabel,

--- a/src/components/viewer/pdf/layers/layout-translate-overlay.tsx
+++ b/src/components/viewer/pdf/layers/layout-translate-overlay.tsx
@@ -11,8 +11,8 @@ import type { LayoutTranslateItem } from "@/lib/pdf/layout/layout-translate";
 import { PDF_PAGE_RASTER_DARK_CLASS } from "@/lib/pdf/page-theme";
 
 type LayoutTranslateOverlayProps = {
+	/** Items already bucketed for this one page (groupLayoutTranslateItemsByPage). */
 	items: readonly LayoutTranslateItem[];
-	pageIndex: number;
 	/** Page pixel size (for font-size heuristic). */
 	pageWidthPx: number;
 	pageHeightPx: number;
@@ -133,21 +133,87 @@ export function fontSizeForLayoutTranslateBox(
 }
 
 /**
+ * Fit-result cache. Streaming job updates repaint every mounted page, but the
+ * fitted size only depends on (item, box pixel size, source, text), so
+ * unchanged blocks reuse their last result instead of re-running the
+ * binary-search fit on every render. Inner maps use raw strings as keys
+ * (value equality), so cache hits build no large key strings. Bounded:
+ * oldest item entries are evicted first; per-item maps hold only the few
+ * text variants a block goes through (placeholder → final).
+ */
+const FONT_SIZE_CACHE_MAX_ITEMS = 1024;
+const FONT_SIZE_CACHE_MAX_SOURCES = 8;
+const FONT_SIZE_CACHE_MAX_TEXTS = 32;
+
+type FontSizeCacheEntry = {
+	boxWidthPx: number;
+	boxHeightPx: number;
+	bySource: Map<string, Map<string, number>>;
+};
+
+const fontSizeCache = new Map<string, FontSizeCacheEntry>();
+
+function fontSizeForLayoutTranslateItem(
+	item: LayoutTranslateItem,
+	pageWidthPx: number,
+	pageHeightPx: number,
+	text: string,
+): number {
+	const boxWidthPx = item.bbox.w * pageWidthPx;
+	const boxHeightPx = item.bbox.h * pageHeightPx;
+	let entry = fontSizeCache.get(item.id);
+	if (!entry) {
+		if (fontSizeCache.size >= FONT_SIZE_CACHE_MAX_ITEMS) {
+			const oldest = fontSizeCache.keys().next().value;
+			if (oldest !== undefined) fontSizeCache.delete(oldest);
+		}
+		entry = { boxWidthPx, boxHeightPx, bySource: new Map() };
+		fontSizeCache.set(item.id, entry);
+	} else if (
+		entry.boxWidthPx !== boxWidthPx ||
+		entry.boxHeightPx !== boxHeightPx
+	) {
+		// Zoom or region geometry changed: cached sizes no longer apply.
+		entry.boxWidthPx = boxWidthPx;
+		entry.boxHeightPx = boxHeightPx;
+		entry.bySource.clear();
+	}
+	let byText = entry.bySource.get(item.source);
+	if (!byText) {
+		if (entry.bySource.size >= FONT_SIZE_CACHE_MAX_SOURCES) {
+			entry.bySource.clear();
+		}
+		byText = new Map();
+		entry.bySource.set(item.source, byText);
+	}
+	const hit = byText.get(text);
+	if (hit !== undefined) return hit;
+	const fontSize = fontSizeForLayoutTranslateBox(
+		item.bbox,
+		pageWidthPx,
+		pageHeightPx,
+		item.source,
+		text,
+	);
+	if (byText.size >= FONT_SIZE_CACHE_MAX_TEXTS) byText.clear();
+	byText.set(text, fontSize);
+	return fontSize;
+}
+
+/**
  * Paint translated (or in-flight) blocks for one PDF page.
  */
 export const LayoutTranslateOverlay = memo(function LayoutTranslateOverlay({
 	items,
-	pageIndex,
 	pageWidthPx,
 	pageHeightPx,
 	pdfDark = false,
 }: LayoutTranslateOverlayProps) {
 	const onPage = items.filter(
 		(it) =>
-			it.pageIndex === pageIndex &&
-			(it.status === "done" ||
-				it.status === "running" ||
-				(it.status === "error" && it.translated)),
+			it.status === "done" ||
+			it.status === "running" ||
+			(it.status === "error" && it.translated),
 	);
 	if (onPage.length === 0) return null;
 
@@ -159,11 +225,10 @@ export const LayoutTranslateOverlay = memo(function LayoutTranslateOverlay({
 						? (item.translated ?? "…")
 						: (item.translated ?? "");
 				const isHeading = isLayoutTranslateHeadingKind(item.kind);
-				const fontSize = fontSizeForLayoutTranslateBox(
-					item.bbox,
+				const fontSize = fontSizeForLayoutTranslateItem(
+					item,
 					pageWidthPx,
 					pageHeightPx,
-					item.source,
 					text,
 				);
 				return (

--- a/src/components/viewer/pdf/layers/page-layers.tsx
+++ b/src/components/viewer/pdf/layers/page-layers.tsx
@@ -70,7 +70,10 @@ export type PdfPageLayoutSlice = {
 	hoverableRegionsByPage: ReadonlyMap<number, PdfLayoutRegion[]>;
 	rawRegionsByPage: ReadonlyMap<number, PdfLayoutRegion[]>;
 	layoutOverlayVisible: boolean;
-	layoutTranslateItems: LayoutTranslateItem[];
+	layoutTranslateItemsByPage: ReadonlyMap<
+		number,
+		readonly LayoutTranslateItem[]
+	>;
 	equationSymbolCount: number;
 	/** Layout-hover drafts auto-hide, so their frame needs a hover surface. */
 	visualDraftEphemeral: boolean;
@@ -145,6 +148,8 @@ export const PdfPageLayers = memo(function PdfPageLayers({
 			? marks.focusedLayoutRegion
 			: null;
 	const pins = marks.pinsByPage.get(pageNumber) ?? EMPTY_PINS;
+	const layoutTranslateOnPage =
+		layout.layoutTranslateItemsByPage.get(pageIndex);
 	// Page shell: paper-white in light mode; near-black when PDF dark mode is on
 	// so loading gaps match inverted page rasters.
 	return (
@@ -255,10 +260,9 @@ export const PdfPageLayers = memo(function PdfPageLayers({
 						})
 					: null}
 				{/* Bulk layout translate: progressive text overlays over body blocks. */}
-				{layout.layoutTranslateItems.length > 0 ? (
+				{layoutTranslateOnPage && layoutTranslateOnPage.length > 0 ? (
 					<LayoutTranslateOverlay
-						items={layout.layoutTranslateItems}
-						pageIndex={pageIndex}
+						items={layoutTranslateOnPage}
 						pageWidthPx={width}
 						pageHeightPx={height}
 						pdfDark={pdfDark}

--- a/src/components/viewer/pdf/pdf-viewer.tsx
+++ b/src/components/viewer/pdf/pdf-viewer.tsx
@@ -772,7 +772,7 @@ function PdfViewerInner({
 	});
 
 	const {
-		layoutTranslateJob,
+		layoutTranslateItemsByPage,
 		layoutTranslateRunning,
 		layoutTranslateActive,
 		layoutTranslateLabel,
@@ -1095,7 +1095,7 @@ function PdfViewerInner({
 			hoverableRegionsByPage,
 			rawRegionsByPage,
 			layoutOverlayVisible,
-			layoutTranslateItems: layoutTranslateJob.items,
+			layoutTranslateItemsByPage,
 			equationSymbolCount: equationSymbols.length,
 			visualDraftEphemeral: Boolean(visualDraftEditor?.ephemeral),
 		}),
@@ -1103,7 +1103,7 @@ function PdfViewerInner({
 			hoverableRegionsByPage,
 			rawRegionsByPage,
 			layoutOverlayVisible,
-			layoutTranslateJob.items,
+			layoutTranslateItemsByPage,
 			equationSymbols.length,
 			visualDraftEditor?.ephemeral,
 		],

--- a/src/lib/pdf/layout/index.ts
+++ b/src/lib/pdf/layout/index.ts
@@ -80,6 +80,7 @@ export {
 	slugFromTitle,
 } from "@/lib/pdf/layout/layout-index";
 export {
+	groupLayoutTranslateItemsByPage,
 	LAYOUT_TRANSLATE_CONCURRENCY,
 	LAYOUT_TRANSLATE_MAX_CHARS,
 	type LayoutTranslateItem,

--- a/src/lib/pdf/layout/layout-translate.ts
+++ b/src/lib/pdf/layout/layout-translate.ts
@@ -167,6 +167,51 @@ export function toLayoutTranslateItems(
 	return regions.map((r) => ({ ...r, status: "pending" as const }));
 }
 
+/** Paint-relevant identity of one bucket slot (id, progress, partial text). */
+function sameLayoutTranslateBucketSlot(
+	before: LayoutTranslateItem | undefined,
+	after: LayoutTranslateItem,
+): boolean {
+	return (
+		before !== undefined &&
+		before.id === after.id &&
+		before.status === after.status &&
+		before.translated === after.translated
+	);
+}
+
+/**
+ * Bucket job items by page so each page overlay reads its own list instead of
+ * filtering the whole job. When `previous` is given, a bucket whose
+ * paint-relevant contents are unchanged reuses the previous array identity, so
+ * memoized page overlays bail out while the streaming job only touches the
+ * page currently translating.
+ */
+export function groupLayoutTranslateItemsByPage(
+	items: readonly LayoutTranslateItem[],
+	previous?: ReadonlyMap<number, readonly LayoutTranslateItem[]>,
+): ReadonlyMap<number, readonly LayoutTranslateItem[]> {
+	const grouped = new Map<number, LayoutTranslateItem[]>();
+	for (const item of items) {
+		const bucket = grouped.get(item.pageIndex);
+		if (bucket) bucket.push(item);
+		else grouped.set(item.pageIndex, [item]);
+	}
+	if (!previous) return grouped;
+	const next: Map<number, readonly LayoutTranslateItem[]> = new Map(grouped);
+	for (const [pageIndex, bucket] of grouped) {
+		const prev = previous.get(pageIndex);
+		if (
+			prev &&
+			prev.length === bucket.length &&
+			bucket.every((item, i) => sameLayoutTranslateBucketSlot(prev[i], item))
+		) {
+			next.set(pageIndex, prev);
+		}
+	}
+	return next;
+}
+
 /** Non-streaming Agent runner for bulk layout translate (settings provider=agent). */
 async function resolveLayoutTranslateAgentOpts(): Promise<
 	TranslateRunOptions | undefined

--- a/test/pdf-layout-translate.test.ts
+++ b/test/pdf-layout-translate.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import { fontSizeForLayoutTranslateBox } from "@/components/viewer/pdf/layers/layout-translate-overlay";
 import {
+	groupLayoutTranslateItemsByPage,
+	type LayoutTranslateItem,
+	type LayoutTranslateItemStatus,
 	layoutRegionSourceText,
 	listTranslatableLayoutRegions,
 	toLayoutTranslateItems,
@@ -246,5 +249,52 @@ describe("fontSizeForLayoutTranslateBox", () => {
 		// Denser CN may use a larger size to fill the same box, but not unbounded.
 		expect(withZh).toBeGreaterThanOrEqual(paperLike * 0.95);
 		expect(withZh).toBeLessThanOrEqual(paperLike * 1.25 + 0.5);
+	});
+});
+
+describe("groupLayoutTranslateItemsByPage", () => {
+	function translateItem(
+		id: string,
+		pageIndex: number,
+		status: LayoutTranslateItemStatus = "pending",
+	): LayoutTranslateItem {
+		return {
+			id,
+			pageIndex,
+			bbox: { x: 0.1, y: 0.1, w: 0.5, h: 0.05 },
+			kind: "text",
+			readingOrder: 0,
+			source: `source ${id}`,
+			status,
+		};
+	}
+
+	it("buckets items by page, keeping job order within a page", () => {
+		const grouped = groupLayoutTranslateItemsByPage([
+			translateItem("b", 1),
+			translateItem("a", 0),
+			translateItem("c", 1),
+		]);
+		expect([...grouped.keys()]).toEqual([1, 0]);
+		expect(grouped.get(0)?.map((it) => it.id)).toEqual(["a"]);
+		expect(grouped.get(1)?.map((it) => it.id)).toEqual(["b", "c"]);
+	});
+
+	it("reuses previous bucket identity for unchanged pages", () => {
+		const before = groupLayoutTranslateItemsByPage([
+			{ ...translateItem("a", 0, "done"), translated: "甲" },
+			translateItem("b", 1, "running"),
+		]);
+		// Fresh item objects (streaming publish copies everything); only page 1 advanced.
+		const after = groupLayoutTranslateItemsByPage(
+			[
+				{ ...translateItem("a", 0, "done"), translated: "甲" },
+				{ ...translateItem("b", 1, "done"), translated: "乙" },
+			],
+			before,
+		);
+		expect(after.get(0)).toBe(before.get(0));
+		expect(after.get(1)).not.toBe(before.get(1));
+		expect(after.get(1)?.map((it) => it.status)).toEqual(["done"]);
 	});
 });


### PR DESCRIPTION
## Summary
- 字号拟合结果缓存：`layout-translate-overlay` 增加模块级有界缓存（item id → 盒像素尺寸 → source → text，多级 Map 以原始字符串为键，命中零拼接；容量上限 1024 item，FIFO 淘汰，zoom/几何变化自动失效），避免每次渲染对每个区块重跑 12 轮二分 + 正则的 `fontSizeForLayoutTranslateBox`。
- items 按页分桶：`usePdfLayoutTranslate` 用新增的纯函数 `groupLayoutTranslateItemsByPage` 在每次 job 更新时一次性预计算 `pageIndex → items` Map（替代每页对全量 items 的 filter）；内容未变化的页复用旧桶数组身份，使 memo 化的 `LayoutTranslateOverlay` 在其他页流式翻译时直接 bail out，不再重渲染。
- 流式 job 更新机制本身未动；`PdfPageLayoutSlice` 相应改为携带分桶 Map，`LayoutTranslateOverlay` 去掉 `pageIndex` prop，只保留状态过滤。

## Test plan
- [x] `pnpm exec tsc --noEmit` 通过
- [x] `biome check` 改动文件通过
- [x] `vitest run test/pdf-layout-translate.test.ts`：11 通过（含新增分桶与桶身份复用 2 例）
- [ ] 手动：打开含布局分析的 PDF，启动全文翻译，确认覆盖层渐进绘制、字号与修复前一致；滚动/缩放时覆盖层正常跟随；停止/清除/重跑三态正常

Fixes #275