### PR TITLE
fix(windows): stop console windows flashing on startup and in Diagnostics

### DIFF
--- a/docs/backend/doctor.md
+++ b/docs/backend/doctor.md
@@ -88,6 +88,7 @@ Doctor 聚合本地 Vault 的只读完整性检查，并为论文别名、双链
 
 - `node` / `npm`：解析路径 + `--version`（5s 超时），状态 `available / missing / unusable`；
 - `npm prefix -g`：追加进环境 PATH 后再查 node（覆盖 npm 全局安装但 GUI PATH 缺失的场景）。
+- Windows：探测子进程一律带 `CREATE_NO_WINDOW`（`diagnostic_command` 统一收口）。应用是 GUI 子系统二进制，缺该标志时 Windows 会给每个控制台子进程新建可见控制台——表现为每次打开/刷新问题诊断，每探测一个工具就多一个黑窗（标题即该工具路径，两个 hermes 条目就是两个黑窗）。
 
 Codex 登录状态不再放在主机运行环境；改由 Agent 卡片第三行展示（见下）。
 

--- a/docs/backend/telemetry.md
+++ b/docs/backend/telemetry.md
@@ -32,6 +32,8 @@
 | `custom_agent_count` | 已注册的自定义 Agent 数量（不含名称/命令） |
 | `$session_id` | 本次运行生成的 UUID（PostHog 保留属性，Sessions 口径依赖它） |
 
+> Windows 的 `device_model` 走 `reg query`，该子进程必须带 `CREATE_NO_WINDOW`。发布版是 GUI 子系统二进制，缺这个 flag 时 Windows 会为它分配可见控制台窗口，表现为每次启动都在首帧前闪一下黑窗（`app started` 在 setup 后 `spawn_blocking` 发送，与窗口首帧时间上重叠）。
+
 Person 属性：`$set` → `app_version` / `os_name` / `os_version` / `arch` / `device_model` / `installed_agents` / `custom_agent_count`；`$set_once` → `first_app_version`。`installed_agents` 随每次启动更新，可直接在 PostHog 按 Agent 过滤 / 分群。
 
 ### `app exited`（`RunEvent::Exit` 回调中发送并 flush）

