### PR TITLE
perf(pdf): 流式更新与 pin 几何解耦，消除逐 chunk 全量重渲染

### DIFF
--- a/src/components/viewer/pdf/hooks/use-pdf-marks-io.ts
+++ b/src/components/viewer/pdf/hooks/use-pdf-marks-io.ts
@@ -25,6 +25,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { useStableDerived } from "@/components/viewer/pdf/hooks/use-stable-derived";
 import type { PdfViewerProps } from "@/components/viewer/pdf/types";
 import { isTauri } from "@/lib/core/tauri";
 import {
@@ -32,7 +33,7 @@ import {
 	type PdfVisualSessionTrace,
 } from "@/lib/pdf/agent-trace";
 import { listPdfAskThreads } from "@/lib/pdf/ask";
-import { threadHasUserQuestion } from "@/lib/pdf/ask/schema";
+import { threadHasUserQuestion, threadPreview } from "@/lib/pdf/ask/schema";
 import type { PdfAskThread } from "@/lib/pdf/ask/types";
 import { marksDir } from "@/lib/pdf/selection";
 import { listPdfTranslates } from "@/lib/pdf/translate";
@@ -215,9 +216,24 @@ export function usePdfMarksIo({
 	}, [paperAbsPath, isActive]);
 
 	// Publish ask threads (with a real question) to the annotations panel.
+	// Gated on a fingerprint of the fields the panel renders (question preview,
+	// page, status, message count): streaming gives `threads` a fresh identity on
+	// every chunk, and republishing each chunk rewrote annotationsStore and
+	// re-rendered the panel several times per second.
+	const asksFingerprint = threads
+		.filter(threadHasUserQuestion)
+		.map(
+			(th) =>
+				`${th.id}|${th.status}|${th.anchor.page}|${th.anchor.rects[0]?.y ?? 0}|${th.messages.length}|${threadPreview(th)}`,
+		)
+		.join(";");
+	const publishedAsks = useStableDerived(
+		() => threads.filter(threadHasUserQuestion),
+		asksFingerprint,
+	);
 	useEffect(() => {
-		onAsksChangeRef.current?.(threads.filter(threadHasUserQuestion));
-	}, [threads, onAsksChangeRef]);
+		onAsksChangeRef.current?.(publishedAsks);
+	}, [publishedAsks, onAsksChangeRef]);
 
 	// Publish visual agent-trace marks to the annotations panel.
 	useEffect(() => {

--- a/src/components/viewer/pdf/hooks/use-pdf-page-text.ts
+++ b/src/components/viewer/pdf/hooks/use-pdf-page-text.ts
@@ -14,7 +14,7 @@
 
 import type { PdfEngine } from "@embedpdf/models";
 import type { useDocumentManagerCapability } from "@embedpdf/plugin-document-manager/react";
-import { type RefObject, useEffect, useRef, useState } from "react";
+import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
 import type { PdfVisualSessionTrace } from "@/lib/pdf/agent-trace";
 import { threadHasUserQuestion } from "@/lib/pdf/ask/schema";
 import type { PdfAskThread } from "@/lib/pdf/ask/types";
@@ -69,7 +69,28 @@ export function usePdfPageText({
 	const pageTextMapRef = useRef(pageTextMap);
 	pageTextMapRef.current = pageTextMap;
 
+	// Which off-screen pages carry a mark and must load their text geometry.
+	// Keyed on the resulting page set (a primitive), not the mark arrays: while a
+	// reply / translation streams, those arrays get a fresh identity on every
+	// chunk although no anchor page changes, and re-running the fetch effect per
+	// chunk is pure waste.
+	const markPagesKey = useMemo(() => {
+		const pages = new Set<number>();
+		for (const tr of translates) {
+			if (!tr.error) pages.add(tr.page - 1);
+		}
+		for (const th of threads) {
+			if (threadHasUserQuestion(th)) pages.add(th.anchor.page - 1);
+		}
+		for (const h of highlights) {
+			if (h.comment?.trim()) pages.add(h.page - 1);
+		}
+		for (const v of visualTraces) pages.add(v.page - 1);
+		return [...pages].sort((a, b) => a - b).join(",");
+	}, [translates, threads, highlights, visualTraces]);
+
 	// Load real page text geometry for pages that have pins (or near the viewport).
+	// biome-ignore lint/correctness/useExhaustiveDependencies: mark arrays are intentionally represented by markPagesKey — the anchor page set is the only input the fetch consumes
 	useEffect(() => {
 		if (!engine || !docCap || totalPages <= 0) return;
 		const doc = docCap.getDocument(docId);
@@ -119,17 +140,7 @@ export function usePdfPageText({
 					pageTextPendingRef.current.delete(pageIndex);
 				});
 		}
-	}, [
-		engine,
-		docCap,
-		docId,
-		totalPages,
-		currentPage,
-		translates,
-		threads,
-		highlights,
-		visualTraces,
-	]);
+	}, [engine, docCap, docId, totalPages, currentPage, markPagesKey]);
 
 	return { pageTextMap, pageTextMapRef };
 }

