### PR TITLE
fix(pdf): 渲染划线翻译中的 LaTeX

### DIFF
--- a/src/components/viewer/pdf/cards/translate-card.tsx
+++ b/src/components/viewer/pdf/cards/translate-card.tsx
@@ -1,5 +1,6 @@
 import { Languages, MinusIcon, Settings2Icon, Trash2Icon } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { MessageResponse } from "@/components/ai-elements/message";
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import { Button } from "@/components/ui/button";
 import { SelectionCard } from "@/components/viewer/pdf/cards/selection-card";
@@ -77,9 +78,9 @@ export function TranslateCard({
 			) : null}
 
 			{showResult ? (
-				<p className="min-w-0 whitespace-pre-wrap break-words text-[13px] text-foreground leading-relaxed">
+				<MessageResponse className="min-w-0 whitespace-pre-wrap break-words text-[13px] text-foreground leading-relaxed">
 					{result}
-				</p>
+				</MessageResponse>
 			) : null}
 
 			{!showLoading && !showResult && !error ? (

--- a/test/pdf-selection-translate-card.test.ts
+++ b/test/pdf-selection-translate-card.test.ts
@@ -1,0 +1,30 @@
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { TranslateCard } from "@/components/viewer/pdf/cards/translate-card";
+
+vi.mock("react-i18next", () => ({
+	useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/components/viewer/pdf/cards/selection-card", () => ({
+	SelectionCard: ({ children }: { children: ReactNode }) => children,
+}));
+
+describe("PDF selection translate card", () => {
+	it("renders inline LaTeX through KaTeX", () => {
+		const markup = renderToStaticMarkup(
+			createElement(TranslateCard, {
+				screen: { x: 0, y: 0 },
+				result: "能量关系是 $E=mc^2$。",
+				streaming: false,
+				error: null,
+				onOpenSettings: () => {},
+				onHide: () => {},
+				onDelete: () => {},
+			}),
+		);
+
+		expect(markup).toContain('class="katex"');
+	});
+});


### PR DESCRIPTION
## 问题

PDF 划线翻译结果使用普通文本节点展示，翻译中保留的 LaTeX 会原样显示。

## 修改

- 在 `TranslateCard` 中复用现有 `MessageResponse` 数学渲染链路
- 保持翻译请求和持久化数据不变
- 添加组件回归测试，验证行内公式生成 KaTeX 标记

## 验证

- `pnpm test`（91 个测试文件、716 项测试通过）
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec biome check src/components/viewer/pdf/cards/translate-card.tsx test/pdf-selection-translate-card.test.ts`
