### PR TITLE
fix(agent): 打开agent给出的正文中的链接和思维链中的链接时，删除弹窗，直接跳转浏览器

### DIFF
--- a/src/components/ai-elements/external-link.tsx
+++ b/src/components/ai-elements/external-link.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ComponentPropsWithoutRef } from "react";
+import { useCallback } from "react";
+
+import { openExternalUrl } from "@/lib/core/open-external";
+
+type ExternalLinkProps = ComponentPropsWithoutRef<"a"> & {
+	node?: unknown;
+};
+
+/**
+ * Streamdown `<a>` renderer. Disables streamdown's built-in link-safety
+ * confirmation modal and opens the link directly in the system browser.
+ *
+ * `target="_blank"` is intentionally dropped: Tauri's webview routes `_blank`
+ * links natively, which would double-open alongside `openExternalUrl`.
+ */
+export const ExternalLink = ({
+	href,
+	node: _node,
+	target: _target,
+	children,
+	...props
+}: ExternalLinkProps) => {
+	const handleClick = useCallback(
+		(event: React.MouseEvent<HTMLAnchorElement>) => {
+			if (!href || href === "streamdown:incomplete-link") return;
+			event.preventDefault();
+			openExternalUrl(href);
+		},
+		[href],
+	);
+
+	return (
+		<a
+			href={href}
+			className="wrap-anywhere font-medium text-primary underline"
+			{...props}
+			onClick={handleClick}
+		>
+			{children}
+		</a>
+	);
+};

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -29,6 +29,8 @@ import {
 import { cn } from "@/lib/core/utils";
 import { normalizeMarkdownMath } from "@/lib/markdown/math-normalize";
 
+import { ExternalLink } from "./external-link";
+
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
 	from: UIMessage["role"];
 };
@@ -351,6 +353,8 @@ export const MessageResponse = memo(
 					"w-full min-w-0 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
 					className,
 				)}
+				components={{ a: ExternalLink }}
+				linkSafety={{ enabled: false }}
 				plugins={streamdownPlugins}
 				{...props}
 			>

--- a/src/components/ai-elements/reasoning.tsx
+++ b/src/components/ai-elements/reasoning.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/core/utils";
 
+import { ExternalLink } from "./external-link";
 import { Shimmer } from "./shimmer";
 
 interface ReasoningContextValue {
@@ -204,7 +205,13 @@ export const ReasoningContent = memo(
 			)}
 			{...props}
 		>
-			<Streamdown plugins={streamdownPlugins}>{children}</Streamdown>
+			<Streamdown
+				components={{ a: ExternalLink }}
+				linkSafety={{ enabled: false }}
+				plugins={streamdownPlugins}
+			>
+				{children}
+			</Streamdown>
 		</CollapsibleContent>
 	),
 );


### PR DESCRIPTION
…on modal

Streamdown's link-safety modal (enabled by default) intercepted link clicks in agent messages. Disable it and render links through a custom <a> that opens the system browser via the opener plugin, dropping target="_blank" to avoid Tauri double-opening.