### PR TITLE
修复重启后打开论文右侧 NOTES 面板缺失的问题

### DIFF
--- a/src/components/workspace/dock-workspace.tsx
+++ b/src/components/workspace/dock-workspace.tsx
@@ -86,6 +86,8 @@ export type DockWorkspaceHandle = {
 	cycleActive: (delta: number) => void;
 	/** Activate an existing panel by id. */
 	activatePanel: (panelId: string) => void;
+	/** True when the panel is registered in this dock and can be activated. */
+	canActivatePanel: (panelId: string) => boolean;
 	/** Make all visible Dockview grid groups equal width. */
 	equalizeGridGroups: () => void;
 };
@@ -654,6 +656,9 @@ export const DockWorkspace = memo(
 				},
 				activatePanel(panelId) {
 					apiRef.current?.getPanel(panelId)?.api.setActive();
+				},
+				canActivatePanel(panelId) {
+					return Boolean(apiRef.current?.getPanel(panelId));
 				},
 				equalizeGridGroups() {
 					const api = apiRef.current;

--- a/src/lib/workspace/actions.ts
+++ b/src/lib/workspace/actions.ts
@@ -311,42 +311,7 @@ export function openTab(
 			(res.mode === "pdf" || res.mode === "html") &&
 			(opts?.forceNotes || loadSettings().autoOpenPaperNotes);
 		if (wantDefaultNotes && res.notesPath) {
-			const notesId = tabIdForPath(res.notesPath);
-			const notesTab = getTabs().find((t) => t.id === notesId) ?? null;
-			// The notes tab existing in state is not enough: after layout
-			// restores it may live in a split pane / popout that
-			// `activatePanel` cannot bring beside this paper. Reopen it via
-			// the reading placement so it stacks into a visible notes column.
-			if (notesTab && dockHandle()?.canActivatePanel(notesId)) {
-				dockHandle()?.activatePanel(notesId);
-				dockHandle()?.activatePanel(id);
-			} else {
-				if (notesTab) {
-					// Drop the unreachable panel from state so the reopen below
-					// can register a fresh one under the same id.
-					setTabs((prev) => prev.filter((t) => t.id !== notesId));
-				}
-				const paperLike = {
-					...createPlaceholderTab(path, res.mode),
-					...patch,
-				} as DocTab;
-				const notesPane = createNotesSplitPane(paperLike);
-				if (notesPane) {
-					const { notes: notesPlacement } = paperReadingPlacements(getTabs(), {
-						paperId: id,
-						notesId: notesPane.id,
-						activeId: getActiveTabId(),
-						forcedPaperPlacement: opts?.placement,
-					});
-					setTabs((prev) => {
-						if (prev.some((t) => t.id === notesPane.id)) return prev;
-						return [...prev, notesPane];
-					});
-					dockHandle()?.openPanel(notesPane, notesPlacement);
-					// Keep focus on the paper body after NOTES joins the right column.
-					dockHandle()?.activatePanel(id);
-				}
-			}
+			openNotesForPaper(id, patch, path);
 		}
 
 		const vault = getVaultPath();
@@ -368,6 +333,65 @@ export function openTab(
 			notePaperFocus(path);
 		}
 	})();
+}
+
+/**
+ * Ensure the NOTES companion panel of paper tab `paperId` is open beside it.
+ * `paperPatch`/`paperPath` come from a freshly loaded tab; without them the
+ * patch is read from the current tab state (hydrate path).
+ * The notes tab existing in state is not enough: after layout restore it may
+ * live in a split pane / popout that `activatePanel` cannot bring beside this
+ * paper — drop it from state and reopen via the reading placement so it
+ * stacks into a visible notes column.
+ */
+function openNotesForPaper(
+	paperId: string,
+	paperPatch?: Partial<DocTab>,
+	paperPath?: string,
+): void {
+	const tab = getTabs().find((t) => t.id === paperId);
+	const notesPath = paperPatch?.notesPath ?? tab?.notesPath ?? null;
+	if (!tab && !paperPath) return;
+	const path = paperPath ?? tab?.path ?? "";
+	const notesId = notesPath ? tabIdForPath(notesPath) : null;
+	const notesTab = notesId
+		? (getTabs().find((t) => t.id === notesId) ?? null)
+		: null;
+	const notesInDock = notesId
+		? Boolean(dockHandle()?.canActivatePanel(notesId))
+		: false;
+	if (notesTab && notesInDock && notesId) {
+		dockHandle()?.activatePanel(notesId);
+		dockHandle()?.activatePanel(paperId);
+		return;
+	}
+	if (notesTab && notesId) {
+		// Drop the unreachable panel from state so the reopen below can
+		// register a fresh one under the same id.
+		setTabs((prev) => prev.filter((t) => t.id !== notesId));
+	}
+	const paperLike = {
+		...createPlaceholderTab(path, tab?.mode ?? "pdf"),
+		...(paperPatch ?? {}),
+		...tab,
+		notesPath,
+	} as DocTab;
+	const notesPane = createNotesSplitPane(paperLike);
+	if (!notesPane) {
+		return;
+	}
+	const { notes: notesPlacement } = paperReadingPlacements(getTabs(), {
+		paperId,
+		notesId: notesPane.id,
+		activeId: getActiveTabId(),
+	});
+	setTabs((prev) => {
+		if (prev.some((t) => t.id === notesPane.id)) return prev;
+		return [...prev, notesPane];
+	});
+	dockHandle()?.openPanel(notesPane, notesPlacement);
+	// Keep focus on the paper body after NOTES joins the right column.
+	dockHandle()?.activatePanel(paperId);
 }
 
 /**
@@ -1067,6 +1091,17 @@ export function hydratePlaceholderTabs(tabIds: readonly string[]): void {
 					seedKey: 1,
 					loaded: true,
 				});
+				// A restored paper body hydrates after its NOTES panel was
+				// pruned from the layout — open the companion now, otherwise
+				// the first click shows the PDF without notes beside it.
+				if (
+					res.kind === "paper" &&
+					(res.mode === "pdf" || res.mode === "html") &&
+					res.notesPath &&
+					loadSettings().autoOpenPaperNotes
+				) {
+					openNotesForPaper(id);
+				}
 			} finally {
 				placeholderLoads.delete(id);
 			}

--- a/src/lib/workspace/actions.ts
+++ b/src/lib/workspace/actions.ts
@@ -312,11 +312,20 @@ export function openTab(
 			(opts?.forceNotes || loadSettings().autoOpenPaperNotes);
 		if (wantDefaultNotes && res.notesPath) {
 			const notesId = tabIdForPath(res.notesPath);
-			const notesAlreadyOpen = getTabs().some((t) => t.id === notesId);
-			if (notesAlreadyOpen) {
+			const notesTab = getTabs().find((t) => t.id === notesId) ?? null;
+			// The notes tab existing in state is not enough: after layout
+			// restores it may live in a split pane / popout that
+			// `activatePanel` cannot bring beside this paper. Reopen it via
+			// the reading placement so it stacks into a visible notes column.
+			if (notesTab && dockHandle()?.canActivatePanel(notesId)) {
 				dockHandle()?.activatePanel(notesId);
 				dockHandle()?.activatePanel(id);
 			} else {
+				if (notesTab) {
+					// Drop the unreachable panel from state so the reopen below
+					// can register a fresh one under the same id.
+					setTabs((prev) => prev.filter((t) => t.id !== notesId));
+				}
 				const paperLike = {
 					...createPlaceholderTab(path, res.mode),
 					...patch,

--- a/src/lib/workspace/dock-registry.ts
+++ b/src/lib/workspace/dock-registry.ts
@@ -19,6 +19,12 @@ export type DockHandle = {
 	cycleActive: (delta: number) => void;
 	/** Activate an existing panel by id. */
 	activatePanel: (panelId: string) => void;