--- a/src/components/viewer/pdf/hooks/use-stable-derived.ts
+++ b/src/components/viewer/pdf/hooks/use-stable-derived.ts
@@ -1,0 +1,24 @@
+/**
+ * Referentially-stable derived value for the PDF viewer's page-render path.
+ *
+ * Streaming (ask / translate) replaces the whole mark array on every chunk even
+ * though the geometry-relevant fields (anchor rects, page, preview) are untouched.
+ * A `useMemo` keyed on those arrays therefore returns a fresh identity per chunk,
+ * which churns `pinsByPage` → `pageMarks` → `renderPage` and forces the Scroller
+ * to re-render every mounted page for every streamed token.
+ *
+ * This hook re-derives only when the caller-provided `fingerprint` (a string over
+ * the fields the derivation actually reads) changes, and otherwise returns the
+ * cached reference. The fingerprint is a plain primitive, so downstream memos
+ * keep their identity across chunks.
+ */
+
+import { useRef } from "react";
+
+export function useStableDerived<T>(derive: () => T, fingerprint: string): T {
+	const cacheRef = useRef<{ fingerprint: string; value: T } | null>(null);
+	if (!cacheRef.current || cacheRef.current.fingerprint !== fingerprint) {
+		cacheRef.current = { fingerprint, value: derive() };
+	}
+	return cacheRef.current.value;
+}

--- a/src/components/viewer/pdf/layers/page-layers.tsx
+++ b/src/components/viewer/pdf/layers/page-layers.tsx
@@ -35,7 +35,7 @@ import { PdfRegionSelectLayer } from "@/components/viewer/pdf/layers/region-sele
 import { SelectionGutter } from "@/components/viewer/pdf/layers/selection-gutter";
 import { cn } from "@/lib/core/utils";
 import type { PdfVisualSessionTrace } from "@/lib/pdf/agent-trace";