--- a/docs/bug_fix/windows-console-window-flash.md
+++ b/docs/bug_fix/windows-console-window-flash.md
@@ -1,0 +1,118 @@
+# Windows 启动与「问题诊断」弹出黑色控制台窗口
+
+**状态**：已修复（两处控制台子进程补 `CREATE_NO_WINDOW`；分支 `fix/windows-doctor-console-window`，提交 `83f75a0b` / `8fd0216d`）
+**影响面**：Windows 发布版（GUI 子系统）两个独立场景 —— 启动时闪一次黑终端、打开「设置 → 问题诊断」时每探测一个工具弹一个黑窗
+**相关代码**：
+
+- `src-tauri/src/core/telemetry/device.rs` — `raw_device_model()`，新增 `device_model_command()`
+- `src-tauri/src/core/telemetry/mod.rs` — `Telemetry::start` 无条件调用 `collect_device_info()`
+- `src-tauri/src/features/agent/doctor.rs` — `diagnostic_command()` / `run_command()`
+- `src-tauri/src/features/agent/commands/doctor.rs` — `doctor_check_host` / `doctor_check_agents`
+- `src/components/settings/panes/doctor-pane.tsx` — 面板挂载即触发探测
+- 对照实现（均已带该 flag）：`features/agent/registry/lifecycle.rs`、`features/agent/registry/version_check.rs`、`integration/mcp/tunnel.rs`
+- 文档：[`../backend/doctor.md`](../backend/doctor.md)、[`../backend/telemetry.md`](../backend/telemetry.md)
+
+---
+
+## 1. 问题现象
+
+### 1.1 启动时闪一次黑终端
+
+直接运行 `agentero.exe`：启动过程中闪过一个黑终端（极快），随后进入应用。
+
+### 1.2 打开「问题诊断」弹出两个黑窗
+
+进入 设置 → 问题诊断，**无需点击**任何按钮，会弹出黑色终端窗口，且恰好是两个。窗口标题是
+`hermes.exe` 的完整路径；因为 Hermes 冷启动慢，窗口会停留几十秒，不是一闪而过。
+
+> 二次确认时的反直觉现象：用户反馈「官方发布的软件没有遇到过」，但实测官方 0.9.7 同样会弹
+> （见 4.2 的 A/B 数据）。差异只在触发时机 —— 官方那次 `reg` 触发得更早，不易察觉。
+
+## 2. 根因
+
+### 2.1 共性：GUI 子系统 + 控制台子进程缺 `CREATE_NO_WINDOW`
+
+发布版是 `windows_subsystem = "windows"` 的 GUI 进程（PE `Subsystem = 2`）。这类进程 spawn
+**未带 `CREATE_NO_WINDOW`** 的控制台子进程时，Windows 会为子进程分配一个可见控制台 —— 就是看到的黑窗。
+
+本项目其他同类位置（`registry/lifecycle.rs`、`registry/version_check.rs`、`integration/mcp/tunnel.rs`）
+都已带该 flag，只有下面两处是遗漏。
+
+### 2.2 启动路径：telemetry 无条件探测设备型号
+
+`core/telemetry/device.rs` 的 `raw_device_model()`（Windows 分支）用
+
+```
+reg query HKLM\HARDWARE\DESCRIPTION\System\BIOS /v SystemProductName
+```
+
+取硬件型号（macOS 走 `sysctl`、Linux 读 sysfs，Windows 没有更便宜的等价物）。关键在调用时机：
+`Telemetry::start` 里 `install_id()` / `collect_device_info()` 是**无条件**执行的，不受 PostHog
+key 或用户 opt-out 影响，而 `Telemetry::start` 在 Tauri setup 后即被调用 —— 所以**每次启动必闪**。
+
+### 2.3 诊断路径：面板挂载即探测，按注册条目逐个跑
+
+`doctor-pane.tsx` 在 `useEffect` 里直接调 `doctorCheckHost()` + `doctorCheckAgents()`，不需要点击。
+`doctor_check_agents` 对 `agents.json` 里**每一条** Agent 注册项跑一次 `<command> --version`。
+本机注册了两条（`catalog-hermes` 用 `hermes`、自定义 profile 用完整 `hermes.exe` 路径），
+于是出现两个标题相同的黑窗。
+
+## 3. 修复
+
+### 3.1 `doctor.rs`（83f75a0b）
+
+`diagnostic_command` 拆成 `base_command` + `hide_console_window`，Windows 下统一收口
+`creation_flags(CREATE_NO_WINDOW)`，让 cmd / PowerShell / 工具 exe 三条路由共用一处。
+新增 Windows 回归测试钉住命令路由 —— `creation_flags` 在 std 里**没有 getter**，无法直接断言 flag，
+所以测试断言的是 program + args。
+
+### 3.2 `device.rs`（8fd0216d）
+
+抽出 `device_model_command()`，同样加 `creation_flags(CREATE_NO_WINDOW)`；加 Windows 回归测试。
+命令内容与解析逻辑完全不变，设备型号照常采集。
+
+## 4. 验证
+
+### 4.1 单测与静态检查
+
+- `cargo check -p agentero --locked` ✅
+- `cargo test -p agentero --lib features::agent::doctor` → 12 passed ✅
+- `cargo test -p agentero --lib core::telemetry::device` → 1 passed ✅
+- `cargo fmt --all -- --check` 干净；pre-commit（biome + cargo fmt）通过 ✅
+- `pnpm tauri build --config .tauri-build-no-updater.json` 打包成功（NSIS + MSI），
+  产物为 `PE32+ / x86_64 / Subsystem=2 (GUI)` ✅
+
+### 4.2 运行时黑箱验证：`reg.exe` 垫片
+
+5ms 轮询追踪在修复后的构建上**没抓到** `reg`（短命进程，见 4.3），所以改用确定性方法：
+
+写一个 **console 子系统**的同名 `reg.exe` 垫片，实现里调用 `GetConsoleWindow()`：
+
+- 返回 NULL ⇔ 父进程传了 `CREATE_NO_WINDOW`（无窗口）
+- 返回非 NULL ⇔ 会弹黑窗
+
+垫片必须放进**应用目录**（`target/release/` 或安装目录）：CreateProcess 的搜索顺序是
+应用目录 → 当前目录 → System32 → PATH，所以 `PATH` 里的垫片拦不到 `reg`（System32 在 PATH 之前）。
+
+同一个垫片分别喂给两个版本，唯一变量是构建：
+
+| | `reg query` 是否仍被调用 | `GetConsoleWindow()` |
+|---|---|---|
+| 官方 0.9.7 | ✅ 是 | **1 —— 分配控制台窗口（会闪黑框）** |
+| 本修复构建 | ✅ 是 | **0 —— 无控制台窗口** |
+
+结论：`reg query` 功能完整保留（设备型号照常采集），可见控制台窗口消失。这比目视更可靠。
+
+### 4.3 为什么 5ms 轮询不可靠
+
+PowerShell runspace 里「5ms 轮询 `Get-Process` 记录新增 pid」看起来很直接，但每次 `Get-Process`
+都是全量枚举，**实际间隔远大于 5ms**，`reg query` 这类只有几十毫秒的进程经常抓不到。
+命中与否靠运气 —— 别据「没抓到」下结论（本 Bug 排查中先误判过一次）。
+
+## 5. 可复用的排查手法
+
+1. 先确认二进制子系统（PE header 的 `Subsystem` 字段，2=GUI）。GUI + 控制台子进程 = 黑窗前提。
+2. 找可疑 spawn：`grep -n "Command::new" <rs files>`，再逐个查 `CREATE_NO_WINDOW` 覆盖情况。
+3. 用 4.2 的垫片法做确定性验证（优于轮询追踪）。
+4. 应用有 `tauri-plugin-single-instance`：追踪/垫片测试前必须关掉所有实例，否则新进程被转发后直接退出。
+5. 本机环境自身每 ~5.5s 会有一波 `cmd` + `findstr` + `tasklist`（父进程恒定），属噪声，勿计入应用行为。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,7 @@ nav:
       - 版面解析任务一直排队（JobCenter 槽位泄漏）: bug_fix/layout-analyze-job-slot-leak.md
       - 期刊 / venue 取不全（#399）: bug_fix/publication-venue-api.md
       - 导入第三方 Skill 报「description is too long」（#355）: bug_fix/skill-import-description-length.md
+      - Windows 启动与问题诊断弹出黑色控制台窗口: bug_fix/windows-console-window-flash.md
 
 markdown_extensions:
   - admonition

--- a/src-tauri/src/core/telemetry/device.rs
+++ b/src-tauri/src/core/telemetry/device.rs
@@ -5,6 +5,12 @@
 
 use crate::core::paths;
 
+/// `CREATE_NO_WINDOW`: Agentero ships as a GUI-subsystem binary, so a console
+/// child started without this flag makes Windows allocate a visible console
+/// window — a black window flashing over the app on every launch.
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
 #[derive(Debug, Clone)]
 pub(super) struct DeviceInfo {
     pub(super) os_name: String,
@@ -64,15 +70,7 @@ fn raw_device_model() -> Option<String> {
     }
     #[cfg(target_os = "windows")]
     {
-        let out = std::process::Command::new("reg")
-            .args([
-                "query",
-                r"HKLM\HARDWARE\DESCRIPTION\System\BIOS",
-                "/v",
-                "SystemProductName",
-            ])
-            .output()
-            .ok()?;
+        let out = device_model_command().output().ok()?;
         String::from_utf8_lossy(&out.stdout)
             .lines()
             .find_map(|line| line.split("REG_SZ").nth(1))
@@ -82,5 +80,51 @@ fn raw_device_model() -> Option<String> {
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     {
         None
+    }
+}
+
+/// Windows has no `sysctl` equivalent that is cheaper than a registry read, so
+/// the BIOS product name comes from `reg query`. The console window is
+/// suppressed: this runs on every launch from [`super::Telemetry::start`], and
+/// a visible console would flash over the window while it is still painting.
+#[cfg(target_os = "windows")]
+fn device_model_command() -> std::process::Command {
+    use std::os::windows::process::CommandExt;
+
+    let mut command = std::process::Command::new("reg");
+    command
+        .args([
+            "query",
+            r"HKLM\HARDWARE\DESCRIPTION\System\BIOS",
+            "/v",
+            "SystemProductName",
+        ])
+        .creation_flags(CREATE_NO_WINDOW);
+    command
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    /// `creation_flags` has no std getter, so this pins the command the
+    /// no-window wrapper sits on.
+    #[test]
+    fn device_model_command_queries_bios_product_name() {
+        let command = device_model_command();
+        assert_eq!(command.get_program().to_string_lossy(), "reg");
+        let args: Vec<String> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            args,
+            vec![
+                "query",
+                r"HKLM\HARDWARE\DESCRIPTION\System\BIOS",
+                "/v",
+                "SystemProductName",
+            ]
+        );
     }
 }

--- a/src-tauri/src/features/agent/doctor.rs
+++ b/src-tauri/src/features/agent/doctor.rs
@@ -12,6 +12,13 @@ use tokio::process::Command;
 
 const HOST_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Doctor spawns `<tool> --version` probes for every host runtime and registered
+/// Agent. The app ships as a GUI subsystem binary, so a console child without
+/// this flag makes Windows allocate a visible console window — one black window
+/// per probed tool on every Doctor refresh.
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, specta::Type)]
 #[serde(rename_all = "kebab-case")]
 pub enum HostToolStatus {
@@ -96,6 +103,12 @@ fn codex_descriptor(registry: &AgentRegistry) -> Result<AgentDescriptor, AppErro
 }
 
 fn diagnostic_command(path: &Path, args: &[&str]) -> Command {
+    let mut command = base_command(path, args);
+    hide_console_window(&mut command);
+    command
+}
+
+fn base_command(path: &Path, args: &[&str]) -> Command {
     #[cfg(windows)]
     {
         let extension = path
@@ -121,6 +134,17 @@ fn diagnostic_command(path: &Path, args: &[&str]) -> Command {
     let mut command = Command::new(path);
     command.args(args);
     command
+}
+
+fn hide_console_window(command: &mut Command) {
+    #[cfg(windows)]
+    {
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = command;
+    }
 }
 
 async fn run_command(
@@ -338,6 +362,21 @@ mod tests {
             stdout: stdout.to_string(),
             stderr: stderr.to_string(),
         }
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn diagnostic_command_routes_scripts_through_shells() {
+        // `hide_console_window` has no std getter, so guard the routing that the
+        // console-hiding wrapper sits on top of.
+        let cmd = diagnostic_command(Path::new("probe.cmd"), &["--version"]);
+        assert_eq!(cmd.as_std().get_program(), "cmd");
+
+        let ps1 = diagnostic_command(Path::new("probe.ps1"), &["--version"]);
+        assert_eq!(ps1.as_std().get_program(), "powershell");
+
+        let exe = diagnostic_command(Path::new("hermes.exe"), &["--version"]);
+        assert_eq!(exe.as_std().get_program(), "hermes.exe");
     }
 
     #[test]


### PR DESCRIPTION
## 问题

Windows 发布版（GUI 子系统）有两处会弹出黑色控制台窗口：

1. **启动时闪一次**：启动过程中闪过一个黑终端，很快消失；官方 0.9.7 同样存在。
2. **设置 → 问题诊断**：面板一挂载就开始探测，每探测一个工具弹一个黑窗。本机
   `agents.json` 里注册了两条 Agent（`catalog-hermes` 与自定义 Hermes profile），
   所以会同时出现两个标题为 `hermes.exe` 路径的窗口；hermes 冷启动慢，窗口会停留几十秒，
   不是一闪而过。
<img width="1585" height="889" alt="PixPin_2026-09-10_09-40-20" src="https://github.com/user-attachments/assets/b7d0ecc9-8a6d-4e1e-9ab2-51ec7e3662a1" />

## 根因

发布版是 `windows_subsystem = "windows"` 的 GUI 进程，任何**未带 `CREATE_NO_WINDOW`**
的控制台子进程都会让 Windows 为其分配一个可见控制台。

| 位置 | 触发时机 | 缺 flag 的子进程 |
|---|---|---|
| `src-tauri/src/core/telemetry/device.rs` `raw_device_model()` | 每次启动（`Telemetry::start` → `collect_device_info()` 无条件调用，不受 PostHog key / opt-out 影响） | `reg query HKLM\HARDWARE\DESCRIPTION\System\BIOS /v SystemProductName` |
| `src-tauri/src/features/agent/doctor.rs` `diagnostic_command()` | 诊断面板挂载即探测 | `cmd` / `powershell` / `<agent> --version` |

`registry/lifecycle.rs`、`registry/version_check.rs`、`integration/mcp/tunnel.rs` 等同类位置
都已带该 flag，这两处是遗漏。

## 改动

- **`83f75a0b`** `fix(windows): stop doctor probes from opening console windows`
  - `doctor.rs`：`diagnostic_command` 拆成 `base_command` + `hide_console_window`，
    Windows 下统一收口 `creation_flags(CREATE_NO_WINDOW)`；
  - 新增 Windows 回归测试，钉住 cmd / PowerShell / exe 三种命令路由
    （`creation_flags` 在 std 里没有 getter，无法直接断言 flag）；
  - `docs/backend/doctor.md` 补平台约束说明。
- **`8fd0216d`** `fix(windows): stop startup device probe from flashing a console window`
  - `device.rs`：抽出 `device_model_command()` 并加 `creation_flags(CREATE_NO_WINDOW)`；
  - 新增 Windows 回归测试，钉住 program + args 路由；
  - `docs/backend/telemetry.md` 补平台约束说明。
- **`83d4b145`** `docs(windows): add console window flash retrospective`
  - 新增 `docs/bug_fix/windows-console-window-flash.md`（问题现象 / 根因 / 修复 / 验证 /
    可复用的排查手法），并登记进 `mkdocs.yml` 的「Bug 修复记录」导航。

均为 Windows-only 行为修正，不改变命令内容与采集结果。

改动规模：6 files changed, +214 / −9。

## 验证

静态与单测：

- `cargo check -p agentero --locked` ✅
- `cargo test -p agentero --lib features::agent::doctor` → 12 passed ✅
- `cargo test -p agentero --lib core::telemetry::device` → 1 passed ✅
- `cargo fmt --all -- --check` 干净；pre-commit（biome + cargo fmt）通过 ✅
- `pnpm tauri build --config .tauri-build-no-updater.json` 打包成功，产出 NSIS + MSI；
  产物为 `PE32+ / x86_64 / Subsystem=2 (GUI)` ✅

运行时黑箱验证（关键证据）：写了一个 console 子系统的 `reg.exe` 垫片放进**应用目录**
（CreateProcess 搜索顺序里应用目录最先，PATH 里的垫片拦不到），垫片调用
`GetConsoleWindow()` —— 返回 NULL 说明父进程传了 `CREATE_NO_WINDOW`：

| | `reg query` 是否仍被调用 | `GetConsoleWindow()` |
|---|---|---|
| 官方 0.9.7 | ✅ 是 | **1 —— 分配控制台窗口（会闪黑框）**&#8203; |
| 本 PR 构建 | ✅ 是 | **0 —— 无控制台窗口** |

即 `reg query` 功能完整保留（设备型号照常采集），可见控制台窗口消失。
