### PR TITLE
修复 Linux 上设置窗口等辅助窗口标题栏按钮失效的问题

### DIFF
--- a/src-tauri/src/features/window/commands.rs
+++ b/src-tauri/src/features/window/commands.rs
@@ -49,7 +49,6 @@ pub async fn window_new(app: AppHandle) -> Result<(), String> {
             .title("Agentero")
             .inner_size(1280.0, 800.0)
             .min_inner_size(800.0, 520.0)
-            .visible(false)
             .resizable(true);
 
     #[cfg(target_os = "macos")]
@@ -65,6 +64,7 @@ pub async fn window_new(app: AppHandle) -> Result<(), String> {
             TRAFFIC_LIGHT_Y_DEFAULT
         };
         builder = builder
+            .visible(false)
             .hidden_title(true)
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .traffic_light_position(tauri::LogicalPosition::new(TRAFFIC_LIGHT_X, y));
@@ -121,7 +121,6 @@ pub async fn settings_window_open(
             .title("Settings")
             .inner_size(720.0, 560.0)
             .min_inner_size(640.0, 480.0)
-            .visible(false)
             .resizable(true);
 
     #[cfg(target_os = "macos")]
@@ -129,6 +128,7 @@ pub async fn settings_window_open(
         // The 32px header (Tailwind h-8) does not scale with `ui_scale`, so the
         // y position stays at the constant that vertically centers the buttons.
         builder = builder
+            .visible(false)
             .hidden_title(true)
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .traffic_light_position(tauri::LogicalPosition::new(
@@ -236,7 +236,6 @@ pub async fn feature_window_open(
         .title(window_title)
         .inner_size(420.0, 720.0)
         .min_inner_size(320.0, 400.0)
-        .visible(false)
         .resizable(true);
 
     #[cfg(target_os = "macos")]
@@ -252,6 +251,7 @@ pub async fn feature_window_open(
             TRAFFIC_LIGHT_Y_DEFAULT
         };
         builder = builder
+            .visible(false)
             .hidden_title(true)
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .traffic_light_position(tauri::LogicalPosition::new(TRAFFIC_LIGHT_X, y));
@@ -331,7 +331,6 @@ pub async fn doc_window_open(
         .title(window_title)
         .inner_size(960.0, 720.0)
         .min_inner_size(480.0, 360.0)
-        .visible(false)
         .resizable(true);
 
     #[cfg(target_os = "macos")]
@@ -347,6 +346,7 @@ pub async fn doc_window_open(
             TRAFFIC_LIGHT_Y_DEFAULT
         };
         builder = builder
+            .visible(false)
             .hidden_title(true)
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .traffic_light_position(tauri::LogicalPosition::new(TRAFFIC_LIGHT_X, y));


### PR DESCRIPTION
## 问题描述

PR #301 修复了主窗口的标题栏按钮，但**设置窗口**（以及 ⌘N 新窗口、feature/doc 弹窗）的最大化/最小化/关闭按钮在 Linux 上仍然点击无效（双击标题栏后恢复）。

## 根因分析

主窗口修复后，四个动态创建窗口仍然走 `visible(false)` + 页面加载后 `show()` 的启动路径：

- `window_new`（⌘N 新窗口）
- `settings_window_open`（设置窗口）
- `feature_window_open`（右侧栏功能弹窗）
- `doc_window_open`（文档弹窗）

这与 PR #301 修复的根因相同：Linux/GTK 下 hidden→show 启动路径会破坏原生标题栏 hit-test，导致按钮初始不可点击。

## 修复方案

将 `visible(false)` 移入 `#[cfg(target_os = "macos")]` 块：

- **非 macOS**：窗口直接以可见状态创建，完全绕开 hidden→show 路径，GTK hit-test 问题不再触发
- **macOS**：保持原有 `visible(false)` + Overlay 行为不变（macOS 需要隐藏窗口等前端 ready 后显示）

配合 #301 中已有的 `on_page_load` `is_visible()` 保护，已可见窗口不会重复 `show()`。

## 参考

与 #301 相同，参考了 markra 项目的同类修复：
https://github.com/markrahq/markra/pull/368