### PR TITLE
fix(zotero-connector): 延迟移动目录防止重复下载

### DIFF
--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -839,7 +839,7 @@ Agent：`agent_run_once` / `agent_warm` 在 vault 为 `remote:…` 时经 SSH `b
 | 事件 | payload |
 |---|---|
 | `connector:status` | `ConnectorStatus` |
-| `connector:item-saved` | `{ path, id, title, deduped, sessionId }` — 前端刷新树/Library 并 `openPaper` |
+| `connector:item-saved` | `{ path, id, title, deduped, sessionId }` — 新条目在附件成功/失败终结且 latest target 移动完成后仅发一次；`path` 已稳定，前端刷新树/Library 并 `openPaper` |
 | `connector:error` | `{ message, sessionId? }` |
 | `connector:progress` | `{ key, sessionId, path, title, status, progress, detail, error? }` — 映射到左下角后台任务条 |
 

--- a/docs/backend/connector.md
+++ b/docs/backend/connector.md
@@ -11,12 +11,17 @@ Host 在 **`127.0.0.1:23119`** 模拟 Zotero 桌面 Connector HTTP，官方浏�
 - 支持 **`hasAttachmentResolvers`** / **`saveAttachmentFromResolver`**：浏览器直连 PDF
   失败时，用 DOI/arXiv 走 Crossref + Unpaywall 再尝试 OA 副本。
 - 绑定当前 Vault（本地路径或 `remote:<sessionId>`）。
-- 保存后：catalog + paper 目录；刷新树；`openPaper` 聚焦。
+- `saveItems` 只在 session 创建时记录的 Library 作用域中写 paper 壳与 catalog；Chrome
+  先通过 `saveAttachment` 上传 PDF，只有浏览器未取得附件时才进入 DOI/arXiv fallback。
+- Connector 保存对话框后续发送的 `updateSession` 只更新该 session 的 latest target；附件
+  仍未终结时不移动，成功或失败终结后本地 Vault 统一通过共享 `paper_move` 事务移动一次。
+- `connector:item-saved` 只在初次 finalizer 得到稳定路径后发出；前端随后刷新并打开该路径，
+  现有 open/reconcile 流程再按需启动 backend parser。Connector 本身不主动解析。
 - Connector 返回的 Zotero 标签会以 `@zotero:` 前缀保存在 catalog 中，用于保留来源信息；
   这类内部标签不会显示在 Library、Paper Info 或标签筛选中。
 - 远程：stage 后 SFTP；catalog 经 work mirror。
-- 保存请求只写入 paper 壳和 catalog，PDF/TeX 在后台下载；后台单篇资源阶段最多
-  运行 3 分钟，超时会通过 `connector:progress` 报错，不会让任务永久挂起。
+- PDF 保存失败会通过 `connector:progress` 报错，但仍无条件进入 finalizer，使已有 paper
+  壳和资源到达 latest target。移动失败时保留 `desired_parent`，不发送错误的稳定路径事件。
 
 ## 兼容端点（`127.0.0.1:23119`）
 

--- a/docs/backend/connector.md
+++ b/docs/backend/connector.md
@@ -13,15 +13,18 @@ Host 在 **`127.0.0.1:23119`** 模拟 Zotero 桌面 Connector HTTP，官方浏�
 - 绑定当前 Vault（本地路径或 `remote:<sessionId>`）。
 - `saveItems` 只在 session 创建时记录的 Library 作用域中写 paper 壳与 catalog；Chrome
   先通过 `saveAttachment` 上传 PDF，只有浏览器未取得附件时才进入 DOI/arXiv fallback。
-- Connector 保存对话框后续发送的 `updateSession` 只更新该 session 的 latest target；附件
-  仍未终结时不移动，成功或失败终结后本地 Vault 统一通过共享 `paper_move` 事务移动一次。
+- 路径术语：`parent_dir` 是初始父目录；`desired_parent` 是请求父目录（该 session 最近一次
+  有效的文件夹选择）；`paper_paths` / `item_map` 保存当前实际论文路径。
+- Connector 保存对话框后续发送的 `updateSession` 只更新该 session 的 `desired_parent`；附件
+  仍未终结时不移动，成功或失败终结后，本地 Vault 统一通过共享 `paper_move` 事务移动一次。
 - `connector:item-saved` 只在初次 finalizer 得到稳定路径后发出；前端随后刷新并打开该路径，
   现有 open/reconcile 流程再按需启动 backend parser。Connector 本身不主动解析。
 - Connector 返回的 Zotero 标签会以 `@zotero:` 前缀保存在 catalog 中，用于保留来源信息；
   这类内部标签不会显示在 Library、Paper Info 或标签筛选中。
 - 远程：stage 后 SFTP；catalog 经 work mirror。
 - PDF 保存失败会通过 `connector:progress` 报错，但仍无条件进入 finalizer，使已有 paper
-  壳和资源到达 latest target。移动失败时保留 `desired_parent`，不发送错误的稳定路径事件。
+  壳和资源到达 `desired_parent`。移动失败时保留 `desired_parent`；错误与回滚语义沿用共享
+  `paper_move` 事务。
 
 ## 兼容端点（`127.0.0.1:23119`）
 

--- a/docs/backend/paper-import.md
+++ b/docs/backend/paper-import.md
@@ -53,9 +53,12 @@ Skill 不写入 catalog、不创建 `papers/` 条目、不执行 `scripts/`。�
 - 失败回滚：文件夹创建后，若 PDF 复制 / NOTES 壳 / catalog 写入任一失败，删除刚建的论文文件夹，避免出现树里有、catalog 无的"半篇论文"；资源下载阶段的错误不回滚（壳与 catalog 已落地）。
 - 孤儿文件夹自愈：`paper_download_assets` 发现盘上论文文件夹缺 catalog 行（历史失败导入的残留）时，按 `metadata.json` sidecar 重建 catalog 行（无 sidecar 退化为文件夹名最小记录）并发 `paper:imported`，Library / 树随之刷新。
 - 网络资源阶段有整篇论文 `3 分钟`截止时间（`PAPER_ASSET_TIMEOUT`），覆盖 PDF
-  fallback、DOI 元数据查询、arXiv e-print 及 Connector 后台下载；单个 HTTP
+  fallback、DOI 元数据查询及 arXiv e-print；单个 HTTP
   请求仍使用更短的 reqwest timeout。超时不会回滚已经写入的 paper 壳和 catalog，
-  资源错误会保留在导入结果/Connector 进度中，后续可再次执行补资源。
+  资源错误会保留在导入结果中，后续可再次执行补资源。
+- Connector 不启动这条后台资源或解析管线：Chrome 先上传附件，DOI/arXiv Host 下载仅作
+  fallback；附件成功或失败的 finalizer 先将 paper 移到 latest target，再通过稳定路径的
+  `connector:item-saved` 交给现有 open/reconcile 解析流程。
 - 错误：全局 Toast；重复不破坏用户 NOTES。
 - 新建壳会写论文全称 alias，并在元数据足够时写确定性短 alias；历史笔记由 [Doctor](doctor.md) 诊断和确认迁移。`created` 不属于入库壳或 Doctor 的职责。
 

--- a/docs/usage/zotero.md
+++ b/docs/usage/zotero.md
@@ -30,7 +30,7 @@ Agentero Connector 服务默认监听本机 `127.0.0.1:23119`。它只接受本�
 4. 确认保存。
 5. 回到 Agentero，等待 Library 和文件树刷新。
 
-保存成功后，Agentero 会创建或更新论文目录，并尽量下载 PDF。部分站点的 PDF 需要登录，Connector 会尝试通过浏览器上传附件；如果仍然失败，可以在论文行上手动选择 Download。
+保存时 Chrome Connector 会先使用当前浏览器登录状态取得并上传 PDF；浏览器未取得附件时，Agentero 才会尝试 DOI/arXiv OA fallback。无论附件成功或失败，已有论文内容都会在保存流程终结时落到保存对话框最后选择的目标目录；如果仍然缺少 PDF，可以在论文行上手动选择 Download。
 
 ## 保存到子文件夹
 

--- a/src-tauri/src/features/catalog/commands.rs
+++ b/src-tauri/src/features/catalog/commands.rs
@@ -16,6 +16,7 @@ use crate::features::wiki::WikiIndexState;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use tauri::State;
 
 #[derive(Debug, Deserialize)]
@@ -252,18 +253,27 @@ pub async fn paper_move(
     args: PaperMoveArgs,
     index: State<'_, WikiIndexState>,
 ) -> Result<ApiResult<PaperMoveResult>, String> {
-    let index = index.handle();
-    Ok(run_blocking(move || {
+    Ok(match paper_move_service(args, index.handle()).await {
+        Ok(result) => ApiResult::ok(result),
+        Err(error) => map_err(error),
+    })
+}
+
+/// Shared application service for callers that need the same complete
+/// filesystem/catalog/wiki transaction as the Tauri command.
+pub(crate) async fn paper_move_service(
+    args: PaperMoveArgs,
+    index: Arc<Mutex<crate::features::wiki::index::WikiIndex>>,
+) -> Result<PaperMoveResult, AppError> {
+    tauri::async_runtime::spawn_blocking(move || {
         let mut guard = match index.lock() {
             Ok(guard) => guard,
-            Err(error) => return map_err(AppError::message(format!("wiki index lock: {error}"))),
+            Err(error) => return Err(AppError::message(format!("wiki index lock: {error}"))),
         };
-        match move_inner(args, &mut guard) {
-            Ok(r) => ApiResult::ok(r),
-            Err(e) => map_err(e),
-        }
+        move_inner(args, &mut guard)
     })
-    .await)
+    .await
+    .map_err(|error| AppError::message(format!("blocking task failed: {error}")))?
 }
 
 fn move_inner(
@@ -327,6 +337,32 @@ mod move_tests {
         assert!(result.link_update.updated_sources.is_empty());
         assert!(!source.exists());
         assert!(vault.join(&result.new_rel).exists());
+        let _ = fs::remove_dir_all(vault);
+    }
+
+    #[tokio::test]
+    async fn shared_paper_move_service_uses_the_same_transaction() {
+        let vault =
+            std::env::temp_dir().join(format!("agentero-shared-paper-move-{}", Uuid::new_v4()));
+        let source = vault.join("papers/inbox/paper-1/NOTES.md");
+        fs::create_dir_all(source.parent().expect("source parent")).expect("create source parent");
+        fs::write(&source, "# Paper\n").expect("write source");
+
+        let result = paper_move_service(
+            PaperMoveArgs {
+                vault_path: vault.to_string_lossy().to_string(),
+                from_rel: "papers/inbox/paper-1".into(),
+                dest_parent_rel: "papers/final".into(),
+                dirty_paths: Vec::new(),
+            },
+            Arc::new(Mutex::new(WikiIndex::default())),
+        )
+        .await
+        .expect("shared move succeeds");
+
+        assert_eq!(result.new_rel, "papers/final/paper-1");
+        assert!(!vault.join("papers/inbox/paper-1").exists());
+        assert!(vault.join("papers/final/paper-1/NOTES.md").is_file());
         let _ = fs::remove_dir_all(vault);
     }
 }

--- a/src-tauri/src/features/connector/import.rs
+++ b/src-tauri/src/features/connector/import.rs
@@ -4,7 +4,7 @@ use super::state::ProgressItem;
 use crate::core::error::AppError;
 use crate::core::fs::WriteOpts;
 use crate::features::catalog::papers;
-use crate::features::connector::{ConnectorController, ConnectorProgress};
+use crate::features::connector::ConnectorController;
 use crate::features::import::{
     enrich_remote_urls, ensure_paper_assets_with_cookies, map_zotero_item, normalize_parent_dir,
     paper_record_from_meta, write_paper_shell_opts, PaperMeta, ZOTERO_INTERNAL_TAG_PREFIX,
@@ -30,12 +30,12 @@ pub struct ConnectorImportResult {
 
 pub async fn import_connector_item_with_cookies(
     ctrl: Arc<ConnectorController>,
-    session_id: &str,
+    _session_id: &str,
     vault: &Path,
     parent_dir: &str,
     item: &Value,
     page_uri: Option<&str>,
-    cookies: Option<&str>,
+    _cookies: Option<&str>,
 ) -> Result<ConnectorImportResult, AppError> {
     use crate::features::import::paper_import::{
         paper_commit, AssetsPolicy, CommitStatus, DedupePolicy, PaperCommitOptions,
@@ -49,12 +49,7 @@ pub async fn import_connector_item_with_cookies(
         .to_string();
 
     let meta = connector_paper_meta(item, page_uri)?;
-    let (abstract_text, arxiv_id, pdf_url, doi) = (
-        meta.abstract_text.clone(),
-        meta.arxiv_id.clone(),
-        meta.pdf_url.clone(),
-        meta.doi.clone(),
-    );
+    let abstract_text = meta.abstract_text.clone();
 
     // No abstract MT and no awaited downloads — the browser extension's HTTP
     // request must finish within ~15s, so assets stay Deferred.
@@ -103,21 +98,6 @@ pub async fn import_connector_item_with_cookies(
         }
     }
 
-    schedule_asset_download_with_cookies(
-        Some(ctrl),
-        session_id,
-        &commit.title,
-        vault.to_path_buf(),
-        commit.path.clone(),
-        paper_dir,
-        commit.id.clone(),
-        arxiv_id,
-        pdf_url,
-        doi,
-        cookies.map(str::to_string),
-        None,
-    );
-
     Ok(ConnectorImportResult {
         path: commit.path,
         id: commit.id,
@@ -128,85 +108,15 @@ pub async fn import_connector_item_with_cookies(
     })
 }
 
-/// Background asset download + liteparse with connector progress events.
-/// With `remote` set, the staged tree is uploaded after parsing (remote vault).
-#[allow(clippy::too_many_arguments)]
-fn schedule_asset_download_with_cookies(
-    ctrl: Option<Arc<ConnectorController>>,
-    session_id: &str,
-    title: &str,
-    vault_root: PathBuf,
-    path_rel: String,
-    paper_dir: PathBuf,
-    id: String,
-    arxiv_id: Option<String>,
-    pdf_url: Option<String>,
-    doi: Option<String>,
-    cookies: Option<String>,
-    remote: Option<Arc<RemoteSession>>,
-) {
-    let session_id = session_id.to_string();
-    let title = title.to_string();
-    let path_key = path_rel.clone();
-    tauri::async_runtime::spawn(async move {
-        let emit = |status: &str, detail: &str, error: Option<String>| {
-            if let Some(ctrl) = ctrl.as_ref() {
-                ctrl.emit_progress(ConnectorProgress {
-                    key: format!("{session_id}:{path_key}"),
-                    session_id: session_id.clone(),
-                    path: path_key.clone(),
-                    title: title.clone(),
-                    status: status.into(),
-                    progress: None,
-                    detail: Some(detail.into()),
-                    error,
-                });
-            }
-        };
-        emit("running", "Downloading paper assets", None);
-        let assets = ensure_paper_assets_with_cookies(
-            &paper_dir,
-            &id,
-            arxiv_id.as_deref(),
-            pdf_url.as_deref(),
-            doi.as_deref(),
-            cookies.as_deref(),
-        )
-        .await;
-        emit("running", "Generating readable paper text", None);
-        let parse = crate::features::import::pdf_parse::maybe_generate_paper_md_after_download(
-            &vault_root,
-            &path_rel,
-            &paper_dir,
-        )
-        .await;
-        let upload = match &remote {
-            Some(session) => upload_tree(session.fs.as_ref(), &paper_dir, &path_rel).await,
-            None => Ok(()),
-        };
-        let error = match (&assets, &parse, &upload) {
-            (Err(e), _, _) => Some(e.to_string()),
-            (_, p, _) if !p.messages.is_empty() && !p.paper_md => Some(p.messages.join("; ")),
-            (_, _, Err(e)) => Some(e.to_string()),
-            _ => None,
-        };
-        if error.is_some() {
-            emit("failed", "Asset download failed", error);
-        } else {
-            emit("completed", "Assets ready", None);
-        }
-    });
-}
-
-/// Remote vault variant: stage shell → SFTP → catalog push; assets in background.
+/// Remote vault variant: stage the shell, upload it, and push the catalog.
 pub async fn import_connector_item_remote_with_cookies(
-    ctrl: Arc<ConnectorController>,
-    session_id: &str,
+    _ctrl: Arc<ConnectorController>,
+    _session_id: &str,
     session: Arc<RemoteSession>,
     parent_dir: &str,
     item: &Value,
     page_uri: Option<&str>,
-    cookies: Option<&str>,
+    _cookies: Option<&str>,
 ) -> Result<ConnectorImportResult, AppError> {
     let parent_rel = normalize_parent_dir(parent_dir)?;
     let connector_item_id = item.get("id").cloned().unwrap_or(Value::Null);
@@ -256,21 +166,6 @@ pub async fn import_connector_item_remote_with_cookies(
         let mut cat = session.catalog.lock().await;
         cat.push(session.fs.clone()).await?;
     }
-
-    schedule_asset_download_with_cookies(
-        Some(ctrl),
-        session_id,
-        &meta.title,
-        session.work_root.clone(),
-        path_rel.clone(),
-        staging,
-        meta.id.clone(),
-        meta.arxiv_id.clone(),
-        meta.pdf_url.clone(),
-        meta.doi.clone(),
-        cookies.map(str::to_string),
-        Some(session.clone()),
-    );
 
     Ok(ConnectorImportResult {
         path: path_rel,
@@ -323,7 +218,7 @@ pub async fn write_snapshot_html_remote(
     Ok(path)
 }
 
-/// Write browser-uploaded PDF into a remote paper folder and best-effort PAPER.md.
+/// Write a browser-uploaded PDF into a remote paper folder.
 pub async fn write_attachment_pdf_remote(
     session: Arc<RemoteSession>,
     paper_rel: &str,
@@ -348,36 +243,6 @@ pub async fn write_attachment_pdf_remote(
             },
         )
         .await?;
-
-    // Stage for liteparse then push PAPER.md if generated.
-    let staging = session.work_root.join(&rel);
-    let _ = fs::create_dir_all(&staging);
-    let _ = fs::write(staging.join(format!("{id}.pdf")), bytes);
-    let session_bg = session.clone();
-    let rel_bg = rel.clone();
-    tauri::async_runtime::spawn(async move {
-        let _ = crate::features::import::pdf_parse::maybe_generate_paper_md_after_download(
-            &session_bg.work_root,
-            &rel_bg,
-            &session_bg.work_root.join(&rel_bg),
-        )
-        .await;
-        let paper_md = session_bg.work_root.join(&rel_bg).join("PAPER.md");
-        if paper_md.is_file() {
-            if let Ok(md) = fs::read(&paper_md) {
-                let _ = session_bg
-                    .fs
-                    .write(
-                        &format!("{rel_bg}/PAPER.md"),
-                        &md,
-                        WriteOpts {
-                            create_parents: true,
-                        },
-                    )
-                    .await;
-            }
-        }
-    });
 
     Ok(rel)
 }
@@ -599,8 +464,8 @@ fn decode_connector_title(raw: &str) -> String {
 /// Browser-uploaded **standalone** PDF (no parent bibliographic item).
 /// Used when the user saves an open PDF tab via the Connector icon.
 ///
-/// Creates a session + paper shell, writes `{id}.pdf`, schedules liteparse in
-/// the background, and returns metadata for the HTTP 201 body.
+/// Creates a session + paper shell, writes `{id}.pdf`, and returns metadata for
+/// the HTTP 201 body. Parsing is triggered only after `connector:item-saved`.
 /// Official Zotero returns `{ canRecognize }`; we return `canRecognize: false`
 /// because `/connector/getRecognizedItem` is not implemented yet.
 pub async fn import_standalone_attachment(
@@ -680,20 +545,29 @@ pub async fn import_standalone_attachment(
         .await?
     };
 
-    ctrl.record_session_paper(session_id, &result.path);
-    // Map by URL (official uses attachment URL as connector key for standalone).
-    if let Some(u) = url.map(str::trim).filter(|s| !s.is_empty()) {
-        ctrl.record_session_item_paper(session_id, u, &result.path);
-    }
-    ctrl.record_session_item_paper(session_id, &result.id, &result.path);
-    ctrl.emit_item_saved(crate::features::connector::ConnectorItemSaved {
+    let item_key = url
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(&result.id);
+    let saved = crate::features::connector::ConnectorItemSaved {
         path: result.path.clone(),
         id: result.id.clone(),
         title: result.title.clone(),
         deduped: result.deduped,
         session_id: session_id.to_string(),
-    });
+    };
+    ctrl.record_session_import(session_id, item_key, saved.clone(), false)?;
+    // Official standalone saves may address the item by URL or resolved id.
+    if let Some(u) = url.map(str::trim).filter(|value| !value.is_empty()) {
+        ctrl.record_session_item_paper(session_id, u, &result.path);
+    }
+    ctrl.record_session_item_paper(session_id, &result.id, &result.path);
     ctrl.mark_session_done(session_id);
+    if result.deduped {
+        ctrl.emit_item_saved(saved);
+    } else {
+        ctrl.finalize_session_if_ready(session_id).await?;
+    }
     Ok(result)
 }
 
@@ -708,8 +582,7 @@ async fn import_standalone_local(
         paper_commit, AssetsPolicy, CommitStatus, DedupePolicy, PaperCommitOptions,
     };
 
-    // Avoid blocking the Connector HTTP request on liteparse (can exceed 60s).
-    // Deferred + manual PDF write; liteparse runs in the background.
+    // Keep commit deferred; parser jobs are requested after connector:item-saved.
     let title = meta.title.clone();
     let commit = paper_commit(
         meta,
@@ -738,16 +611,6 @@ async fn import_standalone_local(
 
     let paper_dir = PathBuf::from(&commit.paper_dir);
     fs::write(paper_dir.join(format!("{}.pdf", commit.id)), bytes)?;
-
-    let vault_bg = vault.to_path_buf();
-    let path_rel = commit.path.clone();
-    let dir_bg = paper_dir;
-    tauri::async_runtime::spawn(async move {
-        let _ = crate::features::import::pdf_parse::maybe_generate_paper_md_after_download(
-            &vault_bg, &path_rel, &dir_bg,
-        )
-        .await;
-    });
 
     Ok(ConnectorImportResult {
         path: commit.path,
@@ -803,32 +666,6 @@ async fn import_standalone_remote(
         let mut cat = session.catalog.lock().await;
         cat.push(session.fs.clone()).await?;
     }
-
-    let session_bg = session.clone();
-    let rel_bg = path_rel.clone();
-    tauri::async_runtime::spawn(async move {
-        let _ = crate::features::import::pdf_parse::maybe_generate_paper_md_after_download(
-            &session_bg.work_root,
-            &rel_bg,
-            &session_bg.work_root.join(&rel_bg),
-        )
-        .await;
-        let paper_md = session_bg.work_root.join(&rel_bg).join("PAPER.md");
-        if paper_md.is_file() {
-            if let Ok(md) = fs::read(&paper_md) {
-                let _ = session_bg
-                    .fs
-                    .write(
-                        &format!("{rel_bg}/PAPER.md"),
-                        &md,
-                        WriteOpts {
-                            create_parents: true,
-                        },
-                    )
-                    .await;
-            }
-        }
-    });
 
     Ok(ConnectorImportResult {
         path: path_rel,
@@ -897,24 +734,11 @@ pub async fn save_attachment_from_resolver(
         if !assets.pdf && !crate::features::import::has_local_pdf(&paper_dir) {
             return Err(AppError::message("Failed to save an attachment"));
         }
-        let _ = crate::features::import::pdf_parse::maybe_generate_paper_md_after_download(
-            &session.work_root,
-            &paper_rel,
-            &paper_dir,
-        )
-        .await;
         upload_tree(session.fs.as_ref(), &paper_dir, &paper_rel).await?;
         {
             let mut cat = session.catalog.lock().await;
             cat.push(session.fs.clone()).await?;
         }
-        ctrl.emit_item_saved(crate::features::connector::ConnectorItemSaved {
-            path: paper_rel.clone(),
-            id: id.clone(),
-            title: id,
-            deduped: false,
-            session_id: session_id.to_string(),
-        });
         return Ok("Full Text PDF".into());
     }
 
@@ -935,17 +759,6 @@ pub async fn save_attachment_from_resolver(
     if !assets.pdf && !crate::features::import::has_local_pdf(&paper_dir) {
         return Err(AppError::message("Failed to save an attachment"));
     }
-    let _ = crate::features::import::pdf_parse::maybe_generate_paper_md_after_download(
-        &vault, &paper_rel, &paper_dir,
-    )
-    .await;
-    ctrl.emit_item_saved(crate::features::connector::ConnectorItemSaved {
-        path: paper_rel.clone(),
-        id: id.clone(),
-        title: id,
-        deduped: false,
-        session_id: session_id.to_string(),
-    });
     Ok("Full Text PDF".into())
 }
 

--- a/src-tauri/src/features/connector/server.rs
+++ b/src-tauri/src/features/connector/server.rs
@@ -385,22 +385,29 @@ async fn save_items(
 
         match import_result {
             Ok(r) => {
-                if !r.deduped {
-                    state.ctrl.record_session_paper(&session_id, &r.path);
-                }
-                // Remember connector item id → paper so saveAttachment / resolvers resolve.
-                state.ctrl.record_session_item_paper(
-                    &session_id,
-                    &connector_item_key(&r.connector_item_id),
-                    &r.path,
-                );
-                state.ctrl.emit_item_saved(ConnectorItemSaved {
+                let item_key = connector_item_key(&r.connector_item_id);
+                let saved = ConnectorItemSaved {
                     path: r.path.clone(),
                     id: r.id.clone(),
                     title: r.title.clone(),
                     deduped: r.deduped,
                     session_id: session_id.clone(),
-                });
+                };
+                if let Err(error) =
+                    state
+                        .ctrl
+                        .record_session_import(&session_id, &item_key, saved.clone(), true)
+                {
+                    state.ctrl.emit_error(&error.to_string(), Some(&session_id));
+                    state.ctrl.mark_session_done(&session_id);
+                    return json_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        json!({ "error": error.to_string() }),
+                    );
+                }
+                if r.deduped {
+                    state.ctrl.emit_item_saved(saved);
+                }
                 let mut atts = Vec::new();
                 if let Some(arr) = item.get("attachments").and_then(|v| v.as_array()) {
                     for (ai, a) in arr.iter().enumerate() {
@@ -585,12 +592,6 @@ async fn save_snapshot(
             );
         }
     };
-    state.ctrl.record_session_paper(&session_id, &result.path);
-    state.ctrl.record_session_item_paper(
-        &session_id,
-        &connector_item_key(&item["id"]),
-        &result.path,
-    );
     if let Some(html) = body.html.as_deref().filter(|s| !s.is_empty()) {
         let write_result = if let Some(sid) = parse_remote_handle(&handle) {
             match state.ctrl.remote_registry() {
@@ -608,13 +609,32 @@ async fn save_snapshot(
         }
     }
     state.ctrl.mark_session_done(&session_id);
-    state.ctrl.emit_item_saved(ConnectorItemSaved {
+    let saved = ConnectorItemSaved {
         path: result.path.clone(),
         id: result.id.clone(),
         title: result.title.clone(),
         deduped: result.deduped,
         session_id: session_id.clone(),
-    });
+    };
+    if let Err(error) = state.ctrl.record_session_import(
+        &session_id,
+        &connector_item_key(&item["id"]),
+        saved.clone(),
+        false,
+    ) {
+        return json_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            json!({ "error": error.to_string() }),
+        );
+    }
+    if result.deduped {
+        state.ctrl.emit_item_saved(saved);
+    } else if let Err(error) = state.ctrl.finalize_session_if_ready(&session_id).await {
+        return json_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            json!({ "error": error.to_string() }),
+        );
+    }
     json_response(StatusCode::CREATED, json!({ "singleFile": false }))
 }
 
@@ -835,11 +855,64 @@ async fn save_attachment(
         })
         .filter(|s| !s.is_empty());
 
-    match state
+    if let Err(error) = state
         .ctrl
-        .write_attachment_pdf(&session_id, parent_item_id.as_deref(), &body)
+        .begin_browser_attachment(&session_id, parent_item_id.as_deref())
         .await
     {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            json!({ "error": error.to_string() }),
+        );
+    }
+    state.ctrl.emit_attachment_progress(
+        &session_id,
+        parent_item_id.as_deref(),
+        "running",
+        "Saving browser PDF",
+        None,
+    );
+    let write_result = state
+        .ctrl
+        .write_attachment_pdf(&session_id, parent_item_id.as_deref(), &body)
+        .await;
+    match &write_result {
+        Ok(_) => state.ctrl.emit_attachment_progress(
+            &session_id,
+            parent_item_id.as_deref(),
+            "completed",
+            "Browser PDF saved",
+            None,
+        ),
+        Err(error) => state.ctrl.emit_attachment_progress(
+            &session_id,
+            parent_item_id.as_deref(),
+            "failed",
+            "Browser PDF save failed",
+            Some(error.to_string()),
+        ),
+    }
+    let finalize_result = state
+        .ctrl
+        .complete_attachment(
+            &session_id,
+            parent_item_id.as_deref(),
+            write_result.is_ok(),
+            true,
+        )
+        .await;
+    let result = match (write_result, finalize_result) {
+        (Ok(path), Ok(())) => Ok(state
+            .ctrl
+            .session_item_paper(&session_id, parent_item_id.as_deref())
+            .unwrap_or(path)),
+        (Err(error), Ok(())) | (Ok(_), Err(error)) => Err(error),
+        (Err(write_error), Err(finalize_error)) => Err(AppError::message(format!(
+            "{write_error}; finalizer: {finalize_error}"
+        ))),
+    };
+
+    match result {
         Ok(path) => json_response(StatusCode::CREATED, json!({ "path": path })),
         Err(e) => {
             let msg = e.to_string();
@@ -977,7 +1050,25 @@ async fn has_attachment_resolvers(
         );
     };
     match session_has_attachment_resolvers(state.ctrl.as_ref(), &session_id, &item_id).await {
-        Ok(has) => json_response(StatusCode::OK, json!(has)),
+        Ok(has) => {
+            if !has {
+                state.ctrl.emit_attachment_progress(
+                    &session_id,
+                    Some(&item_id),
+                    "failed",
+                    "Browser PDF failed and no fallback resolver is available",
+                    Some("Failed to save an attachment".into()),
+                );
+                if let Err(error) = state
+                    .ctrl
+                    .complete_attachment(&session_id, Some(&item_id), false, false)
+                    .await
+                {
+                    state.ctrl.emit_error(&error.to_string(), Some(&session_id));
+                }
+            }
+            json_response(StatusCode::OK, json!(has))
+        }
         Err(e) => {
             let msg = e.to_string();
             if msg.contains("SESSION_NOT_FOUND") {
@@ -987,6 +1078,20 @@ async fn has_attachment_resolvers(
                 )
             } else {
                 // Soft-fail: tell the extension there are no resolvers.
+                state.ctrl.emit_attachment_progress(
+                    &session_id,
+                    Some(&item_id),
+                    "failed",
+                    "Fallback resolver check failed",
+                    Some(msg),
+                );
+                if let Err(error) = state
+                    .ctrl
+                    .complete_attachment(&session_id, Some(&item_id), false, false)
+                    .await
+                {
+                    state.ctrl.emit_error(&error.to_string(), Some(&session_id));
+                }
                 json_response(StatusCode::OK, json!(false))
             }
         }
@@ -1019,7 +1124,54 @@ async fn save_attachment_from_resolver_handler(
             json!({ "error": "ITEM_ID_NOT_PROVIDED" }),
         );
     };
-    match save_attachment_from_resolver(state.ctrl.clone(), &session_id, &item_id).await {
+    if let Err(error) = state
+        .ctrl
+        .begin_fallback_attachment(&session_id, &item_id)
+        .await
+    {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            json!({ "error": error.to_string() }),
+        );
+    }
+    state.ctrl.emit_attachment_progress(
+        &session_id,
+        Some(&item_id),
+        "running",
+        "Downloading PDF from DOI/arXiv fallback",
+        None,
+    );
+    let save_result =
+        save_attachment_from_resolver(state.ctrl.clone(), &session_id, &item_id).await;
+    match &save_result {
+        Ok(_) => state.ctrl.emit_attachment_progress(
+            &session_id,
+            Some(&item_id),
+            "completed",
+            "Fallback PDF saved",
+            None,
+        ),
+        Err(error) => state.ctrl.emit_attachment_progress(
+            &session_id,
+            Some(&item_id),
+            "failed",
+            "Fallback PDF save failed",
+            Some(error.to_string()),
+        ),
+    }
+    let finalize_result = state
+        .ctrl
+        .complete_attachment(&session_id, Some(&item_id), save_result.is_ok(), true)
+        .await;
+    let result = match (save_result, finalize_result) {
+        (Ok(title), Ok(())) => Ok(title),
+        (Err(error), Ok(())) | (Ok(_), Err(error)) => Err(error),
+        (Err(save_error), Err(finalize_error)) => Err(AppError::message(format!(
+            "{save_error}; finalizer: {finalize_error}"
+        ))),
+    };
+
+    match result {
         Ok(title) => text_response(StatusCode::CREATED, "text/plain", &title),
         Err(e) => {
             let msg = e.to_string();

--- a/src-tauri/src/features/connector/state.rs
+++ b/src-tauri/src/features/connector/state.rs
@@ -7,8 +7,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use tauri::{AppHandle, Emitter};
-use tokio::sync::oneshot;
+use tauri::{AppHandle, Emitter, Manager};
+use tokio::sync::{oneshot, Mutex as AsyncMutex};
 
 /// Default Zotero Connector port (must match official extension default).
 pub const DEFAULT_CONNECTOR_PORT: u16 = 23119;
@@ -67,17 +67,43 @@ pub struct ProgressItem {
     pub attachments: Vec<ProgressAttachment>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttachmentPhase {
+    AwaitingBrowserOrResolver,
+    WritingBrowser,
+    WritingFallback,
+    TerminalSuccess,
+    TerminalFailure,
+}
+
+impl AttachmentPhase {
+    fn is_terminal(self) -> bool {
+        matches!(self, Self::TerminalSuccess | Self::TerminalFailure)
+    }
+}
+
 #[derive(Debug)]
 pub struct SaveSession {
     pub created: std::time::Instant,
     pub items: Vec<ProgressItem>,
     pub done: bool,
-    /// Vault-relative parent (`papers` or `papers/…`) for this save session.
+    /// Immutable initial Vault-relative parent copied from the current Library scope.
     pub parent_dir: String,
+    /// Latest collection-picker target waiting to be applied after attachment IO.
+    pub desired_parent: Option<String>,
     /// Paper folders created in this session (vault-relative), for updateSession moves.
     pub paper_paths: Vec<String>,
     /// Connector item id (stringified) → paper folder path; resolves `saveAttachment` `parentItemID`.
     pub item_map: HashMap<String, String>,
+    /// Per-item primary attachment acquisition state. Deduped items are excluded.
+    pub attachment_phase: HashMap<String, AttachmentPhase>,
+    /// Attachment handlers currently writing into session-owned paper folders.
+    pub active_writers: usize,
+    /// Completion events held until every new item has a stable final path.
+    pub pending_saved: Vec<ConnectorItemSaved>,
+    pub initial_finalized: bool,
+    /// Serializes finalization and collection moves without blocking browser downloads.
+    pub io_gate: Arc<AsyncMutex<()>>,
 }
 
 struct Inner {
@@ -399,9 +425,15 @@ impl ConnectorController {
                 created: std::time::Instant::now(),
                 items,
                 done: false,
-                parent_dir,
+                parent_dir: parent_dir.clone(),
+                desired_parent: Some(parent_dir),
                 paper_paths: Vec::new(),
                 item_map: HashMap::new(),
+                attachment_phase: HashMap::new(),
+                active_writers: 0,
+                pending_saved: Vec::new(),
+                initial_finalized: false,
+                io_gate: Arc::new(AsyncMutex::new(())),
             },
         );
         Ok(())
@@ -416,12 +448,47 @@ impl ConnectorController {
             .unwrap_or_else(|| g.parent_dir.clone())
     }
 
-    pub fn record_session_paper(&self, session_id: &str, paper_path: &str) {
-        if let Ok(mut g) = self.inner.lock() {
-            if let Some(s) = g.sessions.get_mut(session_id) {
-                s.paper_paths.push(paper_path.replace('\\', "/"));
-            }
+    /// Record one imported item. New papers remain pending until their primary
+    /// attachment path is terminal; deduped papers are mapped but never moved.
+    pub fn record_session_import(
+        &self,
+        session_id: &str,
+        connector_item_id: &str,
+        mut payload: ConnectorItemSaved,
+        waits_for_attachment: bool,
+    ) -> Result<(), AppError> {
+        let mut g = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let session = g
+            .sessions
+            .get_mut(session_id)
+            .ok_or_else(|| AppError::message("SESSION_NOT_FOUND"))?;
+        payload.path = payload.path.replace('\\', "/");
+        let item_key = if connector_item_id.is_empty() {
+            payload.id.clone()
+        } else {
+            connector_item_id.to_string()
+        };
+        if !item_key.is_empty() {
+            session
+                .item_map
+                .insert(item_key.clone(), payload.path.clone());
         }
+        if payload.deduped {
+            return Ok(());
+        }
+        if !session.paper_paths.contains(&payload.path) {
+            session.paper_paths.push(payload.path.clone());
+        }
+        session.attachment_phase.insert(
+            item_key,
+            if waits_for_attachment {
+                AttachmentPhase::AwaitingBrowserOrResolver
+            } else {
+                AttachmentPhase::TerminalSuccess
+            },
+        );
+        session.pending_saved.push(payload);
+        Ok(())
     }
 
     /// Map a Connector item id (stringified) to its paper folder, so a later
@@ -468,6 +535,111 @@ impl ConnectorController {
         Ok(session.item_map.get(item_id).cloned())
     }
 
+    fn session_io_gate(&self, session_id: &str) -> Result<Arc<AsyncMutex<()>>, AppError> {
+        let g = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        g.sessions
+            .get(session_id)
+            .map(|session| Arc::clone(&session.io_gate))
+            .ok_or_else(|| AppError::message("SESSION_NOT_FOUND"))
+    }
+
+    fn attachment_key(session: &SaveSession, item_id: Option<&str>) -> Option<String> {
+        if let Some(item_id) = item_id.filter(|id| !id.is_empty()) {
+            if session.attachment_phase.contains_key(item_id) {
+                return Some(item_id.to_string());
+            }
+            if let Some(path) = session.item_map.get(item_id) {
+                if let Some(key) = session.attachment_phase.keys().find(|key| {
+                    session
+                        .item_map
+                        .get(*key)
+                        .is_some_and(|candidate| candidate == path)
+                }) {
+                    return Some(key.clone());
+                }
+            }
+        }
+        if session.attachment_phase.len() == 1 {
+            return session.attachment_phase.keys().next().cloned();
+        }
+        None
+    }
+
+    fn set_attachment_writing(
+        &self,
+        session_id: &str,
+        item_id: Option<&str>,
+        phase: AttachmentPhase,
+    ) -> Result<(), AppError> {
+        let mut g = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let session = g
+            .sessions
+            .get_mut(session_id)
+            .ok_or_else(|| AppError::message("SESSION_NOT_FOUND"))?;
+        session.active_writers += 1;
+        if let Some(key) = Self::attachment_key(session, item_id) {
+            session.attachment_phase.insert(key, phase);
+        }
+        Ok(())
+    }
+
+    pub async fn begin_browser_attachment(
+        &self,
+        session_id: &str,
+        item_id: Option<&str>,
+    ) -> Result<(), AppError> {
+        let gate = self.session_io_gate(session_id)?;
+        let _guard = gate.lock().await;
+        self.set_attachment_writing(session_id, item_id, AttachmentPhase::WritingBrowser)
+    }
+
+    pub async fn begin_fallback_attachment(
+        &self,
+        session_id: &str,
+        item_id: &str,
+    ) -> Result<(), AppError> {
+        let gate = self.session_io_gate(session_id)?;
+        let _guard = gate.lock().await;
+        self.set_attachment_writing(session_id, Some(item_id), AttachmentPhase::WritingFallback)
+    }
+
+    pub fn emit_attachment_progress(
+        &self,
+        session_id: &str,
+        item_id: Option<&str>,
+        status: &str,
+        detail: &str,
+        error: Option<String>,
+    ) {
+        let context = {
+            let g = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            g.sessions.get(session_id).and_then(|session| {
+                let key = Self::attachment_key(session, item_id)?;
+                let path = session.item_map.get(&key)?.clone();
+                let title = session
+                    .pending_saved
+                    .iter()
+                    .find(|saved| saved.path == path)
+                    .map(|saved| saved.title.clone())
+                    .unwrap_or_else(|| key.clone());
+                Some((path, title))
+            })
+        };
+        let Some((path, title)) = context else {
+            return;
+        };
+        self.emit_progress(ConnectorProgress {
+            key: format!("{session_id}:{path}"),
+            session_id: session_id.to_string(),
+            path,
+            title,
+            status: status.to_string(),
+            progress: None,
+            detail: Some(detail.to_string()),
+            error,
+        });
+    }
+
     /// Resolve paper rel for a `saveAttachment` upload (session map / last paper).
     fn resolve_attachment_rel(
         &self,
@@ -510,16 +682,7 @@ impl ConnectorController {
                 .remote_registry()
                 .ok_or_else(|| AppError::message("remote registry unavailable"))?;
             let session = reg.get(sid).await?;
-            let rel = super::import::write_attachment_pdf_remote(session, &rel, bytes).await?;
-            let id = rel.rsplit('/').next().unwrap_or("paper").to_string();
-            self.emit_item_saved(ConnectorItemSaved {
-                path: rel.clone(),
-                id: id.clone(),
-                title: id,
-                deduped: false,
-                session_id: session_id.to_string(),
-            });
-            return Ok(rel);
+            return super::import::write_attachment_pdf_remote(session, &rel, bytes).await;
         }
 
         let vault = PathBuf::from(&handle);
@@ -529,23 +692,6 @@ impl ConnectorController {
         }
         let id = rel.rsplit('/').next().unwrap_or("paper").to_string();
         std::fs::write(paper_dir.join(format!("{id}.pdf")), bytes)?;
-
-        self.emit_item_saved(ConnectorItemSaved {
-            path: rel.clone(),
-            id: id.clone(),
-            title: id.clone(),
-            deduped: false,
-            session_id: session_id.to_string(),
-        });
-
-        let rel_bg = rel.clone();
-        let dir_bg = paper_dir;
-        tauri::async_runtime::spawn(async move {
-            let _ = crate::features::import::pdf_parse::maybe_generate_paper_md_after_download(
-                &vault, &rel_bg, &dir_bg,
-            )
-            .await;
-        });
         Ok(rel)
     }
 
@@ -557,7 +703,184 @@ impl ConnectorController {
         }
     }
 
-    /// Apply Connector collection picker change: remember parent + move papers already saved.
+    fn path_is_in_parent(path: &str, parent: &str) -> bool {
+        path.rsplit_once('/')
+            .is_some_and(|(current_parent, _)| current_parent == parent)
+    }
+
+    fn rebase_path(value: &str, from: &str, to: &str) -> String {
+        if value == from {
+            return to.to_string();
+        }
+        value
+            .strip_prefix(from)
+            .filter(|suffix| suffix.starts_with('/'))
+            .map(|suffix| format!("{to}{suffix}"))
+            .unwrap_or_else(|| value.to_string())
+    }
+
+    fn rebase_session_path(&self, session_id: &str, from: &str, to: &str) {
+        if from == to {
+            return;
+        }
+        if let Ok(mut g) = self.inner.lock() {
+            if let Some(session) = g.sessions.get_mut(session_id) {
+                for path in &mut session.paper_paths {
+                    *path = Self::rebase_path(path, from, to);
+                }
+                for path in session.item_map.values_mut() {
+                    *path = Self::rebase_path(path, from, to);
+                }
+                for saved in &mut session.pending_saved {
+                    saved.path = Self::rebase_path(&saved.path, from, to);
+                }
+            }
+        }
+    }
+
+    async fn move_paper_to_parent(
+        &self,
+        vault_handle: &str,
+        from: &str,
+        parent: &str,
+    ) -> Result<String, AppError> {
+        if Self::path_is_in_parent(from, parent) {
+            return Ok(from.to_string());
+        }
+        if let Some(sid) = crate::features::remote::parse_remote_handle(vault_handle) {
+            let reg = self
+                .remote_registry()
+                .ok_or_else(|| AppError::message("remote registry unavailable"))?;
+            let session = reg.get(sid).await?;
+            return super::import::move_paper_folder_remote(&session, from, parent).await;
+        }
+
+        let app = self
+            .app_handle()
+            .ok_or_else(|| AppError::message("Connector app handle unavailable"))?;
+        let index = app
+            .state::<crate::features::wiki::WikiIndexState>()
+            .handle();
+        let result = crate::features::catalog::commands::paper_move_service(
+            crate::features::catalog::commands::PaperMoveArgs {
+                vault_path: vault_handle.to_string(),
+                from_rel: from.to_string(),
+                dest_parent_rel: parent.to_string(),
+                dirty_paths: Vec::new(),
+            },
+            index,
+        )
+        .await?;
+        Ok(result.new_rel)
+    }
+
+    /// Apply a ready desired target while the caller holds this session's IO gate.
+    async fn apply_ready_session_target(&self, session_id: &str) -> Result<(), AppError> {
+        let (vault_handle, desired_parent, paths) = {
+            let g = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            let session = g
+                .sessions
+                .get(session_id)
+                .ok_or_else(|| AppError::message("SESSION_NOT_FOUND"))?;
+            if session.active_writers != 0
+                || session.attachment_phase.is_empty()
+                || session
+                    .attachment_phase
+                    .values()
+                    .any(|phase| !phase.is_terminal())
+            {
+                return Ok(());
+            }
+            let Some(parent) = session.desired_parent.clone() else {
+                return Ok(());
+            };
+            let handle = g
+                .vault_handle
+                .clone()
+                .ok_or_else(|| AppError::message("No vault open"))?;
+            (handle, parent, session.paper_paths.clone())
+        };
+
+        for from in paths {
+            let new_rel = match self
+                .move_paper_to_parent(&vault_handle, &from, &desired_parent)
+                .await
+            {
+                Ok(path) => path,
+                Err(error) => {
+                    self.emit_error(
+                        &format!("move {from} to {desired_parent}: {error}"),
+                        Some(session_id),
+                    );
+                    return Err(error);
+                }
+            };
+            self.rebase_session_path(session_id, &from, &new_rel);
+        }
+
+        let pending = {
+            let mut g = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            let session = g
+                .sessions
+                .get_mut(session_id)
+                .ok_or_else(|| AppError::message("SESSION_NOT_FOUND"))?;
+            session.desired_parent = None;
+            if session.initial_finalized {
+                Vec::new()
+            } else {
+                session.initial_finalized = true;
+                std::mem::take(&mut session.pending_saved)
+            }
+        };
+        for saved in pending {
+            self.emit_item_saved(saved);
+        }
+        Ok(())
+    }
+
+    pub async fn complete_attachment(
+        &self,
+        session_id: &str,
+        item_id: Option<&str>,
+        success: bool,
+        writer_finished: bool,
+    ) -> Result<(), AppError> {
+        let gate = self.session_io_gate(session_id)?;
+        let _guard = gate.lock().await;
+        {
+            let mut g = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            let session = g
+                .sessions
+                .get_mut(session_id)
+                .ok_or_else(|| AppError::message("SESSION_NOT_FOUND"))?;
+            if writer_finished {
+                session.active_writers =
+                    session.active_writers.checked_sub(1).ok_or_else(|| {
+                        AppError::message("attachment writer completion without a matching start")
+                    })?;
+            }
+            if let Some(key) = Self::attachment_key(session, item_id) {
+                session.attachment_phase.insert(
+                    key,
+                    if success {
+                        AttachmentPhase::TerminalSuccess
+                    } else {
+                        AttachmentPhase::TerminalFailure
+                    },
+                );
+            }
+        }
+        self.apply_ready_session_target(session_id).await
+    }
+
+    pub async fn finalize_session_if_ready(&self, session_id: &str) -> Result<(), AppError> {
+        let gate = self.session_io_gate(session_id)?;
+        let _guard = gate.lock().await;
+        self.apply_ready_session_target(session_id).await
+    }
+
+    /// Remember the latest collection picker target. Pending attachment IO only
+    /// changes desired state; terminal sessions use the shared paper move.
     pub async fn update_session_target(
         &self,
         session_id: &str,
@@ -567,69 +890,29 @@ impl ConnectorController {
             AppError::message(format!("unknown or invalid save target: {target}"))
         })?;
 
-        let (handle, paths_to_move) = {
+        let gate = {
             let mut g = self.inner.lock().unwrap_or_else(|e| e.into_inner());
             g.parent_dir = parent.clone();
-            let handle = g
-                .vault_handle
-                .clone()
-                .ok_or_else(|| AppError::message("No vault open"))?;
+            if g.vault_handle.is_none() {
+                return Err(AppError::message("No vault open"));
+            }
+            let session = g
+                .sessions
+                .get(session_id)
+                .ok_or_else(|| AppError::message("SESSION_NOT_FOUND"))?;
+            Arc::clone(&session.io_gate)
+        };
+
+        let _guard = gate.lock().await;
+        {
+            let mut g = self.inner.lock().unwrap_or_else(|e| e.into_inner());
             let session = g
                 .sessions
                 .get_mut(session_id)
                 .ok_or_else(|| AppError::message("SESSION_NOT_FOUND"))?;
-            session.parent_dir = parent.clone();
-            let paths = session.paper_paths.clone();
-            (handle, paths)
-        };
-
-        let mut new_paths = Vec::new();
-        if let Some(sid) = crate::features::remote::parse_remote_handle(&handle) {
-            let reg = self
-                .remote_registry()
-                .ok_or_else(|| AppError::message("remote registry unavailable"))?;
-            let session = reg.get(sid).await?;
-            for from in &paths_to_move {
-                match super::import::move_paper_folder_remote(&session, from, &parent).await {
-                    Ok(new_rel) => new_paths.push(new_rel),
-                    Err(e) => {
-                        self.emit_error(&format!("move {from}: {e}"), Some(session_id));
-                        new_paths.push(from.clone());
-                    }
-                }
-            }
-        } else {
-            let vault = PathBuf::from(&handle);
-            for from in &paths_to_move {
-                match crate::features::catalog::move_paper_under(&vault, from, &parent) {
-                    Ok(new_rel) => new_paths.push(new_rel),
-                    Err(e) => {
-                        self.emit_error(&format!("move {from}: {e}"), Some(session_id));
-                        new_paths.push(from.clone());
-                    }
-                }
-            }
+            session.desired_parent = Some(parent.clone());
         }
-
-        if !new_paths.is_empty() {
-            if let Ok(mut g) = self.inner.lock() {
-                if let Some(s) = g.sessions.get_mut(session_id) {
-                    s.paper_paths = new_paths.clone();
-                }
-            }
-            for path in &new_paths {
-                if let Some(id) = path.rsplit('/').next() {
-                    self.emit_item_saved(ConnectorItemSaved {
-                        path: path.clone(),
-                        id: id.to_string(),
-                        title: id.to_string(),
-                        deduped: false,
-                        session_id: session_id.to_string(),
-                    });
-                }
-            }
-        }
-
+        self.apply_ready_session_target(session_id).await?;
         Ok(parent)
     }
 
@@ -880,6 +1163,16 @@ impl ConnectorController {
 mod tests {
     use super::*;
 
+    fn saved(session_id: &str, path: &str) -> ConnectorItemSaved {
+        ConnectorItemSaved {
+            path: path.to_string(),
+            id: path.rsplit('/').next().unwrap_or("paper").to_string(),
+            title: "Paper".into(),
+            deduped: false,
+            session_id: session_id.to_string(),
+        }
+    }
+
     #[test]
     fn set_vault_accepts_remote_handle() {
         let ctrl = ConnectorController::new();
@@ -916,5 +1209,214 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn session_keeps_initial_parent_and_tracks_desired_parent_separately() {
+        let ctrl = ConnectorController::new();
+        ctrl.set_parent_dir("papers/inbox".into());
+        ctrl.create_session("s1", Vec::new()).expect("session");
+        ctrl.set_parent_dir("papers/later".into());
+
+        let g = ctrl.inner.lock().expect("state");
+        let session = g.sessions.get("s1").expect("saved session");
+        assert_eq!(session.parent_dir, "papers/inbox");
+        assert_eq!(session.desired_parent.as_deref(), Some("papers/inbox"));
+        assert_eq!(g.parent_dir, "papers/later");
+    }
+
+    #[tokio::test]
+    async fn target_change_while_browser_download_is_pending_only_updates_desired_parent() {
+        let vault = std::env::temp_dir().join(format!(
+            "agentero-connector-pending-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let ctrl = ConnectorController::new();
+        ctrl.set_vault(Some(vault.to_string_lossy().to_string()));
+        ctrl.set_parent_dir("papers/inbox".into());
+        ctrl.create_session("s2", Vec::new()).expect("session");
+        ctrl.record_session_import("s2", "item-1", saved("s2", "papers/inbox/paper-1"), true)
+            .expect("record import");
+
+        ctrl.update_session_target("s2", "Dpapers/final")
+            .await
+            .expect("remember target");
+        ctrl.update_session_target("s2", "Dpapers/latest")
+            .await
+            .expect("replace target");
+
+        let g = ctrl.inner.lock().expect("state");
+        let session = g.sessions.get("s2").expect("saved session");
+        assert_eq!(session.parent_dir, "papers/inbox");
+        assert_eq!(session.desired_parent.as_deref(), Some("papers/latest"));
+        assert_eq!(session.paper_paths, ["papers/inbox/paper-1"]);
+        assert_eq!(
+            session.attachment_phase.get("item-1"),
+            Some(&AttachmentPhase::AwaitingBrowserOrResolver)
+        );
+        assert!(!session.initial_finalized);
+    }
+
+    #[test]
+    fn deduped_import_is_mapped_but_never_owned_by_the_session() {
+        let ctrl = ConnectorController::new();
+        ctrl.create_session("s-dedupe", Vec::new())
+            .expect("session");
+        let mut payload = saved("s-dedupe", "papers/existing");
+        payload.deduped = true;
+
+        ctrl.record_session_import("s-dedupe", "item-1", payload, true)
+            .expect("record dedupe");
+
+        let g = ctrl.inner.lock().expect("state");
+        let session = g.sessions.get("s-dedupe").expect("saved session");
+        assert_eq!(
+            session.item_map.get("item-1").map(String::as_str),
+            Some("papers/existing")
+        );
+        assert!(session.paper_paths.is_empty());
+        assert!(session.attachment_phase.is_empty());
+        assert!(session.pending_saved.is_empty());
+    }
+
+    #[tokio::test]
+    async fn failed_attachment_still_finalizes_shell_when_target_is_unchanged() {
+        let vault = std::env::temp_dir().join(format!(
+            "agentero-connector-failed-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let ctrl = ConnectorController::new();
+        ctrl.set_vault(Some(vault.to_string_lossy().to_string()));
+        ctrl.create_session("s3", Vec::new()).expect("session");
+        ctrl.record_session_import("s3", "item-1", saved("s3", "papers/paper-1"), true)
+            .expect("record import");
+        ctrl.begin_browser_attachment("s3", Some("item-1"))
+            .await
+            .expect("begin browser write");
+
+        ctrl.complete_attachment("s3", Some("item-1"), false, true)
+            .await
+            .expect("failure finalizer");
+        ctrl.finalize_session_if_ready("s3")
+            .await
+            .expect("idempotent finalizer");
+
+        let g = ctrl.inner.lock().expect("state");
+        let session = g.sessions.get("s3").expect("saved session");
+        assert_eq!(
+            session.attachment_phase.get("item-1"),
+            Some(&AttachmentPhase::TerminalFailure)
+        );
+        assert!(session.initial_finalized);
+        assert!(session.desired_parent.is_none());
+        assert!(session.pending_saved.is_empty());
+    }
+
+    #[tokio::test]
+    async fn overlapping_attachment_writers_finalize_only_after_the_last_writer() {
+        let ctrl = ConnectorController::new();
+        let vault = std::env::temp_dir().join(format!(
+            "agentero-connector-writers-{}",
+            uuid::Uuid::new_v4()
+        ));
+        ctrl.set_vault(Some(vault.to_string_lossy().to_string()));
+        ctrl.create_session("s-writers", Vec::new())
+            .expect("session");
+        ctrl.record_session_import(
+            "s-writers",
+            "item-1",
+            saved("s-writers", "papers/paper-1"),
+            true,
+        )
+        .expect("record import");
+        ctrl.begin_browser_attachment("s-writers", Some("item-1"))
+            .await
+            .expect("first writer");
+        ctrl.begin_browser_attachment("s-writers", Some("item-1"))
+            .await
+            .expect("second writer");
+
+        ctrl.complete_attachment("s-writers", Some("item-1"), true, true)
+            .await
+            .expect("first completion");
+        {
+            let g = ctrl.inner.lock().expect("state");
+            let session = g.sessions.get("s-writers").expect("saved session");
+            assert_eq!(session.active_writers, 1);
+            assert!(!session.initial_finalized);
+            assert_eq!(session.pending_saved.len(), 1);
+        }
+
+        ctrl.complete_attachment("s-writers", Some("item-1"), true, true)
+            .await
+            .expect("last completion");
+        let g = ctrl.inner.lock().expect("state");
+        let session = g.sessions.get("s-writers").expect("saved session");
+        assert_eq!(session.active_writers, 0);
+        assert!(session.initial_finalized);
+        assert!(session.pending_saved.is_empty());
+    }
+
+    #[tokio::test]
+    async fn late_attachment_begin_waits_for_the_session_move_gate() {
+        let ctrl = Arc::new(ConnectorController::new());
+        ctrl.create_session("s-late", Vec::new()).expect("session");
+        ctrl.record_session_import("s-late", "item-1", saved("s-late", "papers/paper-1"), true)
+            .expect("record import");
+        let gate = ctrl.session_io_gate("s-late").expect("gate");
+        let guard = gate.lock().await;
+        let ctrl_bg = Arc::clone(&ctrl);
+        let begin = tokio::spawn(async move {
+            ctrl_bg
+                .begin_browser_attachment("s-late", Some("item-1"))
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !begin.is_finished(),
+            "attachment begin bypassed the move gate"
+        );
+
+        drop(guard);
+        begin.await.expect("join").expect("begin attachment");
+        let g = ctrl.inner.lock().expect("state");
+        assert_eq!(
+            g.sessions
+                .get("s-late")
+                .and_then(|session| session.attachment_phase.get("item-1")),
+            Some(&AttachmentPhase::WritingBrowser)
+        );
+    }
+
+    #[test]
+    fn rebasing_updates_every_session_path_owner() {
+        let ctrl = ConnectorController::new();
+        ctrl.create_session("s4", Vec::new()).expect("session");
+        ctrl.record_session_import("s4", "item-1", saved("s4", "papers/inbox/paper-1"), true)
+            .expect("record import");
+        ctrl.record_session_item_paper("s4", "alias", "papers/inbox/paper-1");
+
+        ctrl.rebase_session_path("s4", "papers/inbox/paper-1", "papers/final/paper-1");
+
+        let g = ctrl.inner.lock().expect("state");
+        let session = g.sessions.get("s4").expect("saved session");
+        assert_eq!(session.paper_paths, ["papers/final/paper-1"]);
+        assert_eq!(
+            session.item_map.get("item-1").map(String::as_str),
+            Some("papers/final/paper-1")
+        );
+        assert_eq!(
+            session.item_map.get("alias").map(String::as_str),
+            Some("papers/final/paper-1")
+        );
+        assert_eq!(session.pending_saved[0].path, "papers/final/paper-1");
+    }
+
+    #[test]
+    fn connector_does_not_start_parser_before_item_saved_handoff() {
+        let parser_entrypoint = ["maybe_generate_paper_md_", "after_download"].concat();
+        assert!(!include_str!("state.rs").contains(&parser_entrypoint));
+        assert!(!include_str!("import.rs").contains(&parser_entrypoint));
+        assert!(!include_str!("server.rs").contains(&parser_entrypoint));
     }
 }


### PR DESCRIPTION
## 问题

Zotero Connector 在附件仍在下载时收到 `updateSession` 论文保存目录变更：

<img width="328" height="166" alt="2026-08-20_08-15-30" src="https://github.com/user-attachments/assets/0e9dd495-5dba-4f16-bc80-a1685efb771e" />

会让移动操作与仍持有旧路径的 writer 产生竞态，形成重复下载请求、生成重复论文目录，并过早触发 `connector:item-saved` 与解析流程并产生大量 PDF parsing 请求。

<img width="243" height="235" alt="2026-08-20_08-14-56" src="https://github.com/user-attachments/assets/2e25831e-e493-4b46-ab68-ea4e5a26c004" />

<img width="184" height="414" alt="2026-08-20_08-16-50" src="https://github.com/user-attachments/assets/9b6623c5-d836-4331-8016-8b174521916c" />


## 改动

- 延迟移动：在 connector 下载 PDF 等附件时，使用 `desired_parent` 字段记录最近一次 updateSession 要保存到的目录，防止下载时变更目录。
- 待 PDF 附件下载完成后再移动；成功或失败都进入 finalizer，调用共享的 `paper_move` 事务，真正移动论文。
- 移动完成后更新 `paper_paths`、`item_map` 元数据，再清除 `desired_parent`，此时 PDF 和路径已稳定，再发送`connector:item-saved` 事件打开 pdf。
- 由 Chrome 优先通过 `saveAttachment` 上传 PDF；仅在浏览器未取得附件时再调用 DOI/arXiv fallback 下载。（与 zotero 保持一致，改动了两边同时下载同时写入的逻辑）
- 移除 Connector 主动调用 parser 的逻辑，发送 `connector:item-saved` 时会在打开 PDF 时自动启动解析。
- 更新 Zotero-Connector 相关文档。

## 验证

- `cargo test -p agentero connector`：17 passed，0 failed
- `git diff --check`：通过

## 范围与限制

- 本地 Vault 复用共享的 `paper_move` 逻辑；远程 Vault 保留现有远程移动实现。
- 移动失败时保留 `desired_parent` 字段。

## 仍然存在的问题

这里只是添加一个 PDF 下载时，延迟移动论文的标记 `desired_parent`。在 pdf parsing 等过程中移动论文，好像仍会出现问题。未来可能需要管理以论文为单位的各种生命周期事件，防止冲突，或更明确设计 vault 与文件系统同步的机制。