### PR TITLE
perf(agent): 跳过未变化的 set_config RPC 并移除会话加载固定等待

### DIFF
--- a/docs/backend/agent.md
+++ b/docs/backend/agent.md
@@ -38,6 +38,10 @@ spawn 用户配置的 agent
 不写入本轮 content buffer），避免第二轮气泡开头重复上一轮回答；usage /
 commands / config 仍可在 load 期间转发。
 
+`agent_load_session` 在 `session/load` 返回后等待回放通知**静默**（200ms 无新
+通知即返回，最长仍封顶 800ms），替代此前的固定 800ms sleep；回放通常在
+response 前/后很快推完，空会话与短会话因此显著更快（#271）。
+
 ## 命令（摘要）
 
 | Command | 说明 |
@@ -107,6 +111,7 @@ ACP **没有**统一的 ask-user tool 规范：各 harness 的字段名、挂载
 - 若 `current_value` 不在 selector 选项中（第三方网关 / cc-switch 等只改默认 model、目录仍是官方列表），Host **注入**该 current id，避免 UI 丢失。
 - `preferred_model_id`（warm / run_once）在与 current 不同时 **始终尝试** `session/set_config_option`，不要求 id 已在上报列表中；失败仅 debug 日志，不阻断会话。
 - Codex `collaboration_mode`（Default / Plan 等）解析为 `agent:collaboration`；`collaboration_mode_id` 在选项内且与 current 不同时尝试 `session/set_config_option`。UI 称「模式」。Plan 才能用 `request_user_input`。不解析 / 不暴露 ACP `category: mode` 沙箱档。
+- Fast 开关（`fast-mode` model_config 选项）与上述一致：仅当会话当前值与请求值不同时才发 `session/set_config_option`，未变化的配置不再每轮重复下发（#271）。
 
 ## User-Agent（中转站亲和）
 

--- a/src-tauri/src/features/agent/acp.rs
+++ b/src-tauri/src/features/agent/acp.rs
@@ -517,6 +517,25 @@ fn fast_mode_from_config_options(
     })
 }
 
