### PR TITLE
fix(paper): preserve MinerU image assets

### DIFF
--- a/crates/agentero-core/src/features/paper/analyze/parse/engines/local.rs
+++ b/crates/agentero-core/src/features/paper/analyze/parse/engines/local.rs
@@ -17,6 +17,7 @@ impl BodyParseEngine for LocalBodyEngine {
             super::super::run_liteparse_markdown(ctx.pdf_path, ctx.task_id).await?;
         Ok(BodyParseOutcome {
             markdown,
+            assets: Vec::new(),
             body_source,
             body_quality,
         })

--- a/crates/agentero-core/src/features/paper/analyze/parse/engines/mod.rs
+++ b/crates/agentero-core/src/features/paper/analyze/parse/engines/mod.rs
@@ -6,6 +6,7 @@
 //! credentials live in a process-wide snapshot (same pattern as
 //! `http::configure_proxy`), refreshed at startup and on `settings_set`.
 
+use super::BodyParseAsset;
 use crate::error::AppError;
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -14,10 +15,13 @@ use std::sync::{Arc, OnceLock, RwLock};
 
 mod local;
 
-/// Successful body parse: markdown plus the catalog quality labels.
+/// Successful body parse: markdown, optional derived assets, and the catalog
+/// quality labels. Assets are regenerated with `PAPER.md` and are never the
+/// source of truth for a paper.
 #[derive(Debug, Clone)]
 pub struct BodyParseOutcome {
     pub markdown: String,
+    pub assets: Vec<BodyParseAsset>,
     pub body_source: String,
     pub body_quality: String,
 }

--- a/crates/agentero-core/src/features/paper/analyze/parse/mod.rs
+++ b/crates/agentero-core/src/features/paper/analyze/parse/mod.rs
@@ -26,6 +26,17 @@ use std::time::Duration;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 const PAPER_MD: &str = "PAPER.md";
+
+/// A derived file returned by a body-parse engine alongside its Markdown.
+///
+/// The writer validates `relative_path` before placing the file below the
+/// paper directory. Engines must not use this for user-authored files such as
+/// `NOTES.md`.
+#[derive(Debug, Clone)]
+pub struct BodyParseAsset {
+    pub relative_path: String,
+    pub bytes: Vec<u8>,
+}
 /// Cancellation is a user action, not a parse failure; `PaperParseResult::fail`
 /// keys off this to avoid reporting cancelled work as broken.
 pub const CANCELLED_MESSAGE: &str = "background task cancelled";
@@ -257,40 +268,38 @@ async fn parse_paper_body_inner(
     #[cfg(not(any(target_os = "ios", target_os = "android")))]
     let parse_result = engines::parse_body_with_engine(&pdf_path, task_id, &mut out.messages)
         .await
-        .map(|o| (o.markdown, o.body_source, o.body_quality));
+        .map(|o| (o.markdown, o.assets, o.body_source, o.body_quality));
     #[cfg(any(target_os = "ios", target_os = "android"))]
-    let parse_result = run_liteparse_markdown(&pdf_path, task_id).await;
+    let parse_result = run_liteparse_markdown(&pdf_path, task_id).await.map(
+        |(markdown, body_source, body_quality)| (markdown, Vec::new(), body_source, body_quality),
+    );
 
     match parse_result {
-        Ok((markdown, body_source, body_quality)) => {
+        Ok((markdown, assets, body_source, body_quality)) => {
             if markdown.trim().is_empty() {
                 out.fail("liteparse returned empty text".into());
                 return out;
             }
-            // Writing PAPER.md (fs) and updating the catalog body fields
-            // (rusqlite, which acquires the process-wide catalog lock) are both
-            // blocking. Run them on the blocking pool so a held catalog lock or
-            // slow disk never stalls a tokio worker.
+            // Writing PAPER.md (fs), its provider-derived assets, and updating
+            // the catalog body fields (rusqlite, which acquires the process-wide
+            // catalog lock) are all blocking. Run them on the blocking pool so a
+            // held catalog lock or slow disk never stalls a tokio worker.
             let paper_dir_owned = paper_dir.to_path_buf();
             let vault_owned = vault.to_path_buf();
             let path_owned = path_rel.to_string();
             let catalog_source = body_source.clone();
             let catalog_quality = body_quality.clone();
             let write_outcome = tokio::task::spawn_blocking(move || {
-                match fs::write(paper_dir_owned.join(PAPER_MD), &markdown) {
-                    Ok(()) => {
-                        let catalog_error = update_catalog_body(
-                            &vault_owned,
-                            &path_owned,
-                            &catalog_source,
-                            &catalog_quality,
-                        )
-                        .err()
-                        .map(|e| e.to_string());
-                        Ok(catalog_error)
-                    }
-                    Err(e) => Err(e.to_string()),
-                }
+                write_paper_body_bundle(&paper_dir_owned, &markdown, &assets)?;
+                let catalog_error = update_catalog_body(
+                    &vault_owned,
+                    &path_owned,
+                    &catalog_source,
+                    &catalog_quality,
+                )
+                .err()
+                .map(|e| e.to_string());
+                Ok(catalog_error)
             })
             .await;
 
@@ -1079,6 +1088,60 @@ fn collect_probe_words(
     }
 }
 
+fn safe_body_asset_path(relative_path: &str) -> Result<PathBuf, AppError> {
+    if relative_path.contains('\\') {
+        return Err(AppError::message(
+            "body parse asset path must use slash separators",
+        ));
+    }
+    let path = Path::new(relative_path);
+    if path.is_absolute() {
+        return Err(AppError::message("body parse asset path must be relative"));
+    }
+
+    let mut safe = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(part) => safe.push(part),
+            std::path::Component::CurDir
+            | std::path::Component::ParentDir
+            | std::path::Component::RootDir
+            | std::path::Component::Prefix(_) => {
+                return Err(AppError::message("body parse asset path is unsafe"));
+            }
+        }
+    }
+    let mut components = safe.components();
+    if components
+        .next()
+        .is_none_or(|part| part.as_os_str() != "images")
+    {
+        return Err(AppError::message(
+            "body parse assets must stay below images",
+        ));
+    }
+    if components.next().is_none() {
+        return Err(AppError::message("body parse asset path is empty"));
+    }
+    Ok(safe)
+}
+fn write_paper_body_bundle(
+    paper_dir: &Path,
+    markdown: &str,
+    assets: &[BodyParseAsset],
+) -> Result<(), String> {
+    for asset in assets {
+        let relative = safe_body_asset_path(&asset.relative_path).map_err(|e| e.to_string())?;
+        let destination = paper_dir.join(relative);
+        let parent = destination
+            .parent()
+            .ok_or_else(|| "body parse asset has no parent directory".to_string())?;
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        fs::write(destination, &asset.bytes).map_err(|e| e.to_string())?;
+    }
+    fs::write(paper_dir.join(PAPER_MD), markdown).map_err(|e| e.to_string())
+}
+
 fn update_catalog_body(
     vault: &Path,
     path_rel: &str,
@@ -1169,6 +1232,50 @@ mod tests {
             OsString::from("input.pdf"),
         ];
         assert!(pdf_parse_worker_request_from_args(incomplete).is_err());
+    }
+
+    #[test]
+    fn writes_paper_body_with_derived_assets() {
+        let dir = tempfile::tempdir().unwrap();
+        write_paper_body_bundle(
+            dir.path(),
+            "# Paper\n\n![](images/figure.jpg)\n",
+            &[BodyParseAsset {
+                relative_path: "images/figure.jpg".into(),
+                bytes: b"image-bytes".to_vec(),
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(dir.path().join(PAPER_MD)).unwrap(),
+            "# Paper\n\n![](images/figure.jpg)\n"
+        );
+        assert_eq!(
+            fs::read(dir.path().join("images/figure.jpg")).unwrap(),
+            b"image-bytes"
+        );
+    }
+
+    #[test]
+    fn refuses_paper_body_asset_path_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        for path in ["../outside.jpg", "images\\..\\outside.jpg", "NOTES.md"] {
+            let err = write_paper_body_bundle(
+                dir.path(),
+                "# Paper",
+                &[BodyParseAsset {
+                    relative_path: path.into(),
+                    bytes: b"unsafe".to_vec(),
+                }],
+            )
+            .unwrap_err();
+            assert!(
+                err.contains("unsafe") || err.contains("slash") || err.contains("images"),
+                "{err}"
+            );
+        }
+        assert!(!dir.path().parent().unwrap().join("outside.jpg").exists());
     }
 
     #[test]

--- a/crates/agentero-core/src/features/paper/analyze/parse/mod.rs
+++ b/crates/agentero-core/src/features/paper/analyze/parse/mod.rs
@@ -289,19 +289,20 @@ async fn parse_paper_body_inner(
             let path_owned = path_rel.to_string();
             let catalog_source = body_source.clone();
             let catalog_quality = body_quality.clone();
-            let write_outcome = tokio::task::spawn_blocking(move || {
-                write_paper_body_bundle(&paper_dir_owned, &markdown, &assets)?;
-                let catalog_error = update_catalog_body(
-                    &vault_owned,
-                    &path_owned,
-                    &catalog_source,
-                    &catalog_quality,
-                )
-                .err()
-                .map(|e| e.to_string());
-                Ok(catalog_error)
-            })
-            .await;
+            let write_outcome: Result<Result<Option<String>, String>, tokio::task::JoinError> =
+                tokio::task::spawn_blocking(move || {
+                    write_paper_body_bundle(&paper_dir_owned, &markdown, &assets)?;
+                    let catalog_error = update_catalog_body(
+                        &vault_owned,
+                        &path_owned,
+                        &catalog_source,
+                        &catalog_quality,
+                    )
+                    .err()
+                    .map(|e| e.to_string());
+                    Ok(catalog_error)
+                })
+                .await;
 
             match write_outcome {
                 Ok(Ok(catalog_error)) => {

--- a/docs/backend/paper-import.md
+++ b/docs/backend/paper-import.md
@@ -84,7 +84,7 @@ Skill 不写入 catalog、不创建 `papers/` 条目、不执行 `scripts/`。�
 | backend | 流程 | `body_source` | `body_quality` |
 |---|---|---|---|
 | `local`（默认） | liteparse worker 子进程 + PDFium | `pdf` / `ocr` | `medium` / `low` |
-| `mineru` | 复用 MinerU 批量提取（上传 → 轮询 → 结果 zip），读取 zip 内 `full.md` | `mineru` | `high` |
+| `mineru` | 复用 MinerU 批量提取（上传 → 轮询 → 结果 zip）；写入 `full.md`，并保留其 ZIP 中 `images/` 下的派生图片资产，保持 `images/...` 相对链接可渲染 | `mineru` | `high` |
 | `paddle` | 复用 AI Studio 异步任务，拼接 JSONL 中每页 `markdown.text`。正文模型默认 `PaddleOCR-VL-1.6`，可在设置里改（版面分析固定 `PP-StructureV3`，不受影响） | `paddle` | `high` |
 | `openaiCompatible` | 渲染 worker 逐页出 150 DPI PNG（上限 100 页）→ OpenAI 兼容 `/chat/completions` 多模态 OCR（预设硅基流动；`PaddlePaddle/PaddleOCR-VL-1.5` 提示词 `OCR:`，`deepseek-ai/DeepSeek-OCR` 用 grounding 提示词，按 model id 自动选择） | `vlm` | `medium` |
 
@@ -93,6 +93,7 @@ Skill 不写入 catalog、不创建 `papers/` 条目、不执行 `scripts/`。�
 - **提示词**：默认按 model id 自动选择（含 `deepseek-ocr` → grounding 提示词；含 `paddleocr` → `OCR:`；其余 → 通用指令）。设置里的 Prompt 输入框可覆盖，留空即走自动。
   - ⚠️ `PaddleOCR-VL` 是**任务提示词**模型，只认它自己那几个固定提示词；换成自由指令会退化成检测模式并吐出 `<|LOC_n|>` 坐标 token。自定义提示词请配指令型 VLM（如 DeepSeek-OCR 去掉 `<|grounding|>`、Qwen-VL 等）。
 - **MinerU 高级选项**：`language`（OCR 语言包，默认 `ch` 中英文，Host 白名单校验）与 `isOcr`（强制 OCR，默认关闭、按文本层自动判断）存在共用的 `layout.providerConfigs.mineru`，版面分析与正文解析复用同一套请求参数。
+- **MinerU 图片资产**：MinerU 的 `full.md` 使用 `images/...` 相对链接引用结果 ZIP 中的裁图。Agentero 将这些图片与 `PAPER.md` 一起写到论文目录中的 `images/`；二者均为可重建的派生物，不改变 PDF、TeX 或 `NOTES.md` 的归档地位。
 - **输出清洗**：grounding 输出形如 `<|ref|>label<|/ref|><|det|>[[box]]<|/det|>\n正文`，`<|ref|>` 内是版面**类别名**（`text` / `title`）而非正文，两段都整体丢弃，否则正文里会混入 `text` / `sub_title` 噪声行；`<|LOC_n|>` 同样剥离。
 - **实现**：`src-tauri/src/features/paper/analyze/parse/engines/`（`BodyParseEngine` trait + local / mineru / paddle / openai_vlm）；云端上传/轮询复用 `features/paper/analyze/layout/hosted` 的 `run_mineru_extract` / `run_paddle_ocr_job`。
 - **Live 验证**（`#[ignore]`，需自备 key，密钥只走环境变量）：

--- a/src-tauri/src/features/paper/analyze/body_engines/mineru.rs
+++ b/src-tauri/src/features/paper/analyze/body_engines/mineru.rs
@@ -1,14 +1,15 @@
 //! MinerU body-parse engine: run the shared cloud extract and read the
-//! `full.md` markdown from the result zip.
+//! `full.md` markdown and its `images/` assets from the result zip.
 
 use crate::core::error::AppError;
 use crate::features::paper::analyze::layout::hosted::engine::HostedProviderCredentials;
 use crate::features::paper::analyze::layout::hosted::mineru::{
-    read_zip_entry_by_candidates, run_mineru_extract,
+    read_mineru_markdown_bundle, run_mineru_extract,
 };
 use crate::features::paper::analyze::parse::engines::{
     BodyParseCtx, BodyParseEngine, BodyParseOutcome,
 };
+use crate::features::paper::analyze::parse::BodyParseAsset;
 use async_trait::async_trait;
 
 pub(crate) struct MineruBodyEngine;
@@ -39,9 +40,17 @@ impl BodyParseEngine for MineruBodyEngine {
                 ctx.is_cancelled()
             })
             .await?;
-        let markdown = read_zip_entry_by_candidates(&zip_bytes, &["full.md"])?;
+        let bundle = read_mineru_markdown_bundle(&zip_bytes)?;
         Ok(BodyParseOutcome {
-            markdown,
+            markdown: bundle.markdown,
+            assets: bundle
+                .assets
+                .into_iter()
+                .map(|asset| BodyParseAsset {
+                    relative_path: asset.relative_path,
+                    bytes: asset.bytes,
+                })
+                .collect(),
             body_source: "mineru".to_string(),
             body_quality: "high".to_string(),
         })
@@ -52,8 +61,8 @@ impl BodyParseEngine for MineruBodyEngine {
 mod tests {
     use super::*;
 
-    /// Live end-to-end MinerU extract; prints the result-zip entry names so a
-    /// schema change (e.g. `full.md` renamed) is immediately visible.
+    /// Live end-to-end MinerU extract; prints the result-zip entry names and
+    /// extracted asset count so a schema change remains visible.
     ///
     /// ```sh
     /// AGENTERO_MINERU_LIVE_PDF=/tmp/x.pdf AGENTERO_MINERU_API_KEY=sk-… \
@@ -91,8 +100,13 @@ mod tests {
             .collect();
         println!("zip entries: {names:?}");
 
-        let markdown = read_zip_entry_by_candidates(&zip, &["full.md"]).expect("full.md entry");
-        println!("--- markdown ({} chars) ---\n{markdown}", markdown.len());
-        assert!(!markdown.trim().is_empty());
+        let bundle = read_mineru_markdown_bundle(&zip).expect("MinerU markdown bundle");
+        println!(
+            "--- markdown ({} chars), assets={} ---\n{}",
+            bundle.markdown.len(),
+            bundle.assets.len(),
+            bundle.markdown
+        );
+        assert!(!bundle.markdown.trim().is_empty());
     }
 }

--- a/src-tauri/src/features/paper/analyze/body_engines/mod.rs
+++ b/src-tauri/src/features/paper/analyze/body_engines/mod.rs
@@ -11,7 +11,7 @@
 //! the cloud job runners in [`crate::features::paper::analyze::layout::hosted`] (upload →
 //! poll → zip/JSONL). Sharing those runners avoids duplicating the HTTP
 //! orchestration; the same cloud job is run once and consumed differently
-//! (zip → `full.md` here; zip → `content_list.json` boxes there).
+//! (zip → `full.md` plus `images/` assets here; zip → `content_list.json` boxes there).
 //! `openai_vlm` is self-contained and does not touch `layout::hosted`.
 //!
 //! Both trees draw credentials from the single `layout.providerConfigs`

--- a/src-tauri/src/features/paper/analyze/body_engines/openai_vlm.rs
+++ b/src-tauri/src/features/paper/analyze/body_engines/openai_vlm.rs
@@ -92,6 +92,7 @@ impl BodyParseEngine for OpenAiVlmBodyEngine {
         let markdown = ocr_rendered_pages(&pages, guard.path(), ctx, &target).await?;
         Ok(BodyParseOutcome {
             markdown,
+            assets: Vec::new(),
             body_source: "vlm".to_string(),
             body_quality: "medium".to_string(),
         })

--- a/src-tauri/src/features/paper/analyze/body_engines/paddle.rs
+++ b/src-tauri/src/features/paper/analyze/body_engines/paddle.rs
@@ -56,6 +56,7 @@ impl BodyParseEngine for PaddleBodyEngine {
         }
         Ok(BodyParseOutcome {
             markdown,
+            assets: Vec::new(),
             body_source: "paddle".to_string(),
             body_quality: "high".to_string(),
         })

--- a/src-tauri/src/features/paper/analyze/layout/hosted/mineru.rs
+++ b/src-tauri/src/features/paper/analyze/layout/hosted/mineru.rs
@@ -393,7 +393,7 @@ pub(crate) fn read_mineru_markdown_bundle(bytes: &[u8]) -> Result<MineruMarkdown
     let mut total_bytes = 0u64;
 
     for index in 0..archive.len() {
-        let mut entry = archive
+        let entry = archive
             .by_index(index)
             .map_err(|e| AppError::message(format!("MinerU result zip entry failed: {e}")))?;
         if entry.is_dir() {

--- a/src-tauri/src/features/paper/analyze/layout/hosted/mineru.rs
+++ b/src-tauri/src/features/paper/analyze/layout/hosted/mineru.rs
@@ -20,6 +20,7 @@ use async_trait::async_trait;
 use base64::Engine;
 use reqwest::StatusCode;
 use serde_json::{json, Value};
+use std::collections::HashSet;
 use std::io::Read;
 use std::time::{Duration, Instant};
 
@@ -37,6 +38,24 @@ const MAX_PDF_BASE64_CHARS: usize = 96 * 1024 * 1024;
 /// to prevent zip-bomb OOM (same rationale as the sync gunzip caps).
 const MAX_RESULT_ZIP_BYTES: usize = 256 * 1024 * 1024;
 const MAX_JSON_ENTRY_BYTES: u64 = 128 * 1024 * 1024;
+/// MinerU Markdown refers to extracted figures through `images/...` paths.
+/// Keep the individual and aggregate unpacked sizes bounded because result ZIPs
+/// are remote, untrusted input.
+const MAX_BODY_IMAGE_ENTRY_BYTES: u64 = 32 * 1024 * 1024;
+const MAX_BODY_IMAGE_BYTES: u64 = 128 * 1024 * 1024;
+
+/// The Markdown and figure files required to materialize a MinerU body parse.
+/// Paths remain relative to `PAPER.md`, for example `images/figure-1.jpg`.
+pub(crate) struct MineruMarkdownBundle {
+    pub markdown: String,
+    pub assets: Vec<MineruMarkdownAsset>,
+}
+
+/// One image extracted from a MinerU result ZIP.
+pub(crate) struct MineruMarkdownAsset {
+    pub relative_path: String,
+    pub bytes: Vec<u8>,
+}
 
 pub struct MineruEngine;
 
@@ -326,6 +345,96 @@ pub(crate) fn read_zip_entry_by_candidates(
         )));
     }
     Ok(text)
+}
+
+/// Return a safe, slash-separated image path below `images/`, or `None` for
+/// unrelated ZIP entries. MinerU may prefix ZIP members with a task id, so the
+/// returned path starts at the first `images` directory. Backslashes are
+/// normalized before validation because they become path separators on Windows.
+fn safe_mineru_image_path(name: &str) -> Result<Option<String>, AppError> {
+    let normalized = name.replace('\\', "/");
+    if normalized.contains('\0') || normalized.starts_with('/') {
+        return Err(AppError::message(
+            "MinerU result zip contains an invalid image path",
+        ));
+    }
+    if !normalized.starts_with("images/") && !normalized.contains("/images/") {
+        return Ok(None);
+    }
+    let parts: Vec<&str> = normalized.split('/').collect();
+    if parts
+        .iter()
+        .any(|part| part.is_empty() || *part == "." || *part == ".." || part.contains(':'))
+    {
+        return Err(AppError::message(
+            "MinerU result zip contains an unsafe image path",
+        ));
+    }
+    let Some(images_index) = parts.iter().position(|part| *part == "images") else {
+        return Ok(None);
+    };
+    let image_parts = &parts[images_index + 1..];
+    if image_parts.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(format!("images/{}", image_parts.join("/"))))
+}
+
+/// Extract `full.md` and the `images/` files it references by relative path.
+/// The caller writes them beside `PAPER.md`, preserving MinerU's portable
+/// Markdown instead of rewriting the links to application-specific URLs.
+pub(crate) fn read_mineru_markdown_bundle(bytes: &[u8]) -> Result<MineruMarkdownBundle, AppError> {
+    let markdown = read_zip_entry_by_candidates(bytes, &["full.md"])?;
+    let cursor = std::io::Cursor::new(bytes);
+    let mut archive = zip::ZipArchive::new(cursor)
+        .map_err(|e| AppError::message(format!("MinerU result zip open failed: {e}")))?;
+    let mut assets = Vec::new();
+    let mut paths = HashSet::new();
+    let mut total_bytes = 0u64;
+
+    for index in 0..archive.len() {
+        let mut entry = archive
+            .by_index(index)
+            .map_err(|e| AppError::message(format!("MinerU result zip entry failed: {e}")))?;
+        if entry.is_dir() {
+            continue;
+        }
+        let Some(relative_path) = safe_mineru_image_path(entry.name())? else {
+            continue;
+        };
+        if !paths.insert(relative_path.clone()) {
+            return Err(AppError::message(format!(
+                "MinerU result zip contains duplicate image `{relative_path}`"
+            )));
+        }
+        if entry.size() > MAX_BODY_IMAGE_ENTRY_BYTES {
+            return Err(AppError::message(format!(
+                "MinerU result image `{relative_path}` is too large"
+            )));
+        }
+        let mut image = Vec::with_capacity(entry.size() as usize);
+        entry
+            .take(MAX_BODY_IMAGE_ENTRY_BYTES + 1)
+            .read_to_end(&mut image)
+            .map_err(|e| AppError::message(format!("MinerU result image read failed: {e}")))?;
+        if image.len() as u64 > MAX_BODY_IMAGE_ENTRY_BYTES {
+            return Err(AppError::message(format!(
+                "MinerU result image `{relative_path}` is too large"
+            )));
+        }
+        total_bytes = total_bytes
+            .checked_add(image.len() as u64)
+            .ok_or_else(|| AppError::message("MinerU result images are too large"))?;
+        if total_bytes > MAX_BODY_IMAGE_BYTES {
+            return Err(AppError::message("MinerU result images are too large"));
+        }
+        assets.push(MineruMarkdownAsset {
+            relative_path,
+            bytes: image,
+        });
+    }
+
+    Ok(MineruMarkdownBundle { markdown, assets })
 }
 
 /// Intermediate-result entry names: `*_middle.json` / `middle.json` in older
@@ -708,6 +817,48 @@ mod tests {
         assert_eq!(pages[1].boxes[0].label, "image");
         assert!((pages[1].boxes[0].coordinate[2] - 612.0).abs() < 1e-9);
         assert!((pages[1].boxes[0].coordinate[3] - 396.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn reads_markdown_bundle_with_figure_assets() {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut cursor);
+            let opts = SimpleFileOptions::default();
+            writer.start_file("task/full.md", opts).unwrap();
+            writer
+                .write_all(b"# Paper\n\n![](images/figure-1.jpg)\n")
+                .unwrap();
+            writer.start_file("task/images/figure-1.jpg", opts).unwrap();
+            writer.write_all(b"jpeg-bytes").unwrap();
+            writer.start_file("task/model.json", opts).unwrap();
+            writer.write_all(b"{}").unwrap();
+            writer.finish().unwrap();
+        }
+
+        let bundle = read_mineru_markdown_bundle(cursor.get_ref()).unwrap();
+        assert!(bundle.markdown.contains("images/figure-1.jpg"));
+        assert_eq!(bundle.assets.len(), 1);
+        assert_eq!(bundle.assets[0].relative_path, "images/figure-1.jpg");
+        assert_eq!(bundle.assets[0].bytes, b"jpeg-bytes");
+    }
+
+    #[test]
+    fn rejects_unsafe_mineru_image_paths() {
+        for path in [
+            "images/../escape.jpg",
+            "images\\..\\escape.jpg",
+            "images/./figure.jpg",
+        ] {
+            let err = safe_mineru_image_path(path).unwrap_err();
+            assert!(err.to_string().contains("unsafe"));
+        }
+        assert!(safe_mineru_image_path("other/figure.jpg")
+            .unwrap()
+            .is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve MinerU `images/` assets alongside `PAPER.md`
- support result ZIPs with a task-directory prefix
- validate archive and output paths before writing files
- add bundle extraction and persistence tests

Fixes #467

## Validation
- `cargo fmt --all -- --check`
- `pnpm exec tsc --noEmit --types node,react,react-dom`
- `git diff --check`
- Rust tests are currently blocked in this Windows environment because the MSVC Windows SDK libraries/linker are unavailable; the code and tests are included for CI.