### PR TITLE
feat(skill): 规范 paper-reader 与 agentero-cli 技能在完成精读后自动标记 is_read

### DIFF
--- a/templates/vault/.agents/skills/agentero-cli/SKILL-windows.md
+++ b/templates/vault/.agents/skills/agentero-cli/SKILL-windows.md
@@ -1,6 +1,6 @@
 ---
 name: agentero-cli
-version: 13
+version: 14
 description: >-
   Use the Agentero CLI (bin `agentero-cli` on Windows) to create, discover, and
   inspect a local research vault and catalog—list/get papers, import by id/URL,
@@ -127,10 +127,14 @@ agentero-cli paper get <path|id> --json
 agentero-cli import id <arxiv|doi|url> --json
 # place the new paper under a specific vault-relative parent (default: papers)
 agentero-cli import id <arxiv|doi|url> --parent papers/nlp --json
-# then write {path}/NOTES.md yourself: preserve user prose, never wipe marks/;
-# `paper set-read <path>` only after notes are done
+# parse body from PDF to PAPER.md if no TeX is present
+agentero-cli paper parse <path> --json
 
-# 6) Tags: paper tag set|add|rm <path|id> … --json (clear: tag set --clear)
+# 6) Note & Read: write {path}/NOTES.md (lecture notes), check wikilinks (`agentero-cli doctor wiki`),
+# then close the loop by marking the paper as read in the catalog:
+agentero-cli paper set-read <path> --json
+
+# 7) Tags: paper tag set|add|rm <path|id> … --json (clear: tag set --clear)
 ```
 
 Cite Vault-relative paths in your answer; end with `## Sources` when substantial.
@@ -165,4 +169,5 @@ others follow this body directly.
 - Keep Obsidian wikilinks `[[...]]` when you edit Markdown.
 - Never invent catalog metadata; trust CLI / files.
 - Never overwrite user-written NOTES without explicit request.
+- Always run `agentero-cli paper set-read <path>` after finishing NOTES.md to update catalog read status.
 - Prefer short tool loops: list → get → read files → answer.

--- a/templates/vault/.agents/skills/agentero-cli/SKILL.md
+++ b/templates/vault/.agents/skills/agentero-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentero-cli
-version: 13
+version: 14
 description: >-
   Use the Agentero CLI (bin `agentero`) to create, discover, and inspect a local
   research vault and catalog—list/get papers, import by id/URL, check wikilinks,
@@ -125,10 +125,14 @@ agentero paper get <path|id> --json
 agentero import id <arxiv|doi|url> --json
 # place the new paper under a specific vault-relative parent (default: papers)
 agentero import id <arxiv|doi|url> --parent papers/nlp --json
-# then write {path}/NOTES.md yourself: preserve user prose, never wipe marks/;
-# `paper set-read <path>` only after notes are done
+# parse body from PDF to PAPER.md if no TeX is present
+agentero paper parse <path> --json
 
-# 6) Tags: paper tag set|add|rm <path|id> … --json (clear: tag set --clear)
+# 6) Note & Read: write {path}/NOTES.md (lecture notes), check wikilinks (`agentero doctor wiki`),
+# then close the loop by marking the paper as read in the catalog:
+agentero paper set-read <path> --json
+
+# 7) Tags: paper tag set|add|rm <path|id> … --json (clear: tag set --clear)
 ```
 
 Cite Vault-relative paths in your answer; end with `## Sources` when substantial.
@@ -163,4 +167,5 @@ others follow this body directly.
 - Keep Obsidian wikilinks `[[...]]` when you edit Markdown.
 - Never invent catalog metadata; trust CLI / files.
 - Never overwrite user-written NOTES without explicit request.
+- Always run `agentero paper set-read <path>` after finishing NOTES.md to update catalog read status.
 - Prefer short tool loops: list → get → read files → answer.

--- a/templates/vault/.agents/skills/paper-reader/SKILL.md
+++ b/templates/vault/.agents/skills/paper-reader/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paper-reader
-version: 2
+version: 3
 description: >-
   Read and explain a research paper clearly (prefer TeX, else PAPER.md/PDF).
   Use for core contribution, method deep-dive, experiments, limitations, and
@@ -179,6 +179,7 @@ term.
    - If this CLI command is unavailable, report that semantic link validation
      was not completed. Do not claim that every link resolves.
 8. End with `## Sources` listing **Vault-relative** paths you actually read.
+9. Mark as read in catalog: run `agentero paper set-read {paper} --json`.
 
 ## Rules
 
@@ -187,3 +188,4 @@ term.
 - Never invent experimental numbers; if something is unclear, say so.
 - Math must use `$...$` / `$$...$$` so Agentero can render it (see vault `AGENTS.md`).
 - Final deliverable path: `{paper}/NOTES.md` only for the lecture notes body.
+- Mark as read on completion: always run `agentero paper set-read {paper} --json` after notes and links are done.


### PR DESCRIPTION
## 问题描述
通过外部 Agent 或终端 CLI 执行论文精读（`paper-reader` 工作流）并写入 `NOTES.md` 后，Catalog 中的 `is_read` 状态未被标记为 `true`，导致客户端仍然显示为未精读状态。

## 根因分析
1. **客户端与外部 Agent 职责割裂**：在桌面端 GUI 中，`paper-reader` 工作流完成后由前端宿主程序（`reader.ts`）兜底调用 `setPaperIsRead(..., true)`。因此模板中的 `paper-reader/SKILL.md` 工作流只定义到了第 8 步（写入 `## Sources`），并未要求 Agent 自行调用 CLI 标记已读。脱离桌面 GUI 运行的 Agent（如终端对话驱动）在执行完工作流后无法闭环。
2. **CLI 技能提示偏弱**：`agentero-cli/SKILL.md` 中仅以单行注释提及 `paper set-read`，未列为标准 SOP 步骤与规则约束，导致外部 Agent 极易遗漏。

## 修复方案
1. **`paper-reader/SKILL.md` 增加闭环步骤与强约束**：
   - 工作流追加第 9 步：明确执行 `agentero paper set-read {paper} --json`；
   - 规则增加 `Mark as read on completion` 要求；
   - 版本号升至 `v3`，以便 `ensure_vault` 自动平滑升级已有 Vault 中的该技能。
2. **`agentero-cli/SKILL.md` 规范化 SOP 与规则**：
   - 将“解析正文 -> 撰写笔记 -> `doctor wiki` 验证双链 -> `set-read` 闭环”显式化为第 6 步标准 SOP；
   - 规则增加已读标记硬约束；
   - 同步更新 Windows 变体 `SKILL-windows.md`（对齐 PowerShell 语法与 `agentero-cli` 命令）；
   - 版本号升至 `v14`。