+	/**
+	 * True when `activatePanel` can actually bring the panel to a visible
+	 * group (i.e. the panel is registered in this dock, not in a split
+	 * pane / popout window this handle cannot see).
+	 */
+	canActivatePanel: (panelId: string) => boolean;
 	/** Make all visible Dockview grid groups equal width. */
 	equalizeGridGroups: () => void;
 };


### PR DESCRIPTION
## 问题描述

打开论文时右侧的 NOTES 面板可能不出现，有两种表现：

1. **重启应用后点论文，右侧停留在上一篇论文的笔记或空白**：NOTES 面板存在于标签状态里，但布局恢复后 dock 中没有对应面板，仅聚焦面板的操作落空
2. **重启后第一次点某篇论文没有笔记，点第二次才出现**：布局恢复的占位标签页（`loaded: false`）首次点击只激活面板，NOTES 伴随逻辑要等资源加载完成后的第二次点击才执行

复现方式（场景 2，稳定复现）：

1. 打开论文 X（右侧有笔记），手动关掉 NOTES 面板（保留论文标签页）
2. 关闭应用（保证退出时布局中没有 X 的 NOTES 面板）
3. 重新打开应用，点击论文 X
4. 修复前：右侧无笔记，需再点一次才出现

## 根因分析

工作区中一个 NOTES 面板同时存在于两处：React 标签状态（`tabs` 数组）和 dockview 布局（实际渲染的窗格）。两者可能脱节——布局恢复只还原各分组可见的面板，被拖过分屏（split pane）或弹窗的 NOTES 面板在状态里有记录、dock 里却没有。

`openTab` 判断"NOTES 已打开"只查了标签状态，状态说有就仅执行 `activatePanel`，对 dock 中不存在的面板调用落空，右分屏从未创建。

另一个缺口在占位标签页的水合路径：`openTab` 对已存在的标签页，只有已加载的 paper（`mode: pdf/html`）才做 NOTES 联动；布局恢复的占位标签页未加载资源，首次点击走"仅激活"分支，跳过了整个"加载资源 + 打开 NOTES"流程。首次点击顺带触发了懒加载，所以第二次点击起才正常。

## 修复方案

1. **`DockHandle` 新增 `canActivatePanel(panelId)`**（`dock-registry.ts` + `dock-workspace.tsx`）：用 `api.getPanel(id)` 探测面板是否真实存在于当前 dock
2. **抽出 `openNotesForPaper`**（`actions.ts`）：统一"确保 NOTES 伴随面板打开"的逻辑——面板可达则激活；不可达则从状态移除后按阅读布局（`paperReadingPlacements`）重新打开，叠进已有笔记列或新建右分屏
3. **`openTab` 加载完成后改用 `openNotesForPaper`**，替换原来只查状态的分支
4. **`hydratePlaceholderTabs` 水合完成后补开**：恢复的占位标签页加载出 PDF/HTML 论文正文、且 NOTES 面板不在 dock 时，调用 `openNotesForPaper` 补开伴随面板；面板已随布局恢复的情况内部探测到后只做激活，不重复开

## 验证

- `tsc --noEmit` 类型检查通过，`biome check` 通过，vitest 全量 125 文件 / 1028 用例通过
- Linux（WebKitGTK）实际验证：
  - 重启后点击布局恢复的论文标签页，NOTES 面板按阅读布局重新出现（第一次点击即生效）
  - 新开论文仍走首次右分屏；已有笔记列时正确叠入
  - 关闭 `autoOpenPaperNotes` 设置时不补开，行为不变
  - `⌘\`、右键"打开笔记"、Layout 菜单开关 NOTES 不受影响
