### PR TITLE
fix(agent): 修复 Windows 自定义 ACP Agent 启动失败

### DIFF
--- a/docs/backend/agent.md
+++ b/docs/backend/agent.md
@@ -8,7 +8,8 @@ Agentero 作为 **ACP Client**，stdio JSON-RPC 连接用户本机或远端 Agen
 - 会话 `cwd` = 当前 Vault 根（远程则为远端 Vault 根）。
 - 本地 Pi / 自定义 Agent 会先经 shell 切到 Vault；Windows 仅在传给 `cmd.exe` 时将
   `\\?\D:\...` 形式的本地盘符路径还原为 `D:\...`，避免 CMD 将其误判为 UNC（#458）。
-- Windows 的 cwd 与完整 Agent 命令通过环境变量展开，避免 Rust argv 转义破坏 CMD 内层引号（#458）。
+- Windows 的 cwd 与完整 Agent 命令通过环境变量展开，避免 Rust argv 转义破坏 CMD 内层引号；
+  cwd 环境变量始终携带双引号，防止无空格路径中的括号等 CMD 元字符被当作语法（#458）。
 - 统一接口：OpenCode、OpenClaw、Hermes、Gemini、Claude ACP、Codex ACP、Qoder、Grok、Pi、Dsh（DeepSeek Harness）、Kimi Code、自定义 `command`/`args`/`env`。
 - Dsh：ACP 服务端是 `@deepseek-ai/dsh-acp-demo`（npm 包），与依赖插件一起固定
   `0.1.1-rc.2`。安装/启动三处入口，检测按序回退：

--- a/docs/backend/agent.md
+++ b/docs/backend/agent.md
@@ -6,6 +6,8 @@ Agentero 作为 **ACP Client**，stdio JSON-RPC 连接用户本机或远端 Agen
 
 - Crate：`agent-client-protocol`（及 Codex 的 npm ACP 适配器进程）。
 - 会话 `cwd` = 当前 Vault 根（远程则为远端 Vault 根）。
+- 本地 Pi / 自定义 Agent 会先经 shell 切到 Vault；Windows 仅在传给 `cmd.exe` 时将
+  `\\?\D:\...` 形式的本地盘符路径还原为 `D:\...`，避免 CMD 将其误判为 UNC（#458）。
 - 统一接口：OpenCode、OpenClaw、Hermes、Gemini、Claude ACP、Codex ACP、Qoder、Grok、Pi、Dsh（DeepSeek Harness）、Kimi Code、自定义 `command`/`args`/`env`。
 - Dsh：ACP 服务端是 `@deepseek-ai/dsh-acp-demo`（npm 包），与依赖插件一起固定
   `0.1.1-rc.2`。安装/启动三处入口，检测按序回退：

--- a/docs/backend/agent.md
+++ b/docs/backend/agent.md
@@ -8,6 +8,7 @@ Agentero 作为 **ACP Client**，stdio JSON-RPC 连接用户本机或远端 Agen
 - 会话 `cwd` = 当前 Vault 根（远程则为远端 Vault 根）。
 - 本地 Pi / 自定义 Agent 会先经 shell 切到 Vault；Windows 仅在传给 `cmd.exe` 时将
   `\\?\D:\...` 形式的本地盘符路径还原为 `D:\...`，避免 CMD 将其误判为 UNC（#458）。
+- Windows 的 cwd 与完整 Agent 命令通过环境变量展开，避免 Rust argv 转义破坏 CMD 内层引号（#458）。
 - 统一接口：OpenCode、OpenClaw、Hermes、Gemini、Claude ACP、Codex ACP、Qoder、Grok、Pi、Dsh（DeepSeek Harness）、Kimi Code、自定义 `command`/`args`/`env`。
 - Dsh：ACP 服务端是 `@deepseek-ai/dsh-acp-demo`（npm 包），与依赖插件一起固定
   `0.1.1-rc.2`。安装/启动三处入口，检测按序回退：

