### PR TITLE
修复论文列表 overlay 滚动条遮挡按钮及 Tooltip 行为

### DIFF
--- a/src/components/sidebar/file-tree/tree-rows.tsx
+++ b/src/components/sidebar/file-tree/tree-rows.tsx
@@ -25,6 +25,7 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { contextPathIcon } from "@/lib/agent/context-path-icon";
+import { getPlatformOS } from "@/lib/core/tauri";
 import { cn } from "@/lib/core/utils";
 import { LIBRARY_VIRTUAL_PATH, TRASH_VIRTUAL_PATH } from "@/lib/paper/api";
 import {
@@ -80,7 +81,7 @@ export function PaperTreeRow({
 			className={cn(isCut && "opacity-50")}
 		>
 			{expandable ? (
-				<Tooltip>
+				<Tooltip disableHoverableContent>
 					<TooltipTrigger asChild>
 						<button
 							type="button"
@@ -107,7 +108,9 @@ export function PaperTreeRow({
 							/>
 						</button>
 					</TooltipTrigger>
-					<TooltipContent side="right">{expandLabel}</TooltipContent>
+					<TooltipContent side="right" className="select-none cursor-default">
+						{expandLabel}
+					</TooltipContent>
 				</Tooltip>
 			) : (
 				<span className="size-4 shrink-0" />
@@ -120,14 +123,17 @@ export function PaperTreeRow({
 			</FileTreeName>
 			{showActions ? (
 				<FileTreeActions
-					className="shrink-0"
+					// Linux (WebKitGTK) and macOS (WKWebView) draw overlay scrollbars
+					// that float over content with an 8px-wide hit area; Windows
+					// WebView2 uses classic scrollbars that reserve layout space.
+					className={cn("shrink-0", getPlatformOS() !== "windows" && "pr-2")}
 					onClick={(e) => {
 						e.stopPropagation();
 					}}
 					onKeyDown={(e) => e.stopPropagation()}
 				>
 					{showDownload ? (
-						<Tooltip>
+						<Tooltip disableHoverableContent>
 							<TooltipTrigger asChild>
 								<Button
 									type="button"
@@ -148,7 +154,10 @@ export function PaperTreeRow({
 									)}
 								</Button>
 							</TooltipTrigger>
-							<TooltipContent side="right" className="max-w-xs">
+							<TooltipContent
+								side="right"
+								className="max-w-xs select-none cursor-default"
+							>
 								<p className="font-medium">{t("fileTree.downloadAssets")}</p>
 								<ul className="mt-1 list-disc space-y-0.5 pl-3 text-xs opacity-90">
 									{downloadReasons.map((r) => (
@@ -159,7 +168,7 @@ export function PaperTreeRow({
 						</Tooltip>
 					) : null}
 					{showRead ? (
-						<Tooltip>
+						<Tooltip disableHoverableContent>
 							<TooltipTrigger asChild>
 								<Button
 									type="button"
@@ -180,7 +189,10 @@ export function PaperTreeRow({
 									)}
 								</Button>
 							</TooltipTrigger>
-							<TooltipContent side="right" className="max-w-xs">
+							<TooltipContent
+								side="right"
+								className="max-w-xs select-none cursor-default"
+							>
 								<p className="font-medium">{t("fileTree.readPaper")}</p>
 							</TooltipContent>
 						</Tooltip>
@@ -260,11 +272,11 @@ export function LibraryRow({
 			</FileTreeName>
 			{showDownload ? (
 				<FileTreeActions
-					className="shrink-0"
+					className={cn("shrink-0", getPlatformOS() !== "windows" && "pr-2")}
 					onClick={(e) => e.stopPropagation()}
 					onKeyDown={(e) => e.stopPropagation()}
 				>
-					<Tooltip>
+					<Tooltip disableHoverableContent>
 						<TooltipTrigger asChild>
 							<Button
 								type="button"
@@ -285,7 +297,10 @@ export function LibraryRow({
 								)}
 							</Button>
 						</TooltipTrigger>
-						<TooltipContent side="right" className="max-w-xs">
+						<TooltipContent
+							side="right"
+							className="max-w-xs select-none cursor-default"
+						>
 							{t("fileTree.downloadAllMissing")}
 						</TooltipContent>
 					</Tooltip>


### PR DESCRIPTION
## 问题描述

左侧边栏论文列表中，overlay 滚动条（Linux WebKitGTK / macOS WKWebView）浮在内容上方，8px 宽的点击热区盖住了行末的「精读论文」按钮右半边，导致点击右半边时触发的是滚动条而非按钮。

同时，各按钮的 Tooltip 存在两个问题：
- 鼠标移出触发按钮后提示框不消失（会因鼠标移到提示框上而保持开启）
- 提示框内文字可被选中，快速移动鼠标时光标变成竖线选择状态

## 根因分析

WebKitGTK 和 WKWebView 使用 overlay 滚动条，不占据布局空间，而是浮在内容之上并带有 8px 宽的交互热区。Windows WebView2 使用经典占位式滚动条，本来就占据布局空间，不受此问题影响。

Radix Tooltip 默认开启 hoverable content，鼠标移到提示框上时不会关闭。提示框内容默认可选中。

## 修复方案

1. `FileTreeActions` 加 8px 右内边距（`pr-2`），仅在非 Windows 平台生效（`getPlatformOS() !== "windows"`），让按钮避开 overlay 滚动条热区
2. 所有 `Tooltip` 加 `disableHoverableContent`，鼠标移出触发按钮即消失
3. 所有 `TooltipContent` 加 `select-none cursor-default`，禁止文字选中

涉及的四个 Tooltip：展开/折叠附件、下载论文资源、精读论文、下载全部缺失资源。

## 验证

- `tsc --noEmit` 类型检查通过
- Linux（WebKitGTK）上实际验证：按钮不再被遮挡、点击热区正常、Tooltip 移出即消失、文字不可选中
- Windows 平台不受影响（`pr-2` 通过平台门控跳过，Windows WebView2 经典滚动条本来就占布局空间）