### PR TITLE
perf(editor): 收敛光标/TOC/补全热路径的全文遍历

### DIFF
--- a/src/components/editor/hooks/use-wikilink-editing.ts
+++ b/src/components/editor/hooks/use-wikilink-editing.ts
@@ -73,6 +73,12 @@ export function useWikilinkEditing({
 	const composingWikiLinkDraftRef = useRef(false);
 	const wikiLinkPresentationFrameRef = useRef<number | null>(null);
 	const wikiLinkPresentationMarkdownRef = useRef<string | null>(null);
+	/**
+	 * Selection seen by the previous `syncWikiLinkPresentation`. A draft can
+	 * only become "abandoned" when the selection moves, so the region it left
+	 * is the only place a newly stale draft can be.
+	 */
+	const previousSelectionRef = useRef<PlateEditor["selection"]>(null);
 	const activeWikiLinkPathRef = useRef<{
 		current: number[] | null;
 		unref: () => number[] | null;
@@ -244,18 +250,36 @@ export function useWikilinkEditing({
 			) {
 				return;
 			}
-			// Push the predicate into the traversal: materialising every node (text
-			// leaves included) three times over ran on each caret move.
+			// Drafts only form under the caret (completion / template insert),
+			// and the selection change that abandons one is exactly what runs
+			// this sync — so only the region the selection just left or just
+			// entered can hold a draft to reify. Scan those two regions instead
+			// of the whole document on every caret move; the blur-time
+			// `finalizeWikiLinkDrafts` keeps a full-document safety net.
 			const draftRefs: ReturnType<typeof editor.api.pathRef>[] = [];
-			for (const [node, path] of editor.api.nodes({
-				at: [],
-				match: isWikiLinkDraftText,
-			})) {
-				if (!isWikiLinkDraftText(node)) continue;
-				if (parseWikiLinkMarkdown(node.text) === null) continue;
-				if (isSelectionEditingWikiLinkDraft(path, node.text, selection))
-					continue;
-				draftRefs.push(editor.api.pathRef(path, { affinity: "forward" }));
+			const seenDraftKeys = new Set<string>();
+			const regions = [previousSelectionRef.current, selection];
+			previousSelectionRef.current = selection;
+			for (const region of regions) {
+				if (!region) continue;
+				try {
+					for (const [node, path] of editor.api.nodes({
+						at: region,
+						match: isWikiLinkDraftText,
+					})) {
+						if (!isWikiLinkDraftText(node)) continue;
+						const key = path.join(",");
+						if (seenDraftKeys.has(key)) continue;
+						seenDraftKeys.add(key);
+						if (parseWikiLinkMarkdown(node.text) === null) continue;
+						if (isSelectionEditingWikiLinkDraft(path, node.text, selection))
+							continue;
+						draftRefs.push(editor.api.pathRef(path, { affinity: "forward" }));
+					}
+				} catch {
+					// The region's nodes were deleted before this sync ran; a
+					// deleted region cannot hold a draft left to reify.
+				}
 			}
 			const selectedPath = selectedWikiLinkPath(selection);
 			const activeRef = activeWikiLinkPathRef.current;

--- a/src/components/editor/markdown-editor.tsx
+++ b/src/components/editor/markdown-editor.tsx
@@ -28,6 +28,7 @@ import { HeadingRenameDialog } from "@/components/editor/overlays/heading-rename
 import { SlashCommandMenu } from "@/components/editor/overlays/slash-command-menu";
 import {
 	MINIMUM_TOC_HEADINGS,
+	queryTocHeadings,
 	TocSidebar,
 } from "@/components/editor/overlays/toc-sidebar";
 import { WikiLinkSuggestion } from "@/components/editor/overlays/wiki-link-suggestion";
@@ -182,7 +183,9 @@ export function MarkdownEditor({
 	const plugins = useMemo(
 		() => [
 			...MarkdownEditorKit,
-			TocPlugin,
+			TocPlugin.configure({
+				options: { queryHeading: queryTocHeadings },
+			}),
 			ImagePlugin.configure({
 				options: {
 					uploadImage: async (dataUrl: ArrayBuffer | string) => {

--- a/src/components/editor/overlays/find-replace-bar.tsx
+++ b/src/components/editor/overlays/find-replace-bar.tsx
@@ -40,6 +40,9 @@ function matchesKey(ranges: TRange[]): string {
 		.join("|");
 }
 
+/** Query typing settles before the document is walked and re-decorated. */
+const FIND_DEBOUNCE_MS = 150;
+
 /** All six bar buttons are the same ghost icon button with a bottom tooltip. */
 function IconAction({
 	label,
@@ -105,23 +108,37 @@ export function FindReplaceBar({
 	const [activeIndex, setActiveIndex] = useState(0);
 	const searchInputRef = useRef<HTMLInputElement>(null);
 
+	/**
+	 * The input stays on the live query; matching waits for a pause so a
+	 * keystroke burst costs one full-document walk + redecorate, not one
+	 * per key.
+	 */
+	const [debouncedQuery, setDebouncedQuery] = useState("");
+	useEffect(() => {
+		const timer = window.setTimeout(
+			() => setDebouncedQuery(query),
+			FIND_DEBOUNCE_MS,
+		);
+		return () => window.clearTimeout(timer);
+	}, [query]);
+
 	// Recompute matches on every editor change while the bar is open.
 	const matches = useEditorSelector(
-		(e) => findSearchMatches(e, query),
-		[query],
+		(e) => findSearchMatches(e, debouncedQuery),
+		[debouncedQuery],
 		{ equalityFn: (a, b) => matchesKey(a) === matchesKey(b) },
 	);
 	const index = matches.length ? Math.min(activeIndex, matches.length - 1) : -1;
 
 	useEffect(() => {
-		editor.setOption(FindReplacePlugin, "search", query);
+		editor.setOption(FindReplacePlugin, "search", debouncedQuery);
 		editor.setOption(
 			ActiveSearchHighlightPlugin,
 			"activeMatch",
 			index >= 0 ? matches[index] : null,
 		);
 		editor.api.redecorate();
-	}, [editor, query, matches, index]);
+	}, [editor, debouncedQuery, matches, index]);
 
 	useEffect(
 		() => () => {
@@ -145,16 +162,16 @@ export function FindReplaceBar({
 
 	const scrolledQueryRef = useRef("");
 	useEffect(() => {
-		if (!query) {
+		if (!debouncedQuery) {
 			scrolledQueryRef.current = "";
 			return;
 		}
-		if (matches.length && scrolledQueryRef.current !== query) {
-			scrolledQueryRef.current = query;
+		if (matches.length && scrolledQueryRef.current !== debouncedQuery) {
+			scrolledQueryRef.current = debouncedQuery;
 			setActiveIndex(0);
 			scrollToMatch(editor, matches[0]);
 		}
-	}, [editor, query, matches]);
+	}, [editor, debouncedQuery, matches]);
 
 	const goTo = (target: number) => {
 		if (!matches.length) return;
@@ -166,12 +183,12 @@ export function FindReplaceBar({
 	const replaceCurrent = () => {
 		if (index < 0) return;
 		replaceRange(editor, matches[index], replacement);
-		const next = findSearchMatches(editor, query);
+		const next = findSearchMatches(editor, debouncedQuery);
 		if (!next.length) return;
 		// A replacement containing the query re-matches in place; skip past it.
 		const stillMatches = replacement
 			.toLowerCase()
-			.includes(query.toLowerCase());
+			.includes(debouncedQuery.toLowerCase());
 		const nextIndex =
 			((stillMatches ? index + 1 : index) + next.length) % next.length;
 		setActiveIndex(nextIndex);
@@ -233,7 +250,7 @@ export function FindReplaceBar({
 						}}
 					/>
 					<span className="min-w-11 shrink-0 px-1 text-center text-muted-foreground text-xs tabular-nums">
-						{query
+						{debouncedQuery
 							? matches.length
 								? `${index + 1}/${matches.length}`
 								: t("findReplace.noResults")

--- a/src/components/editor/overlays/toc-sidebar.tsx
+++ b/src/components/editor/overlays/toc-sidebar.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { type Heading, isHeading } from "@platejs/toc";
 import {
 	type TocSideBarProps,
 	useTocSideBar,
 	useTocSideBarState,
 } from "@platejs/toc/react";
+import { NodeApi, type SlateEditor } from "platejs";
 import i18n from "@/i18n";
 import { cn } from "@/lib/core/utils";
 
@@ -16,6 +18,76 @@ const markerWidthByDepth = {
 	5: "w-2.5",
 	6: "w-2",
 } as const;
+
+const headingDepthByType: Record<string, number> = {
+	h1: 1,
+	h2: 2,
+	h3: 3,
+	h4: 4,
+	h5: 5,
+	h6: 6,
+};
+
+type TocHeadingCacheEntry = {
+	/** `editor.children` reference the cache was computed for. */
+	children: unknown;
+	/** Signature of the cached list (id/depth/title per heading). */
+	key: string;
+	list: Heading[];
+};
+
+/** Per-editor cache; editors are keyed weakly so tabs can be GC'd. */
+const tocHeadingCache = new WeakMap<object, TocHeadingCacheEntry>();
+
+/**
+ * `TocPlugin` `queryHeading` override.
+ *
+ * The library's `getHeadingList` walks the whole document and returns a fresh
+ * array on every call — and both `useTocSideBarState` and its content observer
+ * select it, so each edit cost two full walks plus an IntersectionObserver
+ * rebuild (the observer effect depends on the list reference). Memoizing on
+ * `editor.children` shares one walk between the two selectors per edit, and
+ * keeping the array reference stable while heading id/depth/title are
+ * unchanged means edits elsewhere neither re-render the sidebar nor rebuild
+ * the observer.
+ */
+export function queryTocHeadings(editor: SlateEditor): Heading[] {
+	let entry = tocHeadingCache.get(editor);
+	if (entry && entry.children === editor.children) return entry.list;
+
+	const list: Heading[] = [];
+	for (const [node, path] of editor.api.nodes({
+		at: [],
+		match: (n) => isHeading(n),
+	})) {
+		const title = NodeApi.string(node);
+		if (!title) continue;
+		const { id, type } = node as { id?: string; type: string };
+		list.push({
+			id: id ?? "",
+			depth: headingDepthByType[type] ?? 6,
+			path,
+			title,
+			type,
+		});
+	}
+	const key = list
+		.map(
+			(heading) => `${heading.id}\u0000${heading.depth}\u0000${heading.title}`,
+		)
+		.join("\u0001");
+
+	if (!entry) {
+		entry = { children: null, key: "", list: [] };
+		tocHeadingCache.set(editor, entry);
+	}
+	entry.children = editor.children;
+	if (key !== entry.key) {
+		entry.key = key;
+		entry.list = list;
+	}
+	return entry.list;
+}
 
 /**
  * Mounting this component costs two full-document walks per edit (both

--- a/src/components/editor/overlays/wiki-link-suggestion.tsx
+++ b/src/components/editor/overlays/wiki-link-suggestion.tsx
@@ -77,6 +77,9 @@ type CandidateState = {
 	items: WikiSearchCandidate[];
 };
 
+/** Refinements to a Host-backed search wait for a pause in typing. */
+const WIKI_SEARCH_DEBOUNCE_MS = 200;
+
 function completionRequestKey(
 	request: ReturnType<typeof parseWikiCompletionQuery>,
 ): string | null {
@@ -230,12 +233,33 @@ export function WikiLinkSuggestion({
 		[draftRaw],
 	);
 	const requestKey = completionRequestKey(request);
+	/**
+	 * Host-backed searches (file / heading / annotation) are debounced so a
+	 * keystroke burst fires one `wiki_search` instead of one per key. The
+	 * initial trigger (empty query) and local alias completion stay immediate
+	 * so the menu opens without lag.
+	 */
+	const [fetchRequest, setFetchRequest] = useState(request);
+	useEffect(() => {
+		if (!request || request.kind === "alias" || request.query === "") {
+			setFetchRequest(request);
+			return;
+		}
+		const timer = window.setTimeout(
+			() => setFetchRequest(request),
+			WIKI_SEARCH_DEBOUNCE_MS,
+		);
+		return () => window.clearTimeout(timer);
+	}, [request]);
+	const fetchRequestKey = completionRequestKey(fetchRequest);
+	/** True while a debounced refinement has not been fetched yet. */
+	const fetchPending = requestKey !== fetchRequestKey;
 	const [candidateState, setCandidateState] = useState<CandidateState>({
 		requestKey: null,
 		items: [],
 	});
 	const candidates =
-		candidateState.requestKey === requestKey ? candidateState.items : [];
+		candidateState.requestKey === fetchRequestKey ? candidateState.items : [];
 	const candidatesRef = useRef(candidates);
 	candidatesRef.current = candidates;
 	const [recentCandidates, setRecentCandidates] = useState<
@@ -243,22 +267,22 @@ export function WikiLinkSuggestion({
 	>([]);
 	const [loading, setLoading] = useState(false);
 	useEffect(() => {
-		if (!request) {
+		if (!fetchRequest) {
 			setCandidateState({ requestKey: null, items: [] });
 			setLoading(false);
 			return;
 		}
-		if (request.kind === "alias") {
+		if (fetchRequest.kind === "alias") {
 			setCandidateState({
-				requestKey,
+				requestKey: fetchRequestKey,
 				items: [
 					{
 						kind: "alias",
-						path: request.target,
-						insertText: request.target,
-						label: request.query,
-						detail: request.target,
-						alias: request.query || undefined,
+						path: fetchRequest.target,
+						insertText: fetchRequest.target,
+						label: fetchRequest.query,
+						detail: fetchRequest.target,
+						alias: fetchRequest.query || undefined,
 					},
 				],
 			});
@@ -275,16 +299,16 @@ export function WikiLinkSuggestion({
 		setLoading(true);
 		void (async () => {
 			try {
-				if (request.kind === "file") {
-					const results = await searchWikiLinks(vaultPath, request.query, {
+				if (fetchRequest.kind === "file") {
+					const results = await searchWikiLinks(vaultPath, fetchRequest.query, {
 						kind: "file",
 					});
 					if (!cancelled) {
 						const matching = narrowExactWikiFileCandidates(
 							results.filter((candidate) => candidate.kind === "file"),
-							request.query,
+							fetchRequest.query,
 						);
-						if (!request.query) {
+						if (!fetchRequest.query) {
 							const byKey = new Map(
 								matching.map((candidate) => [
 									wikiCompletionCandidateKey(candidate),
@@ -298,26 +322,26 @@ export function WikiLinkSuggestion({
 								return current ? [current] : [];
 							});
 							setCandidateState({
-								requestKey,
+								requestKey: fetchRequestKey,
 								items: recent.length ? recent : matching,
 							});
 							return;
 						}
-						setCandidateState({ requestKey, items: matching });
+						setCandidateState({ requestKey: fetchRequestKey, items: matching });
 					}
 					return;
 				}
 				// Annotation completion is frontend-backed (marks live outside the
 				// Markdown wiki index). Resolve paper from target or NOTES path,
 				// then list from PDF-tab store or disk.
-				if (request.kind === "annotation") {
+				if (fetchRequest.kind === "annotation") {
 					let paperAbs: string | null = null;
 					let pathHint = filePath;
-					if (request.target) {
+					if (fetchRequest.target) {
 						const resolved = await resolveWikiReference(
 							vaultPath,
 							filePath,
-							request.target,
+							fetchRequest.target,
 						);
 						if (resolved?.targetPath) {
 							pathHint = resolved.targetPath;
@@ -342,13 +366,13 @@ export function WikiLinkSuggestion({
 						if (tab?.paperMeta?.path) pathHint = tab.paperMeta.path;
 					}
 					const items = await buildAnnotationCandidates(
-						request.query,
-						request.target,
+						fetchRequest.query,
+						fetchRequest.target,
 						paperAbs,
 						pathHint,
 					);
 					if (!cancelled) {
-						setCandidateState({ requestKey, items });
+						setCandidateState({ requestKey: fetchRequestKey, items });
 					}
 					return;
 				}
@@ -359,7 +383,7 @@ export function WikiLinkSuggestion({
 				const resolved = await resolveWikiReference(
 					vaultPath,
 					filePath,
-					request.target,
+					fetchRequest.target,
 				);
 				if (
 					cancelled ||
@@ -367,26 +391,27 @@ export function WikiLinkSuggestion({
 					resolved.status === "ambiguous"
 				) {
 					if (!cancelled) {
-						setCandidateState({ requestKey, items: [] });
+						setCandidateState({ requestKey: fetchRequestKey, items: [] });
 					}
 					return;
 				}
-				const results = await searchWikiLinks(vaultPath, request.query, {
+				const results = await searchWikiLinks(vaultPath, fetchRequest.query, {
 					path: resolved.targetPath,
-					kind: request.kind,
+					kind: fetchRequest.kind,
 				});
 				if (!cancelled) {
 					setCandidateState({
-						requestKey,
+						requestKey: fetchRequestKey,
 						items: results.filter(
 							(candidate) =>
-								candidate.kind === request.kind &&
+								candidate.kind === fetchRequest.kind &&
 								sameWikiPath(candidate.path, resolved.targetPath ?? ""),
 						),
 					});
 				}
 			} catch {
-				if (!cancelled) setCandidateState({ requestKey, items: [] });
+				if (!cancelled)
+					setCandidateState({ requestKey: fetchRequestKey, items: [] });
 			} finally {
 				if (!cancelled) setLoading(false);
 			}
@@ -394,7 +419,13 @@ export function WikiLinkSuggestion({
 		return () => {
 			cancelled = true;
 		};
-	}, [filePath, recentCandidates, request, requestKey, wikiNav?.vaultPath]);
+	}, [
+		filePath,
+		recentCandidates,
+		fetchRequest,
+		fetchRequestKey,
+		wikiNav?.vaultPath,
+	]);
 
 	const selectCandidateRef = useRef<
 		(candidate: WikiSearchCandidate, submitKey: "Enter" | "Tab") => boolean
@@ -561,12 +592,12 @@ export function WikiLinkSuggestion({
 				role="listbox"
 				aria-label={t("wikiCompletion.label")}
 			>
-				{loading ? (
+				{loading || fetchPending ? (
 					<p className="px-2 py-1.5 text-muted-foreground text-xs">
 						{t("wikiCompletion.loading")}
 					</p>
 				) : null}
-				{!loading && !candidates.length ? (
+				{!loading && !fetchPending && !candidates.length ? (
 					<p className="px-2 py-1.5 text-muted-foreground text-xs">
 						{t("wikiCompletion.empty")}
 					</p>


### PR DESCRIPTION
## Summary

- **光标移动**：`syncWikiLinkPresentation` 不再全文遍历找 wikilink draft，只扫描选区刚离开/进入的两个区域（draft 仅在光标处生成、离开选区时即被 reify，blur 时 `finalizeWikiLinkDrafts` 保留全文兜底）；过期区域用 try/catch 防护。
- **TOC**：为 `TocPlugin` 配置 `queryTocHeadings`——按 `editor.children` 引用记忆化，库内两个 selector 每次编辑共享一次遍历；标题 id/深度/文本不变时返回稳定数组引用，`useEditorSelector` 引用相等即跳过重渲染，IntersectionObserver 不再随每次按键重建。
- **双链补全**：Host 侧 `wiki_search` 防抖 200ms——首次触发（空 query）与本地 alias 保持立即，后续按键连击只发一次搜索；防抖窗口内候选 stale-while-revalidate 并显示 loading，避免空态闪烁。
- **查找栏**：查询防抖 150ms——输入框仍实时受控，匹配计算/高亮装饰/导航与计数统一走防抖值，按键连击只做一次全文遍历 + redecorate。

**跳过项（序列化比对）**：跨双链边界的 `serialize()` 快照比对（issue 第 2 点）未改。用结构化 dirty 标记替代需穷举所有隐式改动来源（IME 组合输入、normalizer 等），漏标会导致改动被误判为纯投影而跳过自动保存，等价性风险高；且它只在跨界事件触发、非每键热路径，收益有限，留待后续单独处理。

## Test plan

- [x] `pnpm exec tsc --noEmit` 通过
- [x] `biome check` 对 5 个改动文件通过（pre-commit lint-staged 亦通过）
- [x] `vitest run` 相关 11 个测试文件 88 用例全部通过（editor-toc / annotation-wikilink / editor-context-menu / ime / slash-command 等）
- [ ] 大文档手动验证：连续移动光标/打字无迟滞；进出 `[[双链]]` 边界展开/折叠正常，IME 输入正常
- [ ] 双链补全：输入 `[[` 立即出候选，连续输入仅触发一次搜索；Tab 跳转 `#`/`@` 段仍流畅
- [ ] 查找栏：快速输入查询时高亮与计数在 ~150ms 后更新，Enter 导航/替换正常
- [ ] TOC：编辑正文时悬浮目录不闪烁；增删/改标题后目录与高亮正确更新

Fixes #272