-import type { PdfAskNormalizedRect, PdfAskThread } from "@/lib/pdf/ask/types";
+import type { PdfAskNormalizedRect } from "@/lib/pdf/ask/types";
 import {
 	isFormulaLayoutKind,
 	type LayoutTranslateItem,
@@ -47,15 +47,26 @@ import {
 } from "@/lib/pdf/layout";
 import { PDF_PAGE_RASTER_DARK_CLASS } from "@/lib/pdf/page-theme";
 import type { SelectionPin } from "@/lib/pdf/selection";
-import type { PdfTranslateRecord } from "@/lib/pdf/translate/types";
 
 /** A mark region pinned to a page (visual draft frame / formula legend frame). */
 type PageRegion = { page: number; region: PdfAskNormalizedRect } | null;
 
+/**
+ * Anchor geometry of an open ask / translate card. Anchor-only: it keeps its
+ * identity while the card body streams, so the page layers skip re-rendering
+ * per streamed chunk.
+ */
+export type PdfActiveCardAnchor = {
+	id: string;
+	/** 1-based page number */
+	page: number;
+	rects: PdfAskNormalizedRect[];
+};
+
 /** Marks and mark-derived overlays. Whole-document work, bucketed by page. */
 export type PdfPageMarksSlice = {
-	activeThread: PdfAskThread | null;
-	activeTranslate: PdfTranslateRecord | null;
+	activeAskAnchor: PdfActiveCardAnchor | null;
+	activeTranslateAnchor: PdfActiveCardAnchor | null;
 	activeVisualTrace: PdfVisualSessionTrace | null;
 	visualDraftRegion: PageRegion;
 	formulaAnnotationRegion: PageRegion;
@@ -125,9 +136,11 @@ export const PdfPageLayers = memo(function PdfPageLayers({
 	const { t } = useTranslation("viewer");
 	const pageNumber = pageIndex + 1;
 	const activeAskOnPage =
-		marks.activeThread?.anchor.page === pageNumber ? marks.activeThread : null;
+		marks.activeAskAnchor?.page === pageNumber ? marks.activeAskAnchor : null;
 	const activeTranslateOnPage =
-		marks.activeTranslate?.page === pageNumber ? marks.activeTranslate : null;
+		marks.activeTranslateAnchor?.page === pageNumber
+			? marks.activeTranslateAnchor
+			: null;
 	const activeVisualOnPage =
 		marks.activeVisualTrace?.page === pageNumber
 			? marks.activeVisualTrace
@@ -302,7 +315,7 @@ export const PdfPageLayers = memo(function PdfPageLayers({
 					: null}
 				{/* Open ask conversation card: highlight the anchored selection. */}
 				{activeAskOnPage
-					? activeAskOnPage.anchor.rects.map((rect) => (
+					? activeAskOnPage.rects.map((rect) => (
 							<div
 								key={`${activeAskOnPage.id}-source-${rect.x}-${rect.y}-${rect.w}-${rect.h}`}
 								className="pointer-events-auto absolute z-[1] rounded-[2px] bg-amber-300/45 dark:bg-amber-400/35"

--- a/src/components/viewer/pdf/pdf-viewer.tsx
+++ b/src/components/viewer/pdf/pdf-viewer.tsx
@@ -74,6 +74,7 @@ import { usePdfTextSelection } from "@/components/viewer/pdf/hooks/use-pdf-text-
 import { usePdfViewerHandle } from "@/components/viewer/pdf/hooks/use-pdf-viewer-handle";
 import { usePdfVisualMarks } from "@/components/viewer/pdf/hooks/use-pdf-visual-marks";
 import { usePdfZoomControls } from "@/components/viewer/pdf/hooks/use-pdf-zoom-controls";
+import { useStableDerived } from "@/components/viewer/pdf/hooks/use-stable-derived";
 import {
 	type PdfPageHandlers,
 	PdfPageLayers,
@@ -95,8 +96,7 @@ import {
 import { cn } from "@/lib/core/utils";
 import { isPdfViewerSource } from "@/lib/paper";
 import { isVisualMarkKind, tracePreview } from "@/lib/pdf/agent-trace";
-import { toSummaries } from "@/lib/pdf/ask";
-import { threadHasUserQuestion } from "@/lib/pdf/ask/schema";
+import { threadHasUserQuestion, threadPreview } from "@/lib/pdf/ask/schema";
 import type { PdfAskNormalizedRect, PdfAskThread } from "@/lib/pdf/ask/types";
 import { equationAnnotationPath } from "@/lib/pdf/equation-annotation";
 import {
@@ -111,6 +111,7 @@ import {
 	pinObscuresBodyText,
 	type SelectionPin,
 } from "@/lib/pdf/selection";
+import type { PdfTranslateRect } from "@/lib/pdf/translate/types";
 import { PDF_ZOOM_MAX, PDF_ZOOM_MIN } from "@/lib/pdf/zoom";
 import { openRightTab } from "@/lib/shell/ui-store";
 import { openPath } from "@/lib/workspace/actions";
@@ -119,6 +120,37 @@ export type {
 	PdfViewerHandle,
 	PdfViewerProps,
 } from "@/components/viewer/pdf/types";
+
+/**
+ * Geometry-only projection of a mark for gutter pins. Extracted from the ask /
+ * translate arrays with a stable identity (see {@link useStableDerived}) so the
+ * per-chunk streaming message bodies cannot invalidate `pinsByPage` (and with it
+ * every mounted page).
+ */
+type AskPinAnchor = {
+	id: string;
+	/** 1-based page number */
+	page: number;
+	rects: PdfAskNormalizedRect[];
+	preview: string;
+	ended: boolean;
+};
+
+type TranslatePinAnchor = {
+	id: string;
+	/** 1-based page number */
+	page: number;
+	rects: PdfTranslateRect[];
+	preview: string;
+	hasError: boolean;
+};
+
+/** Compact value fingerprint of normalized rects (pin geometry input). */
+function rectsKey(
+	rects: ReadonlyArray<{ x: number; y: number; w: number; h: number }>,
+): string {
+	return rects.map((r) => `${r.x},${r.y},${r.w},${r.h}`).join("~");
+}
 
 /**
  * PDF viewer built on EmbedPDF (headless, PDFium/WASM). The engine is shared
@@ -620,9 +652,45 @@ function PdfViewerInner({
 		handleCitationLinkHover,
 	} = usePdfCitations({ docId, annotationCap, hostRef, zoomRef });
 
-	const askSummaries = useMemo(
-		() => toSummaries(threads.filter(threadHasUserQuestion)),
-		[threads],
+	/**
+	 * Pin geometry is anchor data only. While an answer / translation streams,
+	 * every chunk replaces the whole threads / translates array, but none of the
+	 * fields fingerprinted below change — so these projections keep their
+	 * identity and `pinsByPage` (and thus every mounted page) skips re-rendering
+	 * per chunk. The translate pin preview therefore uses the source quote, not
+	 * the streamed result (the open card shows the live text).
+	 */
+	const askPinAnchors = useStableDerived<AskPinAnchor[]>(
+		() =>
+			threads.filter(threadHasUserQuestion).map((th) => ({
+				id: th.id,
+				page: th.anchor.page,
+				rects: th.anchor.rects,
+				preview: threadPreview(th),
+				ended: th.status === "ended",
+			})),
+		threads
+			.map(
+				(th) =>
+					`${th.id}|${threadHasUserQuestion(th) ? 1 : 0}|${th.anchor.page}|${th.status}|${threadPreview(th)}|${rectsKey(th.anchor.rects)}`,
+			)
+			.join(";"),
+	);
+	const translatePinAnchors = useStableDerived<TranslatePinAnchor[]>(
+		() =>
+			translates.map((tr) => ({
+				id: tr.id,
+				page: tr.page,
+				rects: tr.rects,
+				preview: tr.quote?.trim() || tr.id,
+				hasError: Boolean(tr.error),
+			})),
+		translates
+			.map(
+				(tr) =>
+					`${tr.id}|${tr.page}|${tr.error ? 1 : 0}|${tr.quote ?? ""}|${rectsKey(tr.rects)}`,
+			)
+			.join(";"),
 	);
 
 	/**
@@ -654,34 +722,30 @@ function PdfViewerInner({
 				side: pin.side,
 			});
 		}
-		for (const summary of askSummaries) {
-			const pageText = pageTextMap.get(summary.page - 1);
-			const thread = threads.find((th) => th.id === summary.id);
-			const pin = thread
-				? pinFromRects(thread.anchor.rects, pageText)
-				: { x: summary.x, y: summary.y, side: "right" as const };
-			add(summary.page, {
-				id: summary.id,
+		for (const anchor of askPinAnchors) {
+			const pageText = pageTextMap.get(anchor.page - 1);
+			const pin = pinFromRects(anchor.rects, pageText);
+			add(anchor.page, {
+				id: anchor.id,
 				kind: "ask",
 				x: pin.x,
 				y: pin.y,
-				preview: summary.preview,
-				ended: summary.status === "ended",
+				preview: anchor.preview,
+				ended: anchor.ended,
 				overText: pinObscuresBodyText(pin, pageText),
 				side: pin.side,
 			});
 		}
-		for (const translate of translates) {
-			if (translate.error) continue;
-			const pageText = pageTextMap.get(translate.page - 1);
-			const pin = pinFromRects(translate.rects, pageText);
-			add(translate.page, {
-				id: translate.id,
+		for (const anchor of translatePinAnchors) {
+			if (anchor.hasError) continue;
+			const pageText = pageTextMap.get(anchor.page - 1);
+			const pin = pinFromRects(anchor.rects, pageText);
+			add(anchor.page, {
+				id: anchor.id,
 				kind: "translate",
 				x: pin.x,
 				y: pin.y,
-				preview:
-					translate.result?.trim() || translate.quote?.trim() || translate.id,
+				preview: anchor.preview,
 				overText: pinObscuresBodyText(pin, pageText),
 				side: pin.side,
 			});
@@ -705,9 +769,8 @@ function PdfViewerInner({
 	}, [
 		highlights,
 		highlightAnchors,
-		askSummaries,
-		threads,
-		translates,
+		askPinAnchors,
+		translatePinAnchors,
 		visualTraces,
 		pageTextMap,
 	]);
@@ -724,6 +787,39 @@ function PdfViewerInner({
 		if (!isVisualMarkKind(activeCard?.kind)) return null;
 		return visualTraces.find((tr) => tr.id === activeCard.id) ?? null;
 	}, [visualTraces, activeCard]);
+	/**
+	 * On-page source frame of the active ask / translate card: anchor geometry
+	 * only. The page layers never read the streaming body, and the rects
+	 * reference survives chunk updates (updaters spread the record and replace
+	 * `messages` / `result` only), so these keep their identity while streaming
+	 * — unlike the full records the card stack consumes.
+	 */
+	const activeAskId = activeThread?.id ?? null;
+	const activeAskPage = activeThread?.anchor.page ?? null;
+	const activeAskRects = activeThread?.anchor.rects ?? null;
+	const activeAskAnchor = useMemo(
+		() =>
+			activeAskId !== null && activeAskPage !== null && activeAskRects !== null
+				? { id: activeAskId, page: activeAskPage, rects: activeAskRects }
+				: null,
+		[activeAskId, activeAskPage, activeAskRects],
+	);
+	const activeTranslateId = activeTranslate?.id ?? null;
+	const activeTranslatePage = activeTranslate?.page ?? null;
+	const activeTranslateRects = activeTranslate?.rects ?? null;
+	const activeTranslateAnchor = useMemo(
+		() =>
+			activeTranslateId !== null &&
+			activeTranslatePage !== null &&
+			activeTranslateRects !== null
+				? {
+						id: activeTranslateId,
+						page: activeTranslatePage,
+						rects: activeTranslateRects,
+					}
+				: null,
+		[activeTranslateId, activeTranslatePage, activeTranslateRects],
+	);
 	// ---- Layout analysis ----
 	// Four hooks: region buckets, the analysis run, hover (sole owner of the two
 	// mutually exclusive hover cards) and the bulk-translate job.
@@ -1067,8 +1163,8 @@ function PdfViewerInner({
 
 	const pageMarks = useMemo<PdfPageMarksSlice>(
 		() => ({
-			activeThread,
-			activeTranslate,
+			activeAskAnchor,
+			activeTranslateAnchor,
 			activeVisualTrace,
 			visualDraftRegion,
 			formulaAnnotationRegion,
@@ -1078,8 +1174,8 @@ function PdfViewerInner({
 			activeCardId: activeCard?.id ?? null,
 		}),
 		[
-			activeThread,
-			activeTranslate,
+			activeAskAnchor,
+			activeTranslateAnchor,
 			activeVisualTrace,
 			visualDraftRegion,
 			formulaAnnotationRegion,


### PR DESCRIPTION
## Summary
- PDF ask / 划词翻译流式回复时，每个 chunk 替换整个 threads/translates 数组，身份变化经 `pinsByPage → pageMarks → renderPage` 传导，Scroller 逐 chunk 重渲染全部挂载页。本 PR 让 pin 几何只依赖 anchor 数据：`pinsByPage` 依赖按字段指纹稳定的 ask/translate 投影（新增 `useStableDerived`），`pageMarks` 改传活动卡片的 anchor 几何（完整流式记录仍由卡片栈消费）。
- `use-pdf-marks-io` 的面板发布改为按面板可见字段指纹触发，不再逐 chunk 全表 filter 写 `annotationsStore`；`use-pdf-page-text` 抓取 effect 依赖改为 mark 页集合的原始字符串键，不再随数组身份重跑。
- 行为权衡：翻译 pin 的 tooltip 预览改用稳定的选区原文（原先跟随流式 result），流式正文仍在打开的卡片中实时展示。

## Test plan
- [ ] `pnpm exec tsc --noEmit` 与 `pnpm exec biome check .` 通过（已验证）
- [ ] `pnpm exec vitest run` 全量通过（已验证，680/680）
- [ ] PDF ask 提问：流式回复期间确认页面不再逐 chunk 闪烁/重渲染，pin 位置与高亮框保持正确，卡片内容正常流式更新
- [ ] 划词翻译（Agent 流式）：流式期间其余挂载页不重渲染，翻译完成后 pin 悬停卡片内容正确
- [ ] 右侧批注面板在流式期间不逐 chunk 刷新，流式结束后 ask 列表（条数/预览）正确
- [ ] pin 的打开/结束（ended 样式）/删除、批注高亮 pin、视觉批注 pin 行为回归正常

Fixes #269