--- a/src-tauri/src/features/agent/acp.rs
+++ b/src-tauri/src/features/agent/acp.rs
@@ -128,17 +128,21 @@ fn wrap_local_command_with_cwd(
 ) -> (PathBuf, Vec<String>) {
     env.insert(
         "AGENTERO_AGENT_CWD".to_string(),
-        windows_cmd_cwd(cwd),
+        windows_shell_quote(&windows_cmd_cwd(cwd)),
     );
-    let mut script = r#"cd /d "%AGENTERO_AGENT_CWD%" && "#.to_string();
-    script.push_str(&windows_shell_quote(&command.to_string_lossy()));
+    let mut agent_command = windows_shell_quote(&command.to_string_lossy());
     for arg in args {
-        script.push(' ');
-        script.push_str(&windows_shell_quote(arg));
+        agent_command.push(' ');
+        agent_command.push_str(&windows_shell_quote(arg));
     }
+    env.insert("AGENTERO_AGENT_COMMAND".to_string(), agent_command);
     (
         PathBuf::from("cmd"),
-        vec!["/D".to_string(), "/C".to_string(), script],
+        vec![
+            "/D".to_string(),
+            "/C".to_string(),
+            "cd /d %AGENTERO_AGENT_CWD% && %AGENTERO_AGENT_COMMAND%".to_string(),
+        ],
     )
 }
 
