### PR TITLE
fix(editor): preserve HTML attributes in fenced code

### DIFF
--- a/docs/frontend/markdown.md
+++ b/docs/frontend/markdown.md
@@ -134,9 +134,7 @@ Markdown 已能表达的语法不做 HTML 语义化转换，只处理 Markdown �
 
 渲染前经 `DOMPurify` 净化：剥离 `script` / `style` / 表单与内联事件，`iframe` 强制 `sandbox` + `referrerpolicy="no-referrer"` 且仅允许 http(s) `src`，链接强制 `target="_blank" rel="noopener noreferrer"`。应用未启用 CSP，因此净化是唯一防线——Markdown 文件始终保存作者原文，只收窄进入 DOM 的部分。
 
-`@platejs/markdown` 解析前会把 `class` / `for` 改写成 JSX 拼写，取回源码切片时会还原；void 元素会被补成自闭合（`<img …>` → `<img … />`），这是一次性归一化，之后保持稳定。
-
-已知上游缺陷：该改写作用于整份源码字符串，代码围栏内的 HTML 示例里 `class=` 也会被改成 `className=`，与本节无关，需另行修复。
+`@platejs/markdown` 解析前会把 `class` / `for` 改写成 JSX 拼写；编辑器会在取回源码切片和 HTML 代码围栏时还原。void 元素会被补成自闭合（`<img …>` → `<img … />`），这是一次性归一化，之后保持稳定。
 
 ## 代码
 

--- a/src/lib/markdown/html.ts
+++ b/src/lib/markdown/html.ts
@@ -4,6 +4,7 @@ type MdNode = {
 	type: string;
 	name?: string;
 	value?: string;
+	lang?: string;
 	children?: MdNode[];
 	attributes?: { type?: string; name?: string; value?: unknown }[];
 	position?: {
@@ -101,6 +102,9 @@ function expand(node: MdNode, source: string): MdNode[] | null {
 function transformTree(node: MdNode, source: string): void {
 	if (!node.children) return;
 	node.children = node.children.flatMap((child) => {
+		if (child.type === "code" && child.lang?.toLowerCase() === "html") {
+			child.value = toHtmlSource(child.value ?? "");
+		}
 		const next = expand(child, source);
 		if (next) return next;
 		transformTree(child, source);

--- a/test/editor-markdown-html.test.ts
+++ b/test/editor-markdown-html.test.ts
@@ -120,7 +120,8 @@ describe("HTML in Markdown", () => {
 	});
 
 	it("leaves fenced html samples untouched", () => {
-		const source = '```html\n<label class="field" for="email">Email</label>\n```';
+		const source =
+			'```html\n<label class="field" for="email">Email</label>\n```';
 		expect(roundTrip(source)).toBe(source);
 	});
 });

--- a/test/editor-markdown-html.test.ts
+++ b/test/editor-markdown-html.test.ts
@@ -120,7 +120,7 @@ describe("HTML in Markdown", () => {
 	});
 
 	it("leaves fenced html samples untouched", () => {
-		const source = '```html\n<div align="center">x</div>\n```';
+		const source = '```html\n<label class="field" for="email">Email</label>\n```';
 		expect(roundTrip(source)).toBe(source);
 	});
 });


### PR DESCRIPTION
## Summary

- preserve `class` and `for` attributes in fenced HTML code during Markdown round trips
- limit the restoration to HTML fences so JSX and TSX examples remain unchanged
- add regression coverage and update the Markdown documentation

## Tests

- `pnpm exec vitest run`
- `pnpm exec tsc --noEmit`