+/// Value to write for the fast-mode option, or `None` when the session already
+/// holds the requested value. Mirrors the `pref != current_id` guards used for
+/// model/collaboration/effort so unchanged config skips the set_config RPC.
+fn fast_mode_value_to_set(
+    opt: &SessionConfigOption,
+    enabled: bool,
+) -> Option<SessionConfigOptionValue> {
+    let target_id = if enabled { "on" } else { "off" };
+    match &opt.kind {
+        SessionConfigKind::Boolean(current) if current.current_value != enabled => {
+            Some(SessionConfigOptionValue::boolean(enabled))
+        }
+        SessionConfigKind::Select(current) if current.current_value.0.as_ref() != target_id => {
+            Some(SessionConfigOptionValue::value_id(target_id))
+        }
+        _ => None,
+    }
+}
+
 fn emit_session_config_options(
     app: &AgentEventEmitter,
     session_id: &str,
@@ -1666,20 +1685,7 @@ pub async fn run_once(
                 }
                 if let Some(enabled) = fast_mode {
                     if let Some(opt) = config_options.iter().find(|opt| is_fast_option(opt)) {
-                        let value = match &opt.kind {
-                            SessionConfigKind::Boolean(_) => {
-                                Some(SessionConfigOptionValue::boolean(enabled))
-                            }
-                            SessionConfigKind::Select(_) => {
-                                Some(SessionConfigOptionValue::value_id(if enabled {
-                                    "on"
-                                } else {
-                                    "off"
-                                }))
-                            }
-                            _ => None,
-                        };
-                        if let Some(value) = value {
+                        if let Some(value) = fast_mode_value_to_set(opt, enabled) {
                             let response = tokio::select! {
                                 result = timed_acp_request(
                                     "set fast mode",
@@ -2327,6 +2333,14 @@ impl ReplayBuilder {
     }
 }
 
+/// Settle limits for `session/load` history replay. Agents push replayed turns
+/// as `session/update` notifications without a completion marker, so wait until
+/// they quiet down (`REPLAY_SETTLE_QUIET`) instead of always sleeping a fixed
+/// 800 ms; `REPLAY_SETTLE_CAP` keeps the previous worst-case capture window.
+const REPLAY_SETTLE_CAP: std::time::Duration = std::time::Duration::from_millis(800);
+const REPLAY_SETTLE_QUIET: std::time::Duration = std::time::Duration::from_millis(200);
+const REPLAY_SETTLE_POLL: std::time::Duration = std::time::Duration::from_millis(50);
+
 pub async fn load_acp_session(
     desc: &AgentDescriptor,
     session_id: String,
@@ -2337,12 +2351,20 @@ pub async fn load_acp_session(
 
     let builder: Arc<Mutex<ReplayBuilder>> = Arc::new(Mutex::new(ReplayBuilder::default()));
     let builder_for_notif = builder.clone();
+    // Last time a replay notification arrived; lets the settle loop below wait
+    // on actual replay activity instead of a fixed sleep.
+    let last_replay: Arc<Mutex<std::time::Instant>> =
+        Arc::new(Mutex::new(std::time::Instant::now()));
+    let last_replay_for_notif = last_replay.clone();
 
     let result = agent_client_protocol::Client
         .builder()
         .name("agentero")
         .on_receive_notification(
             async move |notification: SessionNotification, _cx| {
+                if let Ok(mut at) = last_replay_for_notif.lock() {
+                    *at = std::time::Instant::now();
+                }
                 let Ok(mut b) = builder_for_notif.lock() else {
                     return Ok(());
                 };
@@ -2416,6 +2438,7 @@ pub async fn load_acp_session(
         )
         .connect_with(acp, {
             let sid = session_id.clone();
+            let last_replay = last_replay.clone();
             move |connection: ConnectionTo<Agent>| async move {
                 timed_acp_request(
                     "initialize",
@@ -2436,8 +2459,21 @@ pub async fn load_acp_session(
                 )
                 .await?;
 
-                // Brief settle so the agent can push replayed notifications.
-                tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+                // Settle until replayed notifications quiet down instead of always
+                // sleeping 800 ms; the capture window stays capped at 800 ms.
+                let settle_start = std::time::Instant::now();
+                loop {
+                    tokio::time::sleep(REPLAY_SETTLE_POLL).await;
+                    let last = last_replay
+                        .lock()
+                        .map(|at| *at)
+                        .unwrap_or_else(|_| std::time::Instant::now());
+                    if last.elapsed() >= REPLAY_SETTLE_QUIET
+                        || settle_start.elapsed() >= REPLAY_SETTLE_CAP
+                    {
+                        break;
+                    }
+                }
                 Ok(())
             }
         })
@@ -2490,10 +2526,11 @@ mod cancelled_payload_tests {
 mod config_option_tests {
     use super::{
         collaboration_from_config_options, effort_from_config_options,
-        fast_mode_from_config_options, models_from_config_options,
+        fast_mode_from_config_options, fast_mode_value_to_set, models_from_config_options,
     };
     use agent_client_protocol::schema::v1::{
-        SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOption,
+        SessionConfigOption, SessionConfigOptionCategory, SessionConfigOptionValue,
+        SessionConfigSelectOption,
     };
 
     #[test]
@@ -2601,6 +2638,38 @@ mod config_option_tests {
         let fast = fast_mode_from_config_options("session", "codex", &options)
             .expect("Codex fast mode should be exposed");
         assert!(fast.enabled);
+    }
+
+    #[test]
+    fn skips_fast_mode_set_when_select_already_matches() {
+        let option = SessionConfigOption::select(
+            "fast-mode",
+            "Fast mode",
+            "on",
+            vec![
+                SessionConfigSelectOption::new("off", "Off"),
+                SessionConfigSelectOption::new("on", "On"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::ModelConfig);
+
+        assert_eq!(fast_mode_value_to_set(&option, true), None);
+        assert_eq!(
+            fast_mode_value_to_set(&option, false),
+            Some(SessionConfigOptionValue::value_id("off"))
+        );
+    }
+
+    #[test]
+    fn skips_fast_mode_set_when_boolean_already_matches() {
+        let option = SessionConfigOption::boolean("fast-mode", "Fast mode", true)
+            .category(SessionConfigOptionCategory::ModelConfig);
+
+        assert_eq!(fast_mode_value_to_set(&option, true), None);
+        assert_eq!(
+            fast_mode_value_to_set(&option, false),
+            Some(SessionConfigOptionValue::boolean(false))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**部分修复 #271**（低风险减耗；连接池化/常驻连接复用不在本 PR 范围，见 issue 评论）。

- **set_config 去重**：`run_once` 每轮最多串行 4 次 `session/set_config_option`（model / collaboration / effort / fast）。其中 model / collaboration / effort 原本已与 agent 上报的 current 值比较、相同即跳过；**fast mode 是唯一无守卫的分支**——只要 `fastMode` 有值且会话声明了 fast 选项，就每轮无条件重发。本 PR 抽出 `fast_mode_value_to_set()`，与其余三项一致：仅当会话当前值（Boolean 的 `current_value` / Select 的 `on`/`off`）与请求值不同才下发。稳态多轮对话中 4 次串行 RPC 因此全部可省。
  - 说明：由于每条消息都 spawn 新进程，"上次已生效的配置" 的权威来源就是 resume/load 响应里 agent 上报的 `config_options`；host 侧再镜像一份跨轮缓存既冗余又可能在 agent 不持久化配置时错误跳过，故未引入。
- **移除 `load_acp_session` 固定 sleep 800ms**：该 sleep 等的是 `session/load` 响应之后异步推来的历史回放通知，ACP 协议没有"回放完成"信号（`SessionUpdate` 无终止标记）。改为**等待回放通知静默**：记录最后一次回放通知到达时间，每 50ms 轮询，连续 200ms 无新通知即返回；总等待仍封顶 800ms（与旧行为相同的最坏捕获窗口，不会新增截断）。回放通常在 response 前后很快推完，空会话/短会话由固定 800ms 降至约 50–250ms。
- 同步更新 `docs/backend/agent.md`。

不做连接池化（issue 修复方法 1），剩余项待后续 PR。

## Test plan

- [x] `cargo check -p agentero --all-targets`
- [x] `cargo clippy -p agentero --all-targets -- -D warnings`（与 CI 一致）
- [x] `cargo fmt --all --check`
- [x] `cargo test -p agentero`：310 passed（含新增 2 个单测：select / boolean 两种 fast-mode 选项在"当前值已等于目标值"时返回 `None` 跳过 RPC，不同时返回对应写入值）
- [ ] 手动：Codex 多轮续聊（固定 model + fast mode 开启），观察 host 日志确认稳态轮次不再出现 `set fast mode` 等 set_config RPC
- [ ] 手动：打开含历史的 ACP 会话（`agent_load_session`），确认 transcript 完整且加载明显变快

Fixes #271