@@ -3441,7 +3445,7 @@ mod cwd_shell_wrap_tests {
     fn wrap_windows_builds_cmd_cd_script() {
         let mut env = HashMap::new();
         let (cmd, args) = wrap_local_command_with_cwd(
-            Path::new(r"C:\Users\name\pi-acp.cmd"),
+            Path::new(r"C:\Program Files\pi-acp.cmd"),
             &["--foo".to_string(), "bar baz".to_string()],
             &mut env,
             Path::new(r"\\?\C:\My Vault"),
@@ -3452,13 +3456,16 @@ mod cwd_shell_wrap_tests {
             vec![
                 "/D".to_string(),
                 "/C".to_string(),
-                r#"cd /d "%AGENTERO_AGENT_CWD%" && "C:\Users\name\pi-acp.cmd" --foo "bar baz""#
-                    .to_string(),
+                "cd /d %AGENTERO_AGENT_CWD% && %AGENTERO_AGENT_COMMAND%".to_string(),
             ]
         );
         assert_eq!(
             env.get("AGENTERO_AGENT_CWD"),
-            Some(&r"C:\My Vault".to_string())
+            Some(&r#""C:\My Vault""#.to_string())
+        );
+        assert_eq!(
+            env.get("AGENTERO_AGENT_COMMAND"),
+            Some(&r#""C:\Program Files\pi-acp.cmd" --foo "bar baz""#.to_string())
         );
         assert_eq!(
             windows_cmd_cwd(Path::new(r"C:\My Vault")),

--- a/src-tauri/src/features/agent/acp.rs
+++ b/src-tauri/src/features/agent/acp.rs
@@ -105,6 +105,17 @@ fn windows_shell_quote(s: &str) -> String {
     }
 }
 
+/// Convert Rust's canonicalized local drive path into a form accepted by `cmd.exe`.
+/// True UNC paths stay unchanged; supporting them requires a separate `pushd` flow.
+#[cfg(windows)]
+fn windows_cmd_cwd(cwd: &Path) -> String {
+    let cwd = cwd.to_string_lossy();
+    cwd.strip_prefix(r"\\?\")
+        .filter(|path| path.as_bytes().get(1) == Some(&b':'))
+        .unwrap_or(cwd.as_ref())
+        .to_string()
+}
+
 /// Windows variant of [`wrap_local_command_with_cwd`]. Uses `cmd /D /C` and an
 /// environment variable for the cwd so spaces in the vault path do not need to
 /// be quoted inside the command string.
@@ -117,7 +128,7 @@ fn wrap_local_command_with_cwd(
 ) -> (PathBuf, Vec<String>) {
     env.insert(
         "AGENTERO_AGENT_CWD".to_string(),
-        cwd.to_string_lossy().to_string(),
+        windows_cmd_cwd(cwd),
     );
     let mut script = r#"cd /d "%AGENTERO_AGENT_CWD%" && "#.to_string();
     script.push_str(&windows_shell_quote(&command.to_string_lossy()));
@@ -3433,7 +3444,7 @@ mod cwd_shell_wrap_tests {
             Path::new(r"C:\Users\name\pi-acp.cmd"),
             &["--foo".to_string(), "bar baz".to_string()],
             &mut env,
-            Path::new(r"C:\My Vault"),
+            Path::new(r"\\?\C:\My Vault"),
         );
         assert_eq!(cmd, PathBuf::from("cmd"));
         assert_eq!(
@@ -3448,6 +3459,14 @@ mod cwd_shell_wrap_tests {
         assert_eq!(
             env.get("AGENTERO_AGENT_CWD"),
             Some(&r"C:\My Vault".to_string())
+        );
+        assert_eq!(
+            windows_cmd_cwd(Path::new(r"C:\My Vault")),
+            r"C:\My Vault"
+        );
+        assert_eq!(
+            windows_cmd_cwd(Path::new(r"\\?\UNC\server\share")),
+            r"\\?\UNC\server\share"
         );
     }
 }

--- a/src-tauri/src/features/agent/acp.rs
+++ b/src-tauri/src/features/agent/acp.rs
@@ -107,13 +107,20 @@ fn windows_shell_quote(s: &str) -> String {
 
 /// Convert Rust's canonicalized local drive path into a form accepted by `cmd.exe`.
 /// True UNC paths stay unchanged; supporting them requires a separate `pushd` flow.
-#[cfg(windows)]
+#[cfg(any(windows, test))]
 fn windows_cmd_cwd(cwd: &Path) -> String {
     let cwd = cwd.to_string_lossy();
     cwd.strip_prefix(r"\\?\")
         .filter(|path| path.as_bytes().get(1) == Some(&b':'))
         .unwrap_or(cwd.as_ref())
         .to_string()
+}
+
+/// Pre-quote the cwd environment value so metacharacters remain literal after
+/// `cmd.exe` expands `%AGENTERO_AGENT_CWD%`, even when the path has no spaces.
+#[cfg(any(windows, test))]
+fn windows_cmd_cwd_env_value(cwd: &Path) -> String {
+    format!("\"{}\"", windows_cmd_cwd(cwd))
 }
 
 /// Windows variant of [`wrap_local_command_with_cwd`]. Uses `cmd /D /C` and an
@@ -128,7 +135,7 @@ fn wrap_local_command_with_cwd(
 ) -> (PathBuf, Vec<String>) {
     env.insert(
         "AGENTERO_AGENT_CWD".to_string(),
-        windows_shell_quote(&windows_cmd_cwd(cwd)),
+        windows_cmd_cwd_env_value(cwd),
     );
     let mut agent_command = windows_shell_quote(&command.to_string_lossy());
     for arg in args {
@@ -3441,6 +3448,22 @@ mod cwd_shell_wrap_tests {
     }
 
     #[test]
+    fn windows_cmd_cwd_env_value_normalizes_and_always_quotes() {
+        assert_eq!(
+            windows_cmd_cwd_env_value(Path::new(r"\\?\C:\Vault)")),
+            r#""C:\Vault)""#
+        );
+        assert_eq!(
+            windows_cmd_cwd_env_value(Path::new(r"C:\Vault")),
+            r#""C:\Vault""#
+        );
+        assert_eq!(
+            windows_cmd_cwd(Path::new(r"\\?\UNC\server\share")),
+            r"\\?\UNC\server\share"
+        );
+    }
+
+    #[test]
     #[cfg(windows)]
     fn wrap_windows_builds_cmd_cd_script() {
         let mut env = HashMap::new();
@@ -3466,14 +3489,6 @@ mod cwd_shell_wrap_tests {
         assert_eq!(
             env.get("AGENTERO_AGENT_COMMAND"),
             Some(&r#""C:\Program Files\pi-acp.cmd" --foo "bar baz""#.to_string())
-        );
-        assert_eq!(
-            windows_cmd_cwd(Path::new(r"C:\My Vault")),
-            r"C:\My Vault"
-        );
-        assert_eq!(
-            windows_cmd_cwd(Path::new(r"\\?\UNC\server\share")),
-            r"\\?\UNC\server\share"
         );
     }
 }


### PR DESCRIPTION
  ## 概要

  修复 Windows 上自定义 ACP Agent 启动失败的问题。该问题在 Vault 路径
  包含 `\\?\` 前缀、路径含空格，或 Agent 命令路径含空格时更容易出现。

  ## 根因

  Windows 本地路径经过 Rust canonicalize 后可能变成 `\\?\D:\...`，CMD
  会将其误判为 UNC 路径。

  此外，Rust `Command` 会对 `/C` 参数中的内层双引号进行 argv 转义，经
  过 `cmd.exe` 二次解析后会生成非法命令。

  ## 修复内容

  - 将 `\\?\D:\...` 本地盘符路径还原为 CMD 可接受的 `D:\...`。
  - 通过环境变量传递 cwd 和完整 Agent 命令，避免 Rust argv 转义破坏
  CMD 引号。
  - 增加 Windows shell 包装逻辑的单元测试。
  - 更新 Agent ACP 运行时文档。


  Fixes #458