### PR TITLE
修复 Linux 上原生标题栏最大化/最小化/关闭按钮失效的问题

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
 		"core:window:allow-toggle-maximize",
 		"core:window:allow-close",
 		"core:window:allow-is-maximized",
+		"core:window:allow-is-visible",
 		"core:webview:allow-create-webview-window",
 		"core:webview:allow-get-all-webviews",
 		"opener:default",

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -101,7 +101,13 @@ pub fn run() {
         builder = builder.on_page_load(|webview, payload| {
             if matches!(payload.event(), tauri::webview::PageLoadEvent::Finished) {
                 // The HTML boot shell is ready now; reveal it while React hydrates.
-                let _ = webview.window().show();
+                // On Linux/GTK, calling show() on an already-visible window can
+                // corrupt the native titlebar hit-test (buttons become dead until
+                // a resize/double-click). Only show if currently hidden.
+                let win = webview.window();
+                if !win.is_visible().unwrap_or(false) {
+                    let _ = win.show();
+                }
             }
         });
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,13 +18,7 @@
         "height": 800,
         "minWidth": 800,
         "minHeight": 520,
-        "visible": false,
-        "hiddenTitle": true,
-        "titleBarStyle": "Overlay",
-        "trafficLightPosition": {
-          "x": 14,
-          "y": 18
-        }
+        "visible": true
       }
     ],
     "security": {

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,15 @@
+{
+  "app": {
+    "windows": [
+      {
+        "visible": false,
+        "hiddenTitle": true,
+        "titleBarStyle": "Overlay",
+        "trafficLightPosition": {
+          "x": 14,
+          "y": 18
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 问题描述

在 Linux 上，点击窗口标题栏的最大化/最小化/关闭按钮没有反应（双击标题栏窗口最大化后按钮恢复正常）。

## 根因分析

通过 git bisect 定位到 commit `e758be79`（`fix(window): use native decorations on Windows/Linux`）引入了该问题。

该 commit 移除了 `set_decorations(false)` 以恢复原生窗口装饰，但 `tauri.conf.json` 中仍保留了 macOS 专属配置：

- `"hiddenTitle": true` — 隐藏原生标题栏
- `"titleBarStyle": "Overlay"` — macOS overlay 样式
- `"visible": false` — 窗口先隐藏再由前端 show()

这些配置在 Linux/GTK 上会导致原生标题栏 hit-test 异常，使按钮在初始状态下无法响应点击。

另外，`on_page_load` 中的 `show()` 调用在窗口已可见时重复调用，也会触发 GTK 的标题栏 hit-test 问题。

## 修复方案

1. **`tauri.conf.json`**：移除 macOS 专属配置，设置 `visible: true`
2. **`tauri.macos.conf.json`**（新建）：将 macOS 专属配置（Overlay、hiddenTitle、trafficLightPosition）放入平台配置覆盖
3. **`app/mod.rs`**：`on_page_load` 的 `show()` 调用前先检查 `is_visible()`，已可见则跳过
4. **`capabilities/default.json`**：添加 `core:window:allow-is-visible` 权限

## 参考

类似问题及修复方案参考了 markra 项目：
https://github.com/markrahq/markra/pull/368