### PR TITLE
feat(settings): Markdown 编辑器三分字体与行距

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
  "ed25519-dalek",
  "encoding_rs",
  "flate2",
+ "fontdb 0.23.0",
  "futures-util",
  "hex",
  "htmd",
@@ -2195,6 +2196,20 @@ dependencies = [
  "slotmap",
  "tinyvec",
  "ttf-parser 0.24.1",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -7700,6 +7715,9 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "tungstenite"
@@ -7964,7 +7982,7 @@ dependencies = [
  "base64 0.22.1",
  "data-url",
  "flate2",
- "fontdb",
+ "fontdb 0.22.0",
  "imagesize",
  "kurbo",
  "log",

--- a/docs/frontend/settings.md
+++ b/docs/frontend/settings.md
@@ -17,7 +17,7 @@
 | 分类 | 内容示例 |
 |---|---|
 | 通用 | Translator URL、Connector 开关、文件树标签/排序、打开行为、笔记导出默认水印、诊断上报开关与手动发送 |
-| Appearance | 明暗、`uiTheme`（tweakcn 预设）、`uiScale` |
+| Appearance | 明暗、`uiTheme`（tweakcn 预设）、`uiScale`；Markdown 编辑器字号 / 字体 / 行距 / 工具栏 |
 | Agent | 目录两层检测（Agent CLI / ACP）、未装「安装」/ 缺 ACP「安装 ACP」/ 已装「升级」、默认 Agent、权限模式、自动精读、可选 **User-Agent**（Codex 中转亲和）、个人提示词、划词提问 Agent |
 | 翻译 | 默认服务选择、商用 API 配置、语言与 Agent 座 |
 | 知识库诊断 | Vault / Catalog / 双链 / 论文 aliases / 视觉批注格式；本地 Vault 可确认批量修复 |
@@ -51,7 +51,11 @@
 - 外观设置中的配色主题以紧凑预览网格展示背景、卡片、主色和强调色；点击预览项即可应用主题。
 - 36 个 tweakcn 预设：`src/themes/tweakcn.json`；`src/lib/ui/theme.ts` 注入 CSS 变量。
 - 刷新主题数据：`node scripts/fetch-tweakcn-themes.mjs`。
-- `uiScale`：80%–150% 五档，改 `html` font-size。
+- `uiScale`：80%–150% 五档，改 `html` font-size（整 UI，与编辑器字号/行距正交）。
+- Markdown 编辑器（Appearance → Markdown editor）：
+  - `editorFontSize`：12–20 px，写在编辑器根节点 `fontSize`。
+  - `editorFontFamily`：`default` | `system` | `serif` | `mono`；仅正文区，不改 chrome；代码块仍 `font-mono`。`default` 继承应用主题栈（Geist）。
+  - `editorLineHeight`：1.4–2.0（步长 0.1，默认 1.6），写在编辑器根节点 `lineHeight`。
 - `batchImportConcurrency`：魔棒批量导入及后续资源下载的并发上限，范围 1–10，默认 5。
 
 ## i18n

--- a/docs/frontend/settings.md
+++ b/docs/frontend/settings.md
@@ -17,7 +17,7 @@
 | 分类 | 内容示例 |
 |---|---|
 | 通用 | Translator URL、Connector 开关、文件树标签/排序、打开行为、笔记导出默认水印、诊断上报开关与手动发送 |
-| Appearance | 明暗、`uiTheme`（tweakcn 预设）、`uiScale`；Markdown 编辑器字号 / 字体 / 行距 / 工具栏 |
+| Appearance | 明暗、`uiTheme`、`uiScale`；界面/正文/等宽字体；Markdown 字号 / 行距 / 工具栏 |
 | Agent | 目录两层检测（Agent CLI / ACP）、未装「安装」/ 缺 ACP「安装 ACP」/ 已装「升级」、默认 Agent、权限模式、自动精读、可选 **User-Agent**（Codex 中转亲和）、个人提示词、划词提问 Agent |
 | 翻译 | 默认服务选择、商用 API 配置、语言与 Agent 座 |
 | 知识库诊断 | Vault / Catalog / 双链 / 论文 aliases / 视觉批注格式；本地 Vault 可确认批量修复 |
@@ -52,10 +52,15 @@
 - 36 个 tweakcn 预设：`src/themes/tweakcn.json`；`src/lib/ui/theme.ts` 注入 CSS 变量。
 - 刷新主题数据：`node scripts/fetch-tweakcn-themes.mjs`。
 - `uiScale`：80%–150% 五档，改 `html` font-size（整 UI，与编辑器字号/行距正交）。
+- 字体（Appearance → Fonts，对齐 Obsidian 三分法）：
+  - `interfaceFontFamily`：界面 chrome（`--font-sans` / `--font-heading`）。
+  - `textFontFamily`：Markdown/笔记正文（仅编辑器根节点）。
+  - `monoFontFamily`：代码块与 `font-mono`（`--font-mono`）。
+  - 取值：空 = 应用默认；`system` / `serif` / `mono` = 内置栈；其余 = 系统字体族名。
+  - 选择器：Popover + 搜索；Host `list_system_fonts`（fontdb）枚举本机字体。
 - Markdown 编辑器（Appearance → Markdown editor）：
-  - `editorFontSize`：12–20 px，写在编辑器根节点 `fontSize`。
-  - `editorFontFamily`：`default` | `system` | `serif` | `mono`；仅正文区，不改 chrome；代码块仍 `font-mono`。`default` 继承应用主题栈（Geist）。
-  - `editorLineHeight`：1.4–2.0（步长 0.1，默认 1.6），写在编辑器根节点 `lineHeight`。
+  - `editorFontSize`：12–20 px。
+  - `editorLineHeight`：1.4–2.0（步长 0.1，默认 1.6）。
 - `batchImportConcurrency`：魔棒批量导入及后续资源下载的并发上限，范围 1–10，默认 5。
 
 ## i18n

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,6 +62,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "logg
 tauri-specta = { version = "2.0.0-rc.25", features = ["derive", "typescript"] }
 specta = { version = "2.0.0-rc.22", features = ["derive"] }
 specta-typescript = "0.0.12"
+fontdb = "0.23"
 
 # Updates and process relaunch are desktop-only. Mobile distribution is owned by
 # its app stores, not the in-app updater.

--- a/src-tauri/src/app/handlers.rs
+++ b/src-tauri/src/app/handlers.rs
@@ -10,6 +10,7 @@ macro_rules! common_commands {
         ::tauri::generate_handler![
             crate::features::settings::commands::settings_get,
             crate::features::settings::commands::settings_set,
+            crate::features::settings::commands::list_system_fonts,
             crate::features::telemetry::commands::telemetry_send_diagnostics,
             crate::features::telemetry::commands::telemetry_report_frontend_errors,
             crate::features::layout_model::commands::layout_model_status,

--- a/src-tauri/src/features/settings/commands.rs
+++ b/src-tauri/src/features/settings/commands.rs
@@ -16,6 +16,31 @@ pub fn settings_get(store: State<'_, AppSettingsStore>) -> ApiResult<SettingsGet
     }
 }
 
+/// Return unique system font family names (sorted). Empty on mobile / failure.
+#[tauri::command]
+pub fn list_system_fonts() -> ApiResult<Vec<String>> {
+    #[cfg(any(target_os = "ios", target_os = "android"))]
+    {
+        return ApiResult::ok(Vec::new());
+    }
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
+    {
+        use std::collections::BTreeSet;
+        let mut db = fontdb::Database::new();
+        db.load_system_fonts();
+        let mut names = BTreeSet::new();
+        for face in db.faces() {
+            for (family, _) in &face.families {
+                let t = family.trim();
+                if !t.is_empty() {
+                    names.insert(t.to_string());
+                }
+            }
+        }
+        ApiResult::ok(names.into_iter().collect())
+    }
+}
+
 #[tauri::command]
 #[cfg(not(target_os = "ios"))]
 pub fn settings_set(

--- a/src-tauri/src/features/settings/mod.rs
+++ b/src-tauri/src/features/settings/mod.rs
@@ -63,6 +63,12 @@ pub struct AppSettings {
     pub locale: String,
     #[serde(default = "default_editor_font_size")]
     pub editor_font_size: u32,
+    /// Markdown editor body font preset (`default` | `system` | `serif` | `mono`).
+    #[serde(default = "default_editor_font_family")]
+    pub editor_font_family: String,
+    /// Markdown editor body line-height (unitless), typical range 1.4–2.0.
+    #[serde(default = "default_editor_line_height")]
+    pub editor_line_height: f64,
     #[serde(default = "default_ui_scale")]
     pub ui_scale: f64,
     #[serde(default = "default_true")]
@@ -167,6 +173,8 @@ impl Default for AppSettings {
             ui_theme: default_ui_theme(),
             locale: default_locale(),
             editor_font_size: default_editor_font_size(),
+            editor_font_family: default_editor_font_family(),
+            editor_line_height: default_editor_line_height(),
             ui_scale: default_ui_scale(),
             show_editor_toolbar: true,
             agent_permission_mode: default_permission_mode(),
@@ -223,6 +231,12 @@ fn default_locale() -> String {
 }
 fn default_editor_font_size() -> u32 {
     14
+}
+fn default_editor_font_family() -> String {
+    "default".into()
+}
+fn default_editor_line_height() -> f64 {
+    1.6
 }
 fn default_ui_scale() -> f64 {
     1.0
@@ -500,6 +514,17 @@ fn normalize(s: &mut AppSettings) {
     }
     if s.editor_font_size < 10 || s.editor_font_size > 32 {
         s.editor_font_size = default_editor_font_size();
+    }
+    const EDITOR_FONT_FAMILIES: &[&str] = &["default", "system", "serif", "mono"];
+    if !EDITOR_FONT_FAMILIES.contains(&s.editor_font_family.as_str()) {
+        s.editor_font_family = default_editor_font_family();
+    }
+    if !s.editor_line_height.is_finite() || s.editor_line_height < 1.4 || s.editor_line_height > 2.0
+    {
+        s.editor_line_height = default_editor_line_height();
+    } else {
+        // Snap to 0.1 steps to match the frontend slider.
+        s.editor_line_height = (s.editor_line_height * 10.0).round() / 10.0;
     }
     const UI_SCALE_PRESETS: &[f64] = &[0.8, 0.9, 1.0, 1.25, 1.5];
     if !s.ui_scale.is_finite() {

--- a/src-tauri/src/features/settings/mod.rs
+++ b/src-tauri/src/features/settings/mod.rs
@@ -63,8 +63,17 @@ pub struct AppSettings {
     pub locale: String,
     #[serde(default = "default_editor_font_size")]
     pub editor_font_size: u32,
-    /// Markdown editor body font preset (`default` | `system` | `serif` | `mono`).
-    #[serde(default = "default_editor_font_family")]
+    /// UI chrome font. Empty = app default. Built-ins: system/serif/mono, else family name.
+    #[serde(default)]
+    pub interface_font_family: String,
+    /// Markdown body font. Empty = inherit interface/default. Same vocabulary as interface.
+    #[serde(default)]
+    pub text_font_family: String,
+    /// Monospace font for code / font-mono. Empty = app default mono stack.
+    #[serde(default)]
+    pub mono_font_family: String,
+    /// Deprecated single editor font preset; migrated into `text_font_family` once.
+    #[serde(default, skip_serializing)]
     pub editor_font_family: String,
     /// Markdown editor body line-height (unitless), typical range 1.4–2.0.
     #[serde(default = "default_editor_line_height")]
@@ -173,7 +182,10 @@ impl Default for AppSettings {
             ui_theme: default_ui_theme(),
             locale: default_locale(),
             editor_font_size: default_editor_font_size(),
-            editor_font_family: default_editor_font_family(),
+            interface_font_family: String::new(),
+            text_font_family: String::new(),
+            mono_font_family: String::new(),
+            editor_font_family: String::new(),
             editor_line_height: default_editor_line_height(),
             ui_scale: default_ui_scale(),
             show_editor_toolbar: true,
@@ -232,11 +244,16 @@ fn default_locale() -> String {
 fn default_editor_font_size() -> u32 {
     14
 }
-fn default_editor_font_family() -> String {
-    "default".into()
-}
 fn default_editor_line_height() -> f64 {
     1.6
+}
+
+fn normalize_font_family_value(raw: &str) -> String {
+    let v = raw.trim();
+    if v.is_empty() || v == "default" {
+        return String::new();
+    }
+    v.chars().take(120).collect()
 }
 fn default_ui_scale() -> f64 {
     1.0
@@ -515,10 +532,15 @@ fn normalize(s: &mut AppSettings) {
     if s.editor_font_size < 10 || s.editor_font_size > 32 {
         s.editor_font_size = default_editor_font_size();
     }
-    const EDITOR_FONT_FAMILIES: &[&str] = &["default", "system", "serif", "mono"];
-    if !EDITOR_FONT_FAMILIES.contains(&s.editor_font_family.as_str()) {
-        s.editor_font_family = default_editor_font_family();
+    s.interface_font_family = normalize_font_family_value(&s.interface_font_family);
+    s.text_font_family = normalize_font_family_value(&s.text_font_family);
+    s.mono_font_family = normalize_font_family_value(&s.mono_font_family);
+    // Migrate deprecated editorFontFamily preset into textFontFamily once.
+    let legacy = normalize_font_family_value(&s.editor_font_family);
+    if s.text_font_family.is_empty() && !legacy.is_empty() {
+        s.text_font_family = legacy;
     }
+    s.editor_font_family.clear();
     if !s.editor_line_height.is_finite() || s.editor_line_height < 1.4 || s.editor_line_height > 2.0
     {
         s.editor_line_height = default_editor_line_height();

--- a/src/components/editor/markdown-editor.tsx
+++ b/src/components/editor/markdown-editor.tsx
@@ -5,6 +5,7 @@ import { ImagePlugin } from "@platejs/media/react";
 import { TocPlugin } from "@platejs/toc/react";
 import { Plate, usePlateEditor } from "platejs/react";
 import {
+	type CSSProperties,
 	type KeyboardEvent,
 	lazy,
 	useCallback,
@@ -84,6 +85,10 @@ export type MarkdownEditorProps = {
 	placeholder?: string;
 	className?: string;
 	fontSize?: number | string;
+	/** CSS font-family stack for body text; omit to keep app theme font. */
+	fontFamily?: string;
+	/** Unitless line-height for body text. */
+	lineHeight?: number;
 	/** Show the WYSIWYG formatting toolbar above the editor. */
 	showToolbar?: boolean;
 	/**
@@ -138,6 +143,8 @@ export function MarkdownEditor({
 	placeholder,
 	className,
 	fontSize,
+	fontFamily,
+	lineHeight,
 	showToolbar,
 	onPersist,
 	onDirtyChange,
@@ -150,6 +157,28 @@ export function MarkdownEditor({
 	const onAssetsChangedRef = useRef(onAssetsChanged);
 	onAssetsChangedRef.current = onAssetsChanged;
 	const editorContainerRef = useRef<HTMLDivElement | null>(null);
+
+	/**
+	 * Body typography on the editor root. When a custom font stack is set, also
+	 * rebind --font-sans / --font-heading so headings (font-heading) follow body
+	 * text. Code blocks keep font-mono / --font-mono and are not overridden.
+	 */
+	const editorTypographyStyle = useMemo((): CSSProperties | undefined => {
+		const style: CSSProperties = {};
+		if (fontSize != null && fontSize !== "") {
+			style.fontSize = fontSize;
+		}
+		if (lineHeight != null && Number.isFinite(lineHeight)) {
+			style.lineHeight = lineHeight;
+		}
+		if (fontFamily) {
+			style.fontFamily = fontFamily;
+			// Scope theme font tokens so headings using font-heading follow body.
+			(style as Record<string, string>)["--font-sans"] = fontFamily;
+			(style as Record<string, string>)["--font-heading"] = fontFamily;
+		}
+		return Object.keys(style).length > 0 ? style : undefined;
+	}, [fontSize, fontFamily, lineHeight]);
 	/** Swallow the `beforeinput` insertParagraph that follows slash Enter confirm. */
 	const suppressNextEditorBreakRef = useRef(false);
 	const [findOpen, setFindOpen] = useState(false);
@@ -608,7 +637,7 @@ export function MarkdownEditor({
 												placeholder={placeholder}
 												readOnly={readOnly}
 												className="min-h-full px-6 pt-4 pb-48"
-												style={fontSize ? { fontSize } : undefined}
+												style={editorTypographyStyle}
 											/>
 											{!readOnly ? (
 												<WikiLinkSuggestion

--- a/src/components/settings/font-family-picker.tsx
+++ b/src/components/settings/font-family-picker.tsx
@@ -1,0 +1,202 @@
+/**
+ * Searchable font family picker (Obsidian-style): built-in stacks + system fonts.
+ */
+
+import { Check, ChevronsUpDown, LoaderCircle } from "lucide-react";
+import { useEffect, useId, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/core/utils";
+import {
+	FONT_STACK_PRESETS,
+	type FontRole,
+	type FontStackPreset,
+	isFontStackPreset,
+	listSystemFonts,
+	resolveFontFamilyCss,
+} from "@/lib/settings";
+
+export type FontFamilyPickerProps = {
+	id?: string;
+	value: string;
+	/** Which CSS role this picker configures (not an ARIA role). */
+	fontRole: FontRole;
+	onChange: (next: string) => void;
+	className?: string;
+	/** Narrow trigger for settings rows. */
+	size?: "sm" | "default";
+};
+
+const PRESET_I18N: Record<
+	FontStackPreset,
+	| "appearance.fontFamily.default"
+	| "appearance.fontFamily.system"
+	| "appearance.fontFamily.serif"
+	| "appearance.fontFamily.mono"
+> = {
+	default: "appearance.fontFamily.default",
+	system: "appearance.fontFamily.system",
+	serif: "appearance.fontFamily.serif",
+	mono: "appearance.fontFamily.mono",
+};
+
+function previewCss(value: string, role: FontRole): string | undefined {
+	const resolved = resolveFontFamilyCss(value || "default", role);
+	if (resolved) return resolved;
+	if (role === "mono") return resolveFontFamilyCss("mono", "mono");
+	return undefined;
+}
+
+export function FontFamilyPicker({
+	id,
+	value,
+	fontRole,
+	onChange,
+	className,
+	size = "sm",
+}: FontFamilyPickerProps) {
+	const { t } = useTranslation("settings");
+	const listId = useId();
+	const [open, setOpen] = useState(false);
+	const [systemFonts, setSystemFonts] = useState<string[]>([]);
+	const [loading, setLoading] = useState(false);
+
+	useEffect(() => {
+		if (!open) return;
+		let cancelled = false;
+		setLoading(true);
+		void listSystemFonts()
+			.then((fonts) => {
+				if (!cancelled) setSystemFonts(fonts);
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [open]);
+
+	const normalized = value.trim() === "default" ? "" : value.trim();
+	const label = (() => {
+		if (!normalized) return t("appearance.fontFamily.default");
+		if (isFontStackPreset(normalized)) return t(PRESET_I18N[normalized]);
+		return normalized;
+	})();
+	const triggerStyle = useMemo(() => {
+		const css = previewCss(normalized, fontRole);
+		return css ? { fontFamily: css } : undefined;
+	}, [normalized, fontRole]);
+
+	const presets = FONT_STACK_PRESETS;
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button
+					id={id}
+					type="button"
+					variant="outline"
+					size={size}
+					role="combobox"
+					aria-expanded={open}
+					aria-controls={listId}
+					className={cn(
+						"min-w-[160px] max-w-[220px] justify-between font-normal",
+						className,
+					)}
+					style={triggerStyle}
+				>
+					<span className="truncate">{label}</span>
+					<ChevronsUpDown className="ml-1 size-3.5 shrink-0 opacity-50" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent
+				align="end"
+				className="w-[280px] p-0"
+				onOpenAutoFocus={(e) => e.preventDefault()}
+			>
+				<Command id={listId}>
+					<CommandInput
+						placeholder={t("appearance.fontFamily.search")}
+						aria-label={t("appearance.fontFamily.search")}
+					/>
+					<CommandList className="max-h-[min(50vh,320px)]">
+						<CommandEmpty>
+							{loading
+								? t("appearance.fontFamily.loading")
+								: t("appearance.fontFamily.noMatch")}
+						</CommandEmpty>
+						<CommandGroup heading={t("appearance.fontFamily.suggested")}>
+							{presets.map((preset) => {
+								const stored = preset === "default" ? "" : preset;
+								const selected = normalized === stored;
+								const css = previewCss(stored, fontRole);
+								const presetLabel = t(PRESET_I18N[preset]);
+								return (
+									<CommandItem
+										key={preset}
+										value={`${preset} ${presetLabel}`}
+										data-checked={selected || undefined}
+										onSelect={() => {
+											onChange(stored);
+											setOpen(false);
+										}}
+										style={css ? { fontFamily: css } : undefined}
+									>
+										<span className="truncate">{presetLabel}</span>
+										{selected ? (
+											<Check className="ml-auto size-3.5 shrink-0 opacity-100" />
+										) : null}
+									</CommandItem>
+								);
+							})}
+						</CommandGroup>
+						{loading ? (
+							<div className="flex items-center justify-center gap-2 py-4 text-muted-foreground text-xs">
+								<LoaderCircle className="size-3.5 animate-spin" />
+								{t("appearance.fontFamily.loading")}
+							</div>
+						) : systemFonts.length > 0 ? (
+							<CommandGroup heading={t("appearance.fontFamily.systemFonts")}>
+								{systemFonts.map((name) => {
+									const selected = normalized === name;
+									return (
+										<CommandItem
+											key={name}
+											value={name}
+											data-checked={selected || undefined}
+											onSelect={() => {
+												onChange(name);
+												setOpen(false);
+											}}
+											style={{ fontFamily: `"${name.replace(/"/g, '\\"')}"` }}
+										>
+											<span className="truncate">{name}</span>
+											{selected ? (
+												<Check className="ml-auto size-3.5 shrink-0 opacity-100" />
+											) : null}
+										</CommandItem>
+									);
+								})}
+							</CommandGroup>
+						) : null}
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/src/components/settings/font-family-picker.tsx
+++ b/src/components/settings/font-family-picker.tsx
@@ -2,7 +2,7 @@
  * Searchable font family picker (Obsidian-style): built-in stacks + system fonts.
  */
 
-import { Check, ChevronsUpDown, LoaderCircle } from "lucide-react";
+import { ChevronsUpDown, LoaderCircle } from "lucide-react";
 import { useEffect, useId, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
@@ -158,9 +158,6 @@ export function FontFamilyPicker({
 										style={css ? { fontFamily: css } : undefined}
 									>
 										<span className="truncate">{presetLabel}</span>
-										{selected ? (
-											<Check className="ml-auto size-3.5 shrink-0 opacity-100" />
-										) : null}
 									</CommandItem>
 								);
 							})}
@@ -186,9 +183,6 @@ export function FontFamilyPicker({
 											style={{ fontFamily: `"${name.replace(/"/g, '\\"')}"` }}
 										>
 											<span className="truncate">{name}</span>
-											{selected ? (
-												<Check className="ml-auto size-3.5 shrink-0 opacity-100" />
-											) : null}
 										</CommandItem>
 									);
 								})}

--- a/src/components/settings/panes/appearance-pane.tsx
+++ b/src/components/settings/panes/appearance-pane.tsx
@@ -17,10 +17,17 @@ import {
 import { Switch } from "@/components/ui/switch";
 import type {
 	AppSettings,
+	EditorFontFamily,
 	LocalePreference,
 	ThemePreference,
 } from "@/lib/settings";
-import { UI_SCALE_PRESETS } from "@/lib/settings";
+import {
+	EDITOR_FONT_FAMILIES,
+	EDITOR_LINE_HEIGHT_MAX,
+	EDITOR_LINE_HEIGHT_MIN,
+	EDITOR_LINE_HEIGHT_STEP,
+	UI_SCALE_PRESETS,
+} from "@/lib/settings";
 import {
 	applyUiTheme,
 	DEFAULT_UI_THEME,
@@ -35,6 +42,8 @@ export type AppearancePaneProps = {
 	locale: LocalePreference;
 	uiScale: number;
 	editorFontSize: number;
+	editorFontFamily: EditorFontFamily;
+	editorLineHeight: number;
 	showEditorToolbar: boolean;
 	patch: (p: Partial<AppSettings>) => void;
 };
@@ -45,12 +54,16 @@ function AppearancePaneInner({
 	locale,
 	uiScale,
 	editorFontSize,
+	editorFontFamily,
+	editorLineHeight,
 	showEditorToolbar,
 	patch,
 }: AppearancePaneProps) {
 	const { t } = useTranslation("settings");
 	const { resolvedTheme, setTheme } = useTheme();
 	const fontId = useId();
+	const fontFamilyId = useId();
+	const lineHeightId = useId();
 	const uiScaleId = useId();
 	const [themeDefs, setThemeDefs] = useState<UiThemeDef[]>([]);
 
@@ -66,6 +79,19 @@ function AppearancePaneInner({
 		}, 150);
 		return () => clearTimeout(id);
 	}, [fontSize, editorFontSize, patch]);
+
+	const [lineHeight, setLineHeight] = useState(editorLineHeight);
+	useEffect(() => {
+		setLineHeight(editorLineHeight);
+	}, [editorLineHeight]);
+
+	useEffect(() => {
+		if (lineHeight === editorLineHeight) return;
+		const id = setTimeout(() => {
+			patch({ editorLineHeight: lineHeight });
+		}, 150);
+		return () => clearTimeout(id);
+	}, [lineHeight, editorLineHeight, patch]);
 
 	useEffect(() => {
 		let active = true;
@@ -273,6 +299,54 @@ function AppearancePaneInner({
 						/>
 						<span className="w-12 text-right text-muted-foreground text-xs tabular-nums">
 							{t("appearance.fontSize.value", { size: fontSize })}
+						</span>
+					</div>
+				</SettingsRow>
+				<SettingsRow
+					label={t("appearance.fontFamily.label")}
+					htmlFor={fontFamilyId}
+				>
+					<Select
+						value={editorFontFamily}
+						onValueChange={(v) =>
+							patch({ editorFontFamily: v as EditorFontFamily })
+						}
+					>
+						<SelectTrigger
+							id={fontFamilyId}
+							size="sm"
+							className="min-w-[140px]"
+						>
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{EDITOR_FONT_FAMILIES.map((family) => (
+								<SelectItem key={family} value={family}>
+									{t(`appearance.fontFamily.${family}`)}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</SettingsRow>
+				<SettingsRow
+					label={t("appearance.lineHeight.label")}
+					htmlFor={lineHeightId}
+				>
+					<div className="flex items-center gap-2">
+						<input
+							id={lineHeightId}
+							type="range"
+							min={EDITOR_LINE_HEIGHT_MIN}
+							max={EDITOR_LINE_HEIGHT_MAX}
+							step={EDITOR_LINE_HEIGHT_STEP}
+							value={lineHeight}
+							onChange={(e) => setLineHeight(Number(e.target.value))}
+							className="w-28 accent-primary"
+						/>
+						<span className="w-12 text-right text-muted-foreground text-xs tabular-nums">
+							{t("appearance.lineHeight.value", {
+								value: lineHeight.toFixed(1),
+							})}
 						</span>
 					</div>
 				</SettingsRow>

--- a/src/components/settings/panes/appearance-pane.tsx
+++ b/src/components/settings/panes/appearance-pane.tsx
@@ -2,6 +2,7 @@ import { Check, LoaderCircle } from "lucide-react";
 import { useTheme } from "next-themes";
 import { memo, useEffect, useId, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { FontFamilyPicker } from "@/components/settings/font-family-picker";
 import {
 	PageTitle,
 	SettingsGroup,
@@ -17,12 +18,10 @@ import {
 import { Switch } from "@/components/ui/switch";
 import type {
 	AppSettings,
-	EditorFontFamily,
 	LocalePreference,
 	ThemePreference,
 } from "@/lib/settings";
 import {
-	EDITOR_FONT_FAMILIES,
 	EDITOR_LINE_HEIGHT_MAX,
 	EDITOR_LINE_HEIGHT_MIN,
 	EDITOR_LINE_HEIGHT_STEP,
@@ -42,7 +41,9 @@ export type AppearancePaneProps = {
 	locale: LocalePreference;
 	uiScale: number;
 	editorFontSize: number;
-	editorFontFamily: EditorFontFamily;
+	interfaceFontFamily: string;
+	textFontFamily: string;
+	monoFontFamily: string;
 	editorLineHeight: number;
 	showEditorToolbar: boolean;
 	patch: (p: Partial<AppSettings>) => void;
@@ -54,7 +55,9 @@ function AppearancePaneInner({
 	locale,
 	uiScale,
 	editorFontSize,
-	editorFontFamily,
+	interfaceFontFamily,
+	textFontFamily,
+	monoFontFamily,
 	editorLineHeight,
 	showEditorToolbar,
 	patch,
@@ -62,7 +65,9 @@ function AppearancePaneInner({
 	const { t } = useTranslation("settings");
 	const { resolvedTheme, setTheme } = useTheme();
 	const fontId = useId();
-	const fontFamilyId = useId();
+	const interfaceFontId = useId();
+	const textFontId = useId();
+	const monoFontId = useId();
 	const lineHeightId = useId();
 	const uiScaleId = useId();
 	const [themeDefs, setThemeDefs] = useState<UiThemeDef[]>([]);
@@ -282,6 +287,48 @@ function AppearancePaneInner({
 			</SettingsGroup>
 
 			<p className="mb-1.5 mt-4 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+				{t("appearance.fonts.section")}
+			</p>
+			<SettingsGroup>
+				<SettingsRow
+					label={t("appearance.fonts.interface")}
+					description={t("appearance.fonts.interfaceHint")}
+					htmlFor={interfaceFontId}
+				>
+					<FontFamilyPicker
+						id={interfaceFontId}
+						fontRole="interface"
+						value={interfaceFontFamily}
+						onChange={(v) => patch({ interfaceFontFamily: v })}
+					/>
+				</SettingsRow>
+				<SettingsRow
+					label={t("appearance.fonts.text")}
+					description={t("appearance.fonts.textHint")}
+					htmlFor={textFontId}
+				>
+					<FontFamilyPicker
+						id={textFontId}
+						fontRole="text"
+						value={textFontFamily}
+						onChange={(v) => patch({ textFontFamily: v })}
+					/>
+				</SettingsRow>
+				<SettingsRow
+					label={t("appearance.fonts.mono")}
+					description={t("appearance.fonts.monoHint")}
+					htmlFor={monoFontId}
+				>
+					<FontFamilyPicker
+						id={monoFontId}
+						fontRole="mono"
+						value={monoFontFamily}
+						onChange={(v) => patch({ monoFontFamily: v })}
+					/>
+				</SettingsRow>
+			</SettingsGroup>
+
+			<p className="mb-1.5 mt-4 font-medium text-muted-foreground text-xs uppercase tracking-wide">
 				{t("appearance.markdownEditor.section")}
 			</p>
 			<SettingsGroup>
@@ -301,32 +348,6 @@ function AppearancePaneInner({
 							{t("appearance.fontSize.value", { size: fontSize })}
 						</span>
 					</div>
-				</SettingsRow>
-				<SettingsRow
-					label={t("appearance.fontFamily.label")}
-					htmlFor={fontFamilyId}
-				>
-					<Select
-						value={editorFontFamily}
-						onValueChange={(v) =>
-							patch({ editorFontFamily: v as EditorFontFamily })
-						}
-					>
-						<SelectTrigger
-							id={fontFamilyId}
-							size="sm"
-							className="min-w-[140px]"
-						>
-							<SelectValue />
-						</SelectTrigger>
-						<SelectContent>
-							{EDITOR_FONT_FAMILIES.map((family) => (
-								<SelectItem key={family} value={family}>
-									{t(`appearance.fontFamily.${family}`)}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
 				</SettingsRow>
 				<SettingsRow
 					label={t("appearance.lineHeight.label")}

--- a/src/components/settings/settings-content.tsx
+++ b/src/components/settings/settings-content.tsx
@@ -269,6 +269,8 @@ export function SettingsContent({
 									locale={settings.locale}
 									uiScale={settings.uiScale}
 									editorFontSize={settings.editorFontSize}
+									editorFontFamily={settings.editorFontFamily}
+									editorLineHeight={settings.editorLineHeight}
 									showEditorToolbar={settings.showEditorToolbar}
 									patch={patch}
 								/>

--- a/src/components/settings/settings-content.tsx
+++ b/src/components/settings/settings-content.tsx
@@ -269,7 +269,9 @@ export function SettingsContent({
 									locale={settings.locale}
 									uiScale={settings.uiScale}
 									editorFontSize={settings.editorFontSize}
-									editorFontFamily={settings.editorFontFamily}
+									interfaceFontFamily={settings.interfaceFontFamily}
+									textFontFamily={settings.textFontFamily}
+									monoFontFamily={settings.monoFontFamily}
 									editorLineHeight={settings.editorLineHeight}
 									showEditorToolbar={settings.showEditorToolbar}
 									patch={patch}

--- a/src/components/settings/settings-native-root.tsx
+++ b/src/components/settings/settings-native-root.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { SettingsSection } from "@/components/settings/types";
 import { isMacOS, isTauri } from "@/lib/core/tauri";
 import {
+	applyDocumentChrome,
 	ensureSettingsLoaded,
 	loadSettings,
 	saveSettingsAsync,
@@ -54,6 +55,15 @@ export function SettingsNativeRoot() {
 			setSettings(next);
 		});
 	}, []);
+
+	// Mirror main-window chrome (scale + interface/mono fonts) so pickers preview live.
+	useEffect(() => {
+		applyDocumentChrome({
+			uiScale: settings.uiScale,
+			interfaceFontFamily: settings.interfaceFontFamily,
+			monoFontFamily: settings.monoFontFamily,
+		});
+	}, [settings.uiScale, settings.interfaceFontFamily, settings.monoFontFamily]);
 
 	useEffect(() => {
 		const onKeyDown = (event: KeyboardEvent) => {

--- a/src/components/shell/doc-window-root.tsx
+++ b/src/components/shell/doc-window-root.tsx
@@ -9,7 +9,7 @@ import { useSettings, useVaultStore } from "@/hooks/use-app-stores";
 import { isMacOS, isTauri } from "@/lib/core/tauri";
 import { isLibraryVirtualPath, isTrashVirtualPath } from "@/lib/paper/api";
 import { refreshLibrary } from "@/lib/paper/library-store";
-import { editorFontFamilyCss } from "@/lib/settings";
+import { applyDocumentChrome, resolveFontFamilyCss } from "@/lib/settings";
 import { readDocWindowParams } from "@/lib/shell/doc-window";
 import { openSettingsWindow } from "@/lib/shell/settings-window";
 import { openRecentVault } from "@/lib/vault/actions";
@@ -45,10 +45,21 @@ export function DocWindowRoot() {
 
 	const vaultPath = useVaultStore((s) => s.vaultPath);
 	const fontSize = useSettings((s) => s.editorFontSize);
-	const fontFamilyPreset = useSettings((s) => s.editorFontFamily);
+	const textFontFamily = useSettings((s) => s.textFontFamily);
 	const lineHeight = useSettings((s) => s.editorLineHeight);
 	const showToolbar = useSettings((s) => s.showEditorToolbar);
-	const fontFamily = editorFontFamilyCss(fontFamilyPreset);
+	const uiScale = useSettings((s) => s.uiScale);
+	const interfaceFontFamily = useSettings((s) => s.interfaceFontFamily);
+	const monoFontFamily = useSettings((s) => s.monoFontFamily);
+	const fontFamily = resolveFontFamilyCss(textFontFamily, "text");
+
+	useEffect(() => {
+		applyDocumentChrome({
+			uiScale,
+			interfaceFontFamily,
+			monoFontFamily,
+		});
+	}, [uiScale, interfaceFontFamily, monoFontFamily]);
 
 	useState(() => {
 		initVaultStore();

--- a/src/components/shell/doc-window-root.tsx
+++ b/src/components/shell/doc-window-root.tsx
@@ -9,6 +9,7 @@ import { useSettings, useVaultStore } from "@/hooks/use-app-stores";
 import { isMacOS, isTauri } from "@/lib/core/tauri";
 import { isLibraryVirtualPath, isTrashVirtualPath } from "@/lib/paper/api";
 import { refreshLibrary } from "@/lib/paper/library-store";
+import { editorFontFamilyCss } from "@/lib/settings";
 import { readDocWindowParams } from "@/lib/shell/doc-window";
 import { openSettingsWindow } from "@/lib/shell/settings-window";
 import { openRecentVault } from "@/lib/vault/actions";
@@ -44,7 +45,10 @@ export function DocWindowRoot() {
 
 	const vaultPath = useVaultStore((s) => s.vaultPath);
 	const fontSize = useSettings((s) => s.editorFontSize);
+	const fontFamilyPreset = useSettings((s) => s.editorFontFamily);
+	const lineHeight = useSettings((s) => s.editorLineHeight);
 	const showToolbar = useSettings((s) => s.showEditorToolbar);
+	const fontFamily = editorFontFamilyCss(fontFamilyPreset);
 
 	useState(() => {
 		initVaultStore();
@@ -180,6 +184,8 @@ export function DocWindowRoot() {
 						}}
 						editor={{
 							fontSize,
+							fontFamily,
+							lineHeight,
 							showToolbar,
 							notesPlaceholder: t("editor.notesPlaceholder"),
 							markdownPlaceholder: t("editor.markdownPlaceholder"),

--- a/src/components/workspace/doc-view.tsx
+++ b/src/components/workspace/doc-view.tsx
@@ -44,6 +44,10 @@ export type DocViewLibraryProps = {
 /** Markdown / NOTES editor props. */
 export type DocViewEditorProps = {
 	fontSize: number;
+	/** CSS font-family stack; omit/undefined keeps app theme font. */
+	fontFamily?: string;
+	/** Unitless line-height for body text. */
+	lineHeight?: number;
 	showToolbar: boolean;
 	notesPlaceholder: string;
 	markdownPlaceholder: string;
@@ -179,6 +183,8 @@ export const DocView = memo(function DocView({
 						}
 						navigationIntent={tab.navigationIntent}
 						fontSize={editor.fontSize}
+						fontFamily={editor.fontFamily}
+						lineHeight={editor.lineHeight}
 						showToolbar={editor.showToolbar}
 						placeholder={
 							isNotes ? editor.notesPlaceholder : editor.markdownPlaceholder

--- a/src/components/workspace/workspace-host.tsx
+++ b/src/components/workspace/workspace-host.tsx
@@ -30,7 +30,7 @@ import {
 	setTabVisualTraces,
 } from "@/lib/pdf/annotations-store";
 import type { LibraryColumnPref } from "@/lib/settings";
-import { editorFontFamilyCss } from "@/lib/settings";
+import { resolveFontFamilyCss } from "@/lib/settings";
 import { patchSettings } from "@/lib/settings/react-store";
 import { openSettingsWindow } from "@/lib/shell/settings-window";
 import { openRightTab } from "@/lib/shell/ui-store";
@@ -98,7 +98,7 @@ export function WorkspaceHost() {
 	const trashReloadSignal = useLibraryStore((s) => s.trashReloadSignal);
 	const libraryColumns = useSettings((s) => s.libraryColumns);
 	const editorFontSize = useSettings((s) => s.editorFontSize);
-	const editorFontFamily = useSettings((s) => s.editorFontFamily);
+	const textFontFamily = useSettings((s) => s.textFontFamily);
 	const editorLineHeight = useSettings((s) => s.editorLineHeight);
 	const showEditorToolbar = useSettings((s) => s.showEditorToolbar);
 	const [visiblePanelIds, setVisiblePanelIds] = useState<string[]>([]);
@@ -212,7 +212,7 @@ export function WorkspaceHost() {
 			},
 			editor: {
 				fontSize: editorFontSize,
-				fontFamily: editorFontFamilyCss(editorFontFamily),
+				fontFamily: resolveFontFamilyCss(textFontFamily, "text"),
 				lineHeight: editorLineHeight,
 				showToolbar: showEditorToolbar,
 				notesPlaceholder: t("editor.notesPlaceholder"),
@@ -246,7 +246,7 @@ export function WorkspaceHost() {
 			libraryScopePath,
 			libraryColumns,
 			editorFontSize,
-			editorFontFamily,
+			textFontFamily,
 			editorLineHeight,
 			showEditorToolbar,
 			rescanning,

--- a/src/components/workspace/workspace-host.tsx
+++ b/src/components/workspace/workspace-host.tsx
@@ -30,6 +30,7 @@ import {
 	setTabVisualTraces,
 } from "@/lib/pdf/annotations-store";
 import type { LibraryColumnPref } from "@/lib/settings";
+import { editorFontFamilyCss } from "@/lib/settings";
 import { patchSettings } from "@/lib/settings/react-store";
 import { openSettingsWindow } from "@/lib/shell/settings-window";
 import { openRightTab } from "@/lib/shell/ui-store";
@@ -97,6 +98,8 @@ export function WorkspaceHost() {
 	const trashReloadSignal = useLibraryStore((s) => s.trashReloadSignal);
 	const libraryColumns = useSettings((s) => s.libraryColumns);
 	const editorFontSize = useSettings((s) => s.editorFontSize);
+	const editorFontFamily = useSettings((s) => s.editorFontFamily);
+	const editorLineHeight = useSettings((s) => s.editorLineHeight);
 	const showEditorToolbar = useSettings((s) => s.showEditorToolbar);
 	const [visiblePanelIds, setVisiblePanelIds] = useState<string[]>([]);
 
@@ -209,6 +212,8 @@ export function WorkspaceHost() {
 			},
 			editor: {
 				fontSize: editorFontSize,
+				fontFamily: editorFontFamilyCss(editorFontFamily),
+				lineHeight: editorLineHeight,
 				showToolbar: showEditorToolbar,
 				notesPlaceholder: t("editor.notesPlaceholder"),
 				markdownPlaceholder: t("editor.markdownPlaceholder"),
@@ -241,6 +246,8 @@ export function WorkspaceHost() {
 			libraryScopePath,
 			libraryColumns,
 			editorFontSize,
+			editorFontFamily,
+			editorLineHeight,
 			showEditorToolbar,
 			rescanning,
 			trashReloadSignal,

--- a/src/hooks/use-app-bootstrap.ts
+++ b/src/hooks/use-app-bootstrap.ts
@@ -11,6 +11,7 @@ import { useVaultOpenRequest } from "@/hooks/use-vault-open-request";
 import i18n, { resolveLocale } from "@/i18n";
 import { isTauri } from "@/lib/core/tauri";
 import { refreshLibrary } from "@/lib/paper/library-store";
+import { applyDocumentChrome } from "@/lib/settings";
 import { initSettingsStore } from "@/lib/settings/react-store";
 import { setSettingsOpenState } from "@/lib/shell/ui-store";
 import { seedVaultSkills, validateRestoredVault } from "@/lib/vault/actions";
@@ -38,6 +39,8 @@ export function useAppBootstrap(): void {
 	const theme = useSettings((s) => s.theme);
 	const locale = useSettings((s) => s.locale);
 	const uiScale = useSettings((s) => s.uiScale);
+	const interfaceFontFamily = useSettings((s) => s.interfaceFontFamily);
+	const monoFontFamily = useSettings((s) => s.monoFontFamily);
 	const vaultPath = useVaultStore((s) => s.vaultPath);
 
 	useEffect(() => {
@@ -62,11 +65,13 @@ export function useAppBootstrap(): void {
 	}, [locale]);
 
 	useEffect(() => {
-		if (typeof document === "undefined") return;
-		document.documentElement.style.fontSize = `${16 * uiScale}px`;
-		// Note: macOS traffic lights are positioned at build-time; Tauri v2 does
-		// not expose a runtime setter for the main window's traffic lights.
-	}, [uiScale]);
+		// Scale + interface/mono fonts. macOS traffic lights stay build-time only.
+		applyDocumentChrome({
+			uiScale,
+			interfaceFontFamily,
+			monoFontFamily,
+		});
+	}, [uiScale, interfaceFontFamily, monoFontFamily]);
 
 	// Validate the restored local Vault before restoring its tree and tabs.
 	useEffect(() => {

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -128,6 +128,15 @@
 			"label": "Interface scale",
 			"value": "{{percent}}%"
 		},
+		"fonts": {
+			"section": "Fonts",
+			"interface": "Interface font",
+			"interfaceHint": "App chrome: sidebars, toolbars, and settings.",
+			"text": "Text font",
+			"textHint": "Markdown and notes body text.",
+			"mono": "Monospace font",
+			"monoHint": "Code blocks, frontmatter, and mono UI."
+		},
 		"markdownEditor": {
 			"section": "Markdown editor"
 		},
@@ -136,11 +145,15 @@
 			"value": "{{size}} px"
 		},
 		"fontFamily": {
-			"label": "Editor font",
 			"default": "Default",
-			"system": "System",
+			"system": "System UI",
 			"serif": "Serif",
-			"mono": "Monospace"
+			"mono": "Monospace",
+			"search": "Search fonts…",
+			"loading": "Loading system fonts…",
+			"noMatch": "No matching fonts",
+			"suggested": "Suggested",
+			"systemFonts": "System fonts"
 		},
 		"lineHeight": {
 			"label": "Line height",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -135,6 +135,17 @@
 			"label": "Editor font size",
 			"value": "{{size}} px"
 		},
+		"fontFamily": {
+			"label": "Editor font",
+			"default": "Default",
+			"system": "System",
+			"serif": "Serif",
+			"mono": "Monospace"
+		},
+		"lineHeight": {
+			"label": "Line height",
+			"value": "{{value}}"
+		},
 		"editorToolbar": {
 			"label": "Formatting toolbar"
 		}

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -121,6 +121,15 @@
 			"label": "界面缩放",
 			"value": "{{percent}}%"
 		},
+		"fonts": {
+			"section": "字体",
+			"interface": "界面字体",
+			"interfaceHint": "侧栏、工具栏、设置等应用界面。",
+			"text": "正文字体",
+			"textHint": "Markdown 与笔记正文。",
+			"mono": "等宽字体",
+			"monoHint": "代码块、Frontmatter 与等宽 UI。"
+		},
 		"markdownEditor": {
 			"section": "Markdown编辑器"
 		},
@@ -129,11 +138,15 @@
 			"value": "{{size}} px"
 		},
 		"fontFamily": {
-			"label": "编辑器字体",
 			"default": "默认",
-			"system": "系统字体",
+			"system": "系统 UI",
 			"serif": "衬线",
-			"mono": "等宽"
+			"mono": "等宽",
+			"search": "搜索字体…",
+			"loading": "正在加载系统字体…",
+			"noMatch": "无匹配字体",
+			"suggested": "推荐",
+			"systemFonts": "系统字体"
 		},
 		"lineHeight": {
 			"label": "行距",

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -128,6 +128,17 @@
 			"label": "编辑器字号",
 			"value": "{{size}} px"
 		},
+		"fontFamily": {
+			"label": "编辑器字体",
+			"default": "默认",
+			"system": "系统字体",
+			"serif": "衬线",
+			"mono": "等宽"
+		},
+		"lineHeight": {
+			"label": "行距",
+			"value": "{{value}}"
+		},
 		"editorToolbar": {
 			"label": "格式工具栏"
 		}

--- a/src/index.css
+++ b/src/index.css
@@ -29,6 +29,9 @@
 @theme inline {
 	--font-heading: var(--font-sans);
 	--font-sans: "Geist Variable", sans-serif;
+	--font-mono:
+		ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+		"Courier New", monospace;
 	--color-sidebar-ring: var(--sidebar-ring);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/src/index.css
+++ b/src/index.css
@@ -26,12 +26,26 @@
 	animation: library-shimmer 1.8s ease-in-out infinite;
 }
 
-@theme inline {
-	--font-heading: var(--font-sans);
-	--font-sans: "Geist Variable", sans-serif;
-	--font-mono:
+/*
+ * Runtime-overridable font stacks (Settings → Appearance → Fonts).
+ * @theme inline bakes token values into utilities, so the theme tokens must
+ * point at these variables — never hardcode family names in @theme, or
+ * interfaceFontFamily / monoFontFamily cannot take effect.
+ */
+:root {
+	--agentero-font-sans:
+		"Geist Variable", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+		sans-serif;
+	--agentero-font-heading: var(--agentero-font-sans);
+	--agentero-font-mono:
 		ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
 		"Courier New", monospace;
+}
+
+@theme inline {
+	--font-heading: var(--agentero-font-heading);
+	--font-sans: var(--agentero-font-sans);
+	--font-mono: var(--agentero-font-mono);
 	--color-sidebar-ring: var(--sidebar-ring);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -1,4 +1,8 @@
-import type { AppSettings, PdfAskSettings } from "@/lib/settings/types";
+import type {
+	AppSettings,
+	EditorFontFamily,
+	PdfAskSettings,
+} from "@/lib/settings/types";
 import { DEFAULT_LIBRARY_COLUMNS } from "@/lib/settings/types";
 import { DEFAULT_TRANSLATE_SETTINGS } from "@/lib/translate/defaults";
 import { DEFAULT_UI_THEME } from "@/lib/ui/theme";
@@ -18,6 +22,42 @@ export const DEFAULT_NETWORK_PROXY_URL = "http://127.0.0.1:7890";
  */
 export const UI_SCALE_PRESETS = [0.8, 0.9, 1, 1.25, 1.5] as const;
 
+/** Markdown editor line-height slider bounds (unitless). */
+export const EDITOR_LINE_HEIGHT_MIN = 1.4;
+export const EDITOR_LINE_HEIGHT_MAX = 2.0;
+export const EDITOR_LINE_HEIGHT_STEP = 0.1;
+export const DEFAULT_EDITOR_LINE_HEIGHT = 1.6;
+
+/**
+ * CSS font stacks for editor body presets. `default` returns undefined so the
+ * editor inherits the app theme stack (Geist / --font-sans).
+ */
+const EDITOR_FONT_FAMILY_CSS: Record<EditorFontFamily, string | undefined> = {
+	default: undefined,
+	system:
+		'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Microsoft YaHei", "Noto Sans SC", sans-serif',
+	serif:
+		'ui-serif, "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, "Songti SC", "Noto Serif CJK SC", "Noto Serif SC", serif',
+	mono: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+};
+
+/** Resolve a preset to a CSS `font-family` value, or undefined for app default. */
+export function editorFontFamilyCss(
+	family: EditorFontFamily,
+): string | undefined {
+	return EDITOR_FONT_FAMILY_CSS[family];
+}
+
+/** Clamp and snap line-height to the supported slider range (0.1 steps). */
+export function clampEditorLineHeight(value: number): number {
+	if (!Number.isFinite(value)) return DEFAULT_EDITOR_LINE_HEIGHT;
+	const clamped = Math.min(
+		EDITOR_LINE_HEIGHT_MAX,
+		Math.max(EDITOR_LINE_HEIGHT_MIN, value),
+	);
+	return Math.round(clamped * 10) / 10;
+}
+
 export const DEFAULT_SETTINGS: AppSettings = {
 	translatorBaseUrl: DEFAULT_TRANSLATOR_BASE_URL,
 	networkProxyEnabled: false,
@@ -36,6 +76,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	uiTheme: DEFAULT_UI_THEME,
 	locale: "system",
 	editorFontSize: 14,
+	editorFontFamily: "default",
+	editorLineHeight: DEFAULT_EDITOR_LINE_HEIGHT,
 	uiScale: 1,
 	showEditorToolbar: true,
 	agentPermissionMode: "restricted",

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -1,8 +1,4 @@
-import type {
-	AppSettings,
-	EditorFontFamily,
-	PdfAskSettings,
-} from "@/lib/settings/types";
+import type { AppSettings, PdfAskSettings } from "@/lib/settings/types";
 import { DEFAULT_LIBRARY_COLUMNS } from "@/lib/settings/types";
 import { DEFAULT_TRANSLATE_SETTINGS } from "@/lib/translate/defaults";
 import { DEFAULT_UI_THEME } from "@/lib/ui/theme";
@@ -27,26 +23,6 @@ export const EDITOR_LINE_HEIGHT_MIN = 1.4;
 export const EDITOR_LINE_HEIGHT_MAX = 2.0;
 export const EDITOR_LINE_HEIGHT_STEP = 0.1;
 export const DEFAULT_EDITOR_LINE_HEIGHT = 1.6;
-
-/**
- * CSS font stacks for editor body presets. `default` returns undefined so the
- * editor inherits the app theme stack (Geist / --font-sans).
- */
-const EDITOR_FONT_FAMILY_CSS: Record<EditorFontFamily, string | undefined> = {
-	default: undefined,
-	system:
-		'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Microsoft YaHei", "Noto Sans SC", sans-serif',
-	serif:
-		'ui-serif, "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, "Songti SC", "Noto Serif CJK SC", "Noto Serif SC", serif',
-	mono: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
-};
-
-/** Resolve a preset to a CSS `font-family` value, or undefined for app default. */
-export function editorFontFamilyCss(
-	family: EditorFontFamily,
-): string | undefined {
-	return EDITOR_FONT_FAMILY_CSS[family];
-}
 
 /** Clamp and snap line-height to the supported slider range (0.1 steps). */
 export function clampEditorLineHeight(value: number): number {
@@ -76,7 +52,9 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	uiTheme: DEFAULT_UI_THEME,
 	locale: "system",
 	editorFontSize: 14,
-	editorFontFamily: "default",
+	interfaceFontFamily: "",
+	textFontFamily: "",
+	monoFontFamily: "",
 	editorLineHeight: DEFAULT_EDITOR_LINE_HEIGHT,
 	uiScale: 1,
 	showEditorToolbar: true,

--- a/src/lib/settings/fonts.ts
+++ b/src/lib/settings/fonts.ts
@@ -1,0 +1,164 @@
+/**
+ * Font settings helpers (interface / text / mono), CSS stacks, and system-font listing.
+ *
+ * Values are free-form strings:
+ * - `""` / `"default"` → app default for that role
+ * - `"system"` | `"serif"` | `"mono"` → built-in CSS stacks
+ * - any other string → a system font family name (quoted + role fallback)
+ */
+
+import { invokeApi } from "@/lib/core/ipc";
+import { isTauri } from "@/lib/core/tauri";
+
+/** Built-in non-system tokens shown at the top of the font picker. */
+export const FONT_STACK_PRESETS = [
+	"default",
+	"system",
+	"serif",
+	"mono",
+] as const;
+export type FontStackPreset = (typeof FONT_STACK_PRESETS)[number];
+
+export type FontRole = "interface" | "text" | "mono";
+
+export const DEFAULT_SANS_STACK =
+	'"Geist Variable", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+
+export const SYSTEM_SANS_STACK =
+	'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Microsoft YaHei", "Noto Sans SC", sans-serif';
+
+export const SERIF_STACK =
+	'ui-serif, "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, "Songti SC", "Noto Serif CJK SC", "Noto Serif SC", serif';
+
+export const MONO_STACK =
+	'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace';
+
+export function isFontStackPreset(v: string): v is FontStackPreset {
+	return (FONT_STACK_PRESETS as readonly string[]).includes(v);
+}
+
+/** Normalize a stored font value (trim; map legacy aliases). */
+export function normalizeFontFamilyValue(raw: unknown): string {
+	if (typeof raw !== "string") return "";
+	const v = raw.trim();
+	if (!v || v === "default") return "";
+	// Cap hand-edited garbage.
+	return v.slice(0, 120);
+}
+
+/**
+ * Resolve a stored font value to a CSS `font-family` list.
+ * Returns `undefined` when the role should keep the stylesheet default
+ * (Geist for interface/text; theme mono for mono).
+ */
+export function resolveFontFamilyCss(
+	value: string,
+	role: FontRole,
+): string | undefined {
+	const v = value.trim();
+	if (!v || v === "default") {
+		return undefined;
+	}
+	if (v === "system") return SYSTEM_SANS_STACK;
+	if (v === "serif") return SERIF_STACK;
+	if (v === "mono") return MONO_STACK;
+
+	const escaped = v.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+	const fallback =
+		role === "mono"
+			? MONO_STACK
+			: role === "text"
+				? SYSTEM_SANS_STACK
+				: SYSTEM_SANS_STACK;
+	return `"${escaped}", ${fallback}`;
+}
+
+/**
+ * Apply interface + mono CSS variables on `documentElement`.
+ * Interface drives `--font-sans` / `--font-heading`; mono drives `--font-mono`.
+ * Empty values clear inline overrides so `@theme` defaults return.
+ */
+export function applyChromeFontCss(
+	interfaceFontFamily: string,
+	monoFontFamily: string,
+): void {
+	if (typeof document === "undefined") return;
+	const root = document.documentElement;
+	const iface = resolveFontFamilyCss(interfaceFontFamily, "interface");
+	if (iface) {
+		root.style.setProperty("--font-sans", iface);
+		root.style.setProperty("--font-heading", iface);
+	} else {
+		root.style.removeProperty("--font-sans");
+		root.style.removeProperty("--font-heading");
+	}
+
+	const mono = resolveFontFamilyCss(monoFontFamily, "mono");
+	if (mono) {
+		root.style.setProperty("--font-mono", mono);
+	} else {
+		root.style.removeProperty("--font-mono");
+	}
+}
+
+/** Apply global UI scale + chrome fonts together. */
+export function applyDocumentChrome(opts: {
+	uiScale: number;
+	interfaceFontFamily: string;
+	monoFontFamily: string;
+}): void {
+	if (typeof document === "undefined") return;
+	const scale = Number.isFinite(opts.uiScale) ? opts.uiScale : 1;
+	document.documentElement.style.fontSize = `${16 * scale}px`;
+	applyChromeFontCss(opts.interfaceFontFamily, opts.monoFontFamily);
+}
+
+/** Display label key suffix for presets; system fonts use the raw name. */
+export function fontFamilyDisplayKey(value: string): string {
+	const v = value.trim();
+	if (!v || v === "default") return "default";
+	if (isFontStackPreset(v)) return v;
+	return "custom";
+}
+
+// --- System font listing (Host-backed, cached) --------------------------------
+
+let systemFontsCache: string[] | null = null;
+let systemFontsPromise: Promise<string[]> | null = null;
+
+/** Return cached system font family names, or load once from the Host. */
+export async function listSystemFonts(): Promise<string[]> {
+	if (systemFontsCache) return systemFontsCache;
+	if (systemFontsPromise) return systemFontsPromise;
+	systemFontsPromise = loadSystemFonts()
+		.then((fonts) => {
+			systemFontsCache = fonts;
+			return fonts;
+		})
+		.finally(() => {
+			systemFontsPromise = null;
+		});
+	return systemFontsPromise;
+}
+
+async function loadSystemFonts(): Promise<string[]> {
+	if (!isTauri()) return [];
+	try {
+		const fonts = await invokeApi<string[]>("list_system_fonts", undefined, {
+			fallback: "Failed to list system fonts",
+		});
+		if (!Array.isArray(fonts)) return [];
+		return fonts
+			.filter((n): n is string => typeof n === "string" && n.trim().length > 0)
+			.map((n) => n.trim())
+			.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
+	} catch {
+		return [];
+	}
+}
+
+/** Drop the cache (e.g. after rare “refresh fonts” actions). */
+export function invalidateSystemFontsCache(): void {
+	systemFontsCache = null;
+	systemFontsPromise = null;
+}

--- a/src/lib/settings/fonts.ts
+++ b/src/lib/settings/fonts.ts
@@ -74,9 +74,20 @@ export function resolveFontFamilyCss(
 }
 
 /**
+ * CSS custom properties consumed by @theme (see src/index.css).
+ * Utilities are inlined as `var(--agentero-font-*)`, so runtime overrides here
+ * actually change chrome / mono UI. Do not set --font-sans alone — Tailwind
+ * does not re-read that for .font-sans when using @theme inline.
+ */
+const CSS_VAR_SANS = "--agentero-font-sans";
+const CSS_VAR_HEADING = "--agentero-font-heading";
+const CSS_VAR_MONO = "--agentero-font-mono";
+
+/**
  * Apply interface + mono CSS variables on `documentElement`.
- * Interface drives `--font-sans` / `--font-heading`; mono drives `--font-mono`.
- * Empty values clear inline overrides so `@theme` defaults return.
+ * Interface → chrome UI (sidebars, settings, toolbars).
+ * Mono → code blocks / font-mono / pre.
+ * Empty values clear inline overrides so :root defaults return.
  */
 export function applyChromeFontCss(
 	interfaceFontFamily: string,
@@ -86,18 +97,21 @@ export function applyChromeFontCss(
 	const root = document.documentElement;
 	const iface = resolveFontFamilyCss(interfaceFontFamily, "interface");
 	if (iface) {
-		root.style.setProperty("--font-sans", iface);
-		root.style.setProperty("--font-heading", iface);
+		root.style.setProperty(CSS_VAR_SANS, iface);
+		root.style.setProperty(CSS_VAR_HEADING, iface);
+		// Belt-and-suspenders: inheritance for nodes without font-sans class.
+		root.style.fontFamily = iface;
 	} else {
-		root.style.removeProperty("--font-sans");
-		root.style.removeProperty("--font-heading");
+		root.style.removeProperty(CSS_VAR_SANS);
+		root.style.removeProperty(CSS_VAR_HEADING);
+		root.style.fontFamily = "";
 	}
 
 	const mono = resolveFontFamilyCss(monoFontFamily, "mono");
 	if (mono) {
-		root.style.setProperty("--font-mono", mono);
+		root.style.setProperty(CSS_VAR_MONO, mono);
 	} else {
-		root.style.removeProperty("--font-mono");
+		root.style.removeProperty(CSS_VAR_MONO);
 	}
 }
 

--- a/src/lib/settings/index.ts
+++ b/src/lib/settings/index.ts
@@ -5,9 +5,24 @@ export {
 	EDITOR_LINE_HEIGHT_MAX,
 	EDITOR_LINE_HEIGHT_MIN,
 	EDITOR_LINE_HEIGHT_STEP,
-	editorFontFamilyCss,
 	UI_SCALE_PRESETS,
 } from "@/lib/settings/defaults";
+export {
+	applyChromeFontCss,
+	applyDocumentChrome,
+	FONT_STACK_PRESETS,
+	type FontRole,
+	type FontStackPreset,
+	fontFamilyDisplayKey,
+	invalidateSystemFontsCache,
+	isFontStackPreset,
+	listSystemFonts,
+	MONO_STACK,
+	normalizeFontFamilyValue,
+	resolveFontFamilyCss,
+	SERIF_STACK,
+	SYSTEM_SANS_STACK,
+} from "@/lib/settings/fonts";
 export {
 	ensureSettingsLoaded,
 	loadSettings,
@@ -23,7 +38,6 @@ export type {
 	AppSettings,
 	AutoUpdateInternalLinks,
 	CommercialTranslateProviderId,
-	EditorFontFamily,
 	LibraryColumnKey,
 	LibraryColumnPref,
 	LocalePreference,
@@ -35,6 +49,4 @@ export type {
 export {
 	AUTO_UPDATE_INTERNAL_LINKS,
 	DEFAULT_LIBRARY_COLUMNS,
-	EDITOR_FONT_FAMILIES,
-	isEditorFontFamily,
 } from "@/lib/settings/types";

--- a/src/lib/settings/index.ts
+++ b/src/lib/settings/index.ts
@@ -1,5 +1,11 @@
 export {
+	clampEditorLineHeight,
+	DEFAULT_EDITOR_LINE_HEIGHT,
 	DEFAULT_TRANSLATOR_BASE_URL,
+	EDITOR_LINE_HEIGHT_MAX,
+	EDITOR_LINE_HEIGHT_MIN,
+	EDITOR_LINE_HEIGHT_STEP,
+	editorFontFamilyCss,
 	UI_SCALE_PRESETS,
 } from "@/lib/settings/defaults";
 export {
@@ -17,6 +23,7 @@ export type {
 	AppSettings,
 	AutoUpdateInternalLinks,
 	CommercialTranslateProviderId,
+	EditorFontFamily,
 	LibraryColumnKey,
 	LibraryColumnPref,
 	LocalePreference,
@@ -28,4 +35,6 @@ export type {
 export {
 	AUTO_UPDATE_INTERNAL_LINKS,
 	DEFAULT_LIBRARY_COLUMNS,
+	EDITOR_FONT_FAMILIES,
+	isEditorFontFamily,
 } from "@/lib/settings/types";

--- a/src/lib/settings/store.ts
+++ b/src/lib/settings/store.ts
@@ -6,6 +6,7 @@ import {
 	isPaperTreeSortMode,
 } from "@/lib/paper/tree-modes";
 import {
+	clampEditorLineHeight,
 	DEFAULT_PDF_ASK_SETTINGS,
 	DEFAULT_SETTINGS,
 	DEFAULT_TRANSLATOR_BASE_URL,
@@ -14,6 +15,7 @@ import {
 import {
 	type AppSettings,
 	DEFAULT_LIBRARY_COLUMNS,
+	isEditorFontFamily,
 	LIBRARY_COLUMN_KEYS,
 	type LibraryColumnKey,
 	type LibraryColumnPref,
@@ -357,6 +359,10 @@ function normalizePartial(
 	) {
 		merged.locale = DEFAULT_SETTINGS.locale;
 	}
+	if (!isEditorFontFamily(merged.editorFontFamily)) {
+		merged.editorFontFamily = DEFAULT_SETTINGS.editorFontFamily;
+	}
+	merged.editorLineHeight = clampEditorLineHeight(merged.editorLineHeight);
 	if (
 		merged.agentPermissionMode !== "restricted" &&
 		merged.agentPermissionMode !== "ask" &&

--- a/src/lib/settings/store.ts
+++ b/src/lib/settings/store.ts
@@ -12,10 +12,10 @@ import {
 	DEFAULT_TRANSLATOR_BASE_URL,
 	snapUiScale,
 } from "@/lib/settings/defaults";
+import { normalizeFontFamilyValue } from "@/lib/settings/fonts";
 import {
 	type AppSettings,
 	DEFAULT_LIBRARY_COLUMNS,
-	isEditorFontFamily,
 	LIBRARY_COLUMN_KEYS,
 	type LibraryColumnKey,
 	type LibraryColumnPref,
@@ -258,6 +258,8 @@ function normalizePartial(
 		agentYolo?: boolean;
 		downloadFulltextToLocal?: boolean;
 		downloadFulltextWhenNoRemotePreview?: boolean;
+		/** @deprecated pre-#242 single editor font preset */
+		editorFontFamily?: string;
 	},
 ): AppSettings {
 	const {
@@ -267,6 +269,7 @@ function normalizePartial(
 		agentYolo: _y,
 		downloadFulltextToLocal: _d1,
 		downloadFulltextWhenNoRemotePreview: _d2,
+		editorFontFamily: legacyEditorFontFamily,
 		...rest
 	} = parsed;
 	const merged = { ...DEFAULT_SETTINGS, ...rest };
@@ -359,8 +362,20 @@ function normalizePartial(
 	) {
 		merged.locale = DEFAULT_SETTINGS.locale;
 	}
-	if (!isEditorFontFamily(merged.editorFontFamily)) {
-		merged.editorFontFamily = DEFAULT_SETTINGS.editorFontFamily;
+	merged.interfaceFontFamily = normalizeFontFamilyValue(
+		merged.interfaceFontFamily,
+	);
+	merged.textFontFamily = normalizeFontFamilyValue(merged.textFontFamily);
+	merged.monoFontFamily = normalizeFontFamilyValue(merged.monoFontFamily);
+	// Migrate short-lived editorFontFamily preset → textFontFamily when the
+	// newer field was never set in storage.
+	if (
+		!parsed.textFontFamily &&
+		typeof legacyEditorFontFamily === "string" &&
+		legacyEditorFontFamily.trim() &&
+		legacyEditorFontFamily !== "default"
+	) {
+		merged.textFontFamily = normalizeFontFamilyValue(legacyEditorFontFamily);
 	}
 	merged.editorLineHeight = clampEditorLineHeight(merged.editorLineHeight);
 	if (

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -24,27 +24,6 @@ export type ThemePreference = "system" | "light" | "dark";
 
 export type LocalePreference = "system" | "en" | "zh-CN";
 
-/**
- * Markdown editor body font preset.
- * `default` keeps the app theme stack (Geist / --font-sans); others override
- * editor content only (not chrome UI).
- */
-export const EDITOR_FONT_FAMILIES = [
-	"default",
-	"system",
-	"serif",
-	"mono",
-] as const;
-
-export type EditorFontFamily = (typeof EDITOR_FONT_FAMILIES)[number];
-
-export function isEditorFontFamily(v: unknown): v is EditorFontFamily {
-	return (
-		typeof v === "string" &&
-		(EDITOR_FONT_FAMILIES as readonly string[]).includes(v)
-	);
-}
-
 /** Sortable / customizable columns in the papers Library table. */
 export type LibraryColumnKey =
 	| "title"
@@ -161,10 +140,21 @@ export type AppSettings = {
 	locale: LocalePreference;
 	editorFontSize: number;
 	/**
-	 * Markdown editor body font preset. Orthogonal to {@link uiScale} and to the
-	 * app chrome font; code blocks stay mono regardless of this value.
+	 * UI chrome font (sidebars, toolbars, settings). Empty = app default (Geist).
+	 * Also accepts built-in stacks (`system` | `serif` | `mono`) or a system
+	 * family name discovered via `list_system_fonts`.
 	 */
-	editorFontFamily: EditorFontFamily;
+	interfaceFontFamily: string;
+	/**
+	 * Markdown / notes body font. Empty = inherit interface / app default.
+	 * Same value vocabulary as {@link interfaceFontFamily}.
+	 */
+	textFontFamily: string;
+	/**
+	 * Monospace font for code blocks, frontmatter, and `font-mono` UI.
+	 * Empty = app default mono stack. Same value vocabulary as above.
+	 */
+	monoFontFamily: string;
 	/**
 	 * Markdown editor body line-height (unitless multiplier). Orthogonal to
 	 * {@link uiScale}. Typical range 1.4–2.0; default 1.6.

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -24,6 +24,27 @@ export type ThemePreference = "system" | "light" | "dark";
 
 export type LocalePreference = "system" | "en" | "zh-CN";
 
+/**
+ * Markdown editor body font preset.
+ * `default` keeps the app theme stack (Geist / --font-sans); others override
+ * editor content only (not chrome UI).
+ */
+export const EDITOR_FONT_FAMILIES = [
+	"default",
+	"system",
+	"serif",
+	"mono",
+] as const;
+
+export type EditorFontFamily = (typeof EDITOR_FONT_FAMILIES)[number];
+
+export function isEditorFontFamily(v: unknown): v is EditorFontFamily {
+	return (
+		typeof v === "string" &&
+		(EDITOR_FONT_FAMILIES as readonly string[]).includes(v)
+	);
+}
+
 /** Sortable / customizable columns in the papers Library table. */
 export type LibraryColumnKey =
 	| "title"
@@ -139,6 +160,16 @@ export type AppSettings = {
 	uiTheme: string;
 	locale: LocalePreference;
 	editorFontSize: number;
+	/**
+	 * Markdown editor body font preset. Orthogonal to {@link uiScale} and to the
+	 * app chrome font; code blocks stay mono regardless of this value.
+	 */
+	editorFontFamily: EditorFontFamily;
+	/**
+	 * Markdown editor body line-height (unitless multiplier). Orthogonal to
+	 * {@link uiScale}. Typical range 1.4–2.0; default 1.6.
+	 */
+	editorLineHeight: number;
 	/**
 	 * Global UI scale multiplier. Affects font-size, spacing, and the title bar,
 	 * so toolbar buttons grow together with the rest of the interface.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import { initAutoHideScrollbars } from "@/lib/core/scrollbars";
 import { isMobileApp, isTauri } from "@/lib/core/tauri";
 import { initErrorReporting } from "@/lib/core/telemetry";
 import {
+	applyDocumentChrome,
 	ensureSettingsLoaded,
 	initSettingsSync,
 	loadSettings,
@@ -45,15 +46,28 @@ async function boot() {
 	await ensureSettingsLoaded();
 	bootStage("settings");
 	initSettingsSync();
-	await applyUiTheme(loadSettings().uiTheme).catch((e) => {
+	const initialSettings = loadSettings();
+	// Apply scale + interface/mono fonts before first paint so settings/main
+	// windows do not flash Geist then switch.
+	applyDocumentChrome({
+		uiScale: initialSettings.uiScale,
+		interfaceFontFamily: initialSettings.interfaceFontFamily,
+		monoFontFamily: initialSettings.monoFontFamily,
+	});
+	await applyUiTheme(initialSettings.uiTheme).catch((e) => {
 		console.warn("[theme] failed to apply initial UI theme", e);
 	});
 	bootStage("theme");
 	subscribeSettings((s) => {
 		void applyUiTheme(s.uiTheme);
+		applyDocumentChrome({
+			uiScale: s.uiScale,
+			interfaceFontFamily: s.interfaceFontFamily,
+			monoFontFamily: s.monoFontFamily,
+		});
 	});
 	initAutoHideScrollbars();
-	const locale = resolveLocale(loadSettings().locale);
+	const locale = resolveLocale(initialSettings.locale);
 	await i18n.changeLanguage(locale);
 	bootStage("i18n");
 	if (typeof document !== "undefined") {


### PR DESCRIPTION
## Summary

Appearance 增加可配置的 **界面 / 正文 / 等宽** 字体与 Markdown **字号 / 行距**，对齐 Obsidian 的字体分层；并与全局 `uiScale` 保持正交。

- **字体三分法**：`interfaceFontFamily`（chrome）、`textFontFamily`（Markdown/笔记正文）、`monoFontFamily`（代码块 / `font-mono`）；取值支持默认、内置栈（系统 UI / 衬线 / 等宽）或本机字体族名
- **可搜索选择器**：Popover + Command；推荐预设 + Host `list_system_fonts`（fontdb）枚举系统字体
- **行距 / 字号**：`editorLineHeight`（1.4–2.0）与既有 `editorFontSize`（12–20）同区
- **落盘与兼容**：FE + Host `settings.json` 同步；旧 `editorFontFamily` 迁移到 `textFontFamily`
- **界面字体生效**：`@theme inline` 烤死 Geist 导致改 `--font-sans` 无效 → 改为可覆盖的 `--agentero-font-*`；启动与 `settings:changed` 时 `applyDocumentChrome`
- **文档 / i18n**：`docs/frontend/settings.md` 与 en / zh-CN 文案

## Demo
1. 三分字体:
<img width="1663" height="923" alt="image" src="https://github.com/user-attachments/assets/8749e41d-2bc9-4547-a98c-6d8c8306613d" />

2. 支持检索本机字体:
<img width="864" height="544" alt="image" src="https://github.com/user-attachments/assets/ecebb87c-f047-4b02-a349-a4b17f95f906" />

## Test plan

- [x] `pnpm exec tsc --noEmit` 通过
- [x] `cargo test --lib features::settings` 6/6 通过
- [x] biome / lint-staged 通过
- [x] 设置 → 外观：切换界面字体，侧栏与设置页文案立即变化
- [x] 切换正文字体 / 行距，仅 Markdown 编辑器变化；代码块仍跟等宽字体
- [x] 字体选择器：搜索过滤；系统字体列表在桌面端可见；选中项仅一个对钩
- [x] 改 `uiScale` 与编辑器字号/行距互不影响
- [x] 主窗 / 设置窗 / 文档弹出窗字体与缩放同步
- [x] 旧配置仅含 `editorFontFamily` 时正确迁移到正文字体

Fixes #242
Closes #286 