### PR TITLE
fix(watcher): 初始化文件 ID 缓存以配对重命名事件

### DIFF
--- a/src-tauri/src/features/watcher/mod.rs
+++ b/src-tauri/src/features/watcher/mod.rs
@@ -92,6 +92,9 @@ impl FsWatchController {
                     log::error!(target: "agentero::watcher", "vault watcher watch failed: {e}");
                     return;
                 }
+                debouncer
+                    .cache()
+                    .add_root(std::path::Path::new(&watch_root), RecursiveMode::Recursive);
                 // Keep the debouncer alive for the lifetime of this loop.
                 loop {
                     if stop_thread.load(Ordering::Relaxed) {


### PR DESCRIPTION
## 问题

macOS FSEvents 不会关联重命名前后的两侧事件。Agentero 虽然使用了 `notify-debouncer-full`，但启动 watcher 时没有初始化文件 ID 缓存，因此这些事件仍会以不完整的 `RenameMode::Any` 到达前端，频繁触发“文件监听器未提供完整的改名前后路径对”警告，真实外部重命名也无法进入 Wiki 链接修复流程。

## 修改

- 在递归 watcher 注册成功后，用相同的 Vault 根目录和递归模式初始化文件 ID 缓存
- 保留现有安全边界：仍然只有 `RenameMode::Both` 且包含两个不同路径时才允许修复链接
- 不增加重试、路径猜测或告警抑制

## 验证

- `cargo test -p agentero --lib`：358 passed，4 ignored，0 failed
- `pnpm lint:rs`
- `cargo fmt --all --check`

## 备注

初始化缓存会递归扫描一次 Vault，成本随文件数量增长；扫描发生在 watcher 后台线程中，不阻塞调用方。