### PR TITLE
feat(settings): make embedding batch size configurable

### DIFF
--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -2362,6 +2362,7 @@ CLI 不再暴露 usage 命令；查询与清理通过桌面端设置 / Host API 
 - **陈旧短路**：非 `force` 且 `computed_at` 为当天、分类集合一致时，直接返回存量，不发任何网络请求。所以 `vault:opened` 的预热调用通常是零成本的。
 - **缓存**：`embed_cache(text_hash, model, dim, vector)` 按 sha256(title+abstract)+model 存小端 f32 向量，语料只 embed 一次；主键含 model，所以换 embedding 模型不会读到旧向量。`arxiv_rec_state` 单行存上次运行，**不按 model 建键**：切换 embedding 来源后的当天首次运行仍会复用存量结果，除非 `force`（既存行为）。均在 catalog schema v6。
 - **凭据**：读设置 `embedding`。`source`（`"builtin"` | `"custom"`）决定用哪一套：非 `custom` 且本次构建注入了内置 provider key 时用构建期网关三元组，否则用已存的 Base URL / API Key / Model。请求都是 `POST {baseUrl}/embeddings`（OpenAI 兼容）。见 [builtin-provider.md](builtin-provider.md) §Embedding。
+- **批次大小**：库内语料和 arXiv 候选都按 `embedding.batchSize` 对未缓存的摘要分批，默认 64。可在设置 → Agent → Embedding 模型中修改；遇到接口单批最多 8 条的限制时改为 8。连接测试仍只发送一条输入。
 - **结构化错误**（前端转空态）：`recommend.no_embedding` 端点未配置（自定义来源缺字段，或构建无内置 key 且未填 BYOK）、`recommend.empty_corpus` 库里没摘要、`recommend.no_candidates` 分类下无新论文。
 
 前端入口：`src/lib/recommend/`。

--- a/docs/backend/builtin-provider.md
+++ b/docs/backend/builtin-provider.md
@@ -161,7 +161,7 @@
 
 也就是说：已经填过自定义端点的老用户**不会被静默切走**，只有真正全新 / 全空的配置才变成内置。
 
-`embedding_config()` 在解析出的 source 非 `"custom"` 且 `builtin::available()` 时返回网关三元组；否则穿透到已存值。这条链路只服务 arXiv 每日推荐（[../development/plaza.md](../development/plaza.md) §3.4），Host 命令 `recommend_arxiv` 透明继承，无需改动。
+`embedding_config()` 在解析出的 source 非 `"custom"` 且 `builtin::available()` 时使用网关凭据；否则穿透到已存值，并随凭据返回用户设置的 `embedding.batchSize`（默认 64）。这条链路只服务 arXiv 每日推荐（[../development/plaza.md](../development/plaza.md) §3.4），Host 命令 `recommend_arxiv` 透明继承。
 
 向量缓存安全：`embed_cache` 的主键是 `(text_hash, model)`（`catalog/schema.rs` v6），所有读写都按 model 过滤，所以换 embedding 模型不会读到旧向量。
 

--- a/docs/backend/settings.md
+++ b/docs/backend/settings.md
@@ -22,7 +22,8 @@
 settings 不存内置 provider 的任何凭证；它只在**读取时**把 id `agentero` 解析到构建期注入的凭证（见 [builtin-provider.md](builtin-provider.md)）。
 
 - **`embedding.source`**（`"builtin"` | `"custom"`）：普通 `#[serde(default)]`，空串即「未设置」，**不是**返回 `"builtin"` 的 default fn——否则一个填了 BYOK 端点但没有 `source` 键的旧 `settings.json`，与「用户显式选了内置」无法区分。`normalize()` 里的 `resolve_embedding_source()` 推断：显式值优先 → `baseUrl`/`apiKey`/`model` 任一非空（全 `*` 掩码也算非空）⇒ `custom` → 三项全空 ⇒ `builtin`。该规则必须与前端 `normalizeEmbeddingSettings` **逐条一致**（它在 Host load、legacy 迁移、每次保存、`settings_set` 回显、`settings:changed` 时都会跑）。已填过自定义端点的老用户不会被静默切走。
-- **`embedding_config()`**：source 非 `custom` 且 `builtin::available()` 时返回网关三元组；无编译期 key 时穿透到已存值，仍为空则 `None`，让 `recommend.no_embedding` 照常触发。
+- **`embedding.batchSize`**：每次 embedding 请求的最大输入条数，默认 **64**；旧配置缺少该字段时同样使用 64，0 在 Host 归一化时回退到 64。设置 → Agent → Embedding 模型中可填写正整数，内置和自定义来源均生效；例如接口单批上限为 8 时设为 **8**，保存后刷新 arXiv Daily。
+- **`embedding_config()`**：返回 `(base_url, api_key, model, batch_size)`；source 非 `custom` 且 `builtin::available()` 时凭据取自内置网关，否则使用已存值，缺少端点配置则 `None`，让 `recommend.no_embedding` 照常触发。批次大小始终取自用户设置。
 - **`layout_api_key` / `layout_base_url` / `layout_model`** 在 **getter 层**特判内置 id，这样所有调用方（`body_engines/mod.rs`、`layout/hosted/commands.rs`）自动正确，不必各自加分支。`layout_prompt` / `layout_language` / `layout_is_ocr` **不特判** → `None` / `None` / `false`：提示词由 VLM 引擎按 model id 推导，后两项是 MinerU 专用。
 - **`layout_provider_settings_key("agentero")`** 返回 `"agentero"`，只为给 parser 凭证 `HashMap` 一个稳定的键；它不对应任何落盘卡片。
 - **`PARSER_BACKENDS` vs `LAYOUT_BACKENDS`**：前者含 `agentero`，后者**不含**。`normalize()` 在每次保存时都会跑并把未列入的 backend 重置为默认值、由 `persist` 写盘，所以白名单就是「选择能否留存」的开关。`default_layout_backend()` 无条件 `"local"`；`default_translate_provider()` 与 `default_parser_backend()` 在 `builtin::available()` 时返回 `agentero`。

--- a/docs/development/plaza.md
+++ b/docs/development/plaza.md
@@ -227,6 +227,7 @@ papers.cool 给几乎所有链接都加了 `target="_blank"`（单个分区页�
 **取舍**
 
 - 首次或大库的整库 embedding 会慢一次（上千篇），之后靠 `embed_cache` 只增量；候选每天仅数十篇。接受首启一次性成本，换掉「每次都重算」。
+- embedding 批次大小可在设置 → Agent → Embedding 模型中调整（`embedding.batchSize`，默认 64），内置和自定义来源均生效。接口单批上限较小时手动调小，例如改为 8；较小批次会增加首次计算的请求次数。
 - 分类/Top-N 不做设置项：Top-20 是常量，分类留在 header。少一层配置面板。
 - `embed_cache` 主键是 `(text_hash, model)`，所以换 embedding 模型是缓存 miss、整库重 embed 一次（不是维度混用）；打分处的维度不匹配记 0 分只是防御性兜底。换来源后建议点一次刷新，见下条。
 - **`arxiv_rec_state` 不按 model 建键**：当天已排序的结果在切换 embedding 来源后的首次运行仍会被复用（陈旧短路只看 `computed_at` 是否当天 + 分类集合是否一致），除非 `force`。既存行为，未随内置 provider 一起改。

--- a/docs/frontend/settings.md
+++ b/docs/frontend/settings.md
@@ -103,6 +103,10 @@
   - `custom`：渲染 vault 内 `.agentero/templates/NOTES.md`（变量 `{{title}} {{authors}} {{year}} {{date}} {{abstract}} {{arxiv_id}} {{doi}} {{url}} {{id}}`，`{{abstract}}` 为原文不翻译，未知变量原样保留；模板缺失回退 standard）。选中该项时显示模板路径与「生成起始模板」按钮（`notes_template_seed`，仅当模板不存在时写入）。
   - 所有模式产物都保证含 aliases frontmatter；只影响新导入，不改存量笔记。
 
+## Embedding 批次大小
+
+设置 → Agent → Embedding 模型提供「批次大小」数字输入框，默认 **64**，内置和自定义接口均可调整。填写正整数后失焦或按 Enter 保存；无效输入恢复为已保存的值。遇到 embedding 接口单批最多 8 条的错误时，改为 **8**，再刷新 arXiv Daily。
+
 ## i18n
 
 - 用户文案一律 `t()` / `react-i18next`；en 源语言，同步 `zh-CN`。

--- a/src-tauri/src/features/paper/discovery/recommend/commands.rs
+++ b/src-tauri/src/features/paper/discovery/recommend/commands.rs
@@ -102,8 +102,8 @@ pub async fn probe_embedding(
     let settings = app.state::<AppSettingsStore>();
     let uses_builtin = settings.embedding_is_builtin();
     let stored = settings.embedding_config();
-    let (base_url, api_key, model) = match stored {
-        Some(triple) => triple,
+    let (base_url, api_key, model, _) = match stored {
+        Some(config) => config,
         None => return ApiResult::err(AppError::message(ERR_NO_EMBEDDING)),
     };
     // The built-in key is shared, not the caller's, so an override would let

--- a/src-tauri/src/features/paper/discovery/recommend/mod.rs
+++ b/src-tauri/src/features/paper/discovery/recommend/mod.rs
@@ -29,8 +29,6 @@ pub const DEFAULT_TOP_N: usize = 20;
 
 /// Cap on abstracts embedded per request so one run cannot fan out unbounded.
 const MAX_CORPUS: usize = 2_000;
-/// Abstracts per `/embeddings` call. Large batches trip provider input limits.
-const EMBED_BATCH: usize = 64;
 /// Chars of an abstract sent for embedding (providers cap tokens per input).
 const MAX_EMBED_CHARS: usize = 4_000;
 const FEED_TIMEOUT: Duration = Duration::from_secs(30);
@@ -487,6 +485,7 @@ async fn embed_all(
     api_key: Option<&str>,
     model: &str,
     texts: &[String],
+    batch_size: usize,
 ) -> Result<Vec<Vec<f32>>, AppError> {
     let hashes: Vec<String> = texts.iter().map(|t| text_hash(t)).collect();
     let cached = {
@@ -510,7 +509,7 @@ async fn embed_all(
         .build()
         .map_err(|e| AppError::message(format!("recommend http client: {e}")))?;
     let mut fresh: Vec<(String, Vec<f32>)> = Vec::new();
-    for chunk in missing.chunks(EMBED_BATCH) {
+    for chunk in missing.chunks(batch_size.max(1)) {
         let inputs: Vec<String> = chunk.iter().map(|(_, t)| t.clone()).collect();
         let vectors = embed_batch(&client, endpoint, api_key, model, &inputs).await?;
         for ((hash, _), vector) in chunk.iter().zip(vectors) {
@@ -568,14 +567,14 @@ fn time_decay_weights(len: usize) -> Vec<f32> {
 
 /// Recompute recommendations, or return the stored run when it is still fresh.
 ///
-/// `settings` is the resolved embedding endpoint `(base_url, api_key, model)`;
+/// `embedding` is the resolved endpoint `(base_url, api_key, model, batch_size)`;
 /// callers read it from `AppSettingsStore` before awaiting.
 pub async fn recommend(
     vault_root: &Path,
     requested_categories: Option<Vec<String>>,
     top_n: Option<usize>,
     force: bool,
-    embedding: Option<(String, Option<String>, String)>,
+    embedding: Option<(String, Option<String>, String, usize)>,
 ) -> Result<RecommendResult, AppError> {
     let categories = {
         let vault = vault_root.to_path_buf();
@@ -597,7 +596,7 @@ pub async fn recommend(
         }
     }
 
-    let Some((base_url, api_key, model)) = embedding else {
+    let Some((base_url, api_key, model, batch_size)) = embedding else {
         return Err(AppError::message(ERR_NO_EMBEDDING));
     };
     let endpoint = resolve_endpoint(&base_url);
@@ -642,6 +641,7 @@ pub async fn recommend(
         api_key.as_deref(),
         &model,
         &corpus_texts,
+        batch_size,
     )
     .await?;
     let mut candidate_vectors = embed_all(
@@ -650,6 +650,7 @@ pub async fn recommend(
         api_key.as_deref(),
         &model,
         &candidate_texts,
+        batch_size,
     )
     .await?;
     for v in corpus_vectors.iter_mut() {
@@ -707,6 +708,71 @@ pub async fn recommend(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn embedding_batch_size_limits_requests_and_preserves_cache() {
+        use axum::{http::StatusCode, routing::post, Json, Router};
+        use std::sync::{Arc, Mutex};
+
+        let batches = Arc::new(Mutex::new(Vec::new()));
+        let observed = batches.clone();
+        let app = Router::new().route(
+            "/embeddings",
+            post(move |Json(body): Json<serde_json::Value>| {
+                let observed = observed.clone();
+                async move {
+                    let inputs = body["input"].as_array().unwrap();
+                    observed.lock().unwrap().push(inputs.len());
+                    if inputs.len() > 8 {
+                        return (
+                            StatusCode::UNPROCESSABLE_ENTITY,
+                            Json(serde_json::json!({"error": "maximum batch size is 8"})),
+                        );
+                    }
+                    let data: Vec<_> = inputs
+                        .iter()
+                        .map(|input| {
+                            let n: f32 = input.as_str().unwrap().parse().unwrap();
+                            serde_json::json!({"embedding": [n, 1.0]})
+                        })
+                        .collect();
+                    (StatusCode::OK, Json(serde_json::json!({"data": data})))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}/embeddings", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let vault = tempfile::tempdir().unwrap();
+        let mut texts: Vec<String> = (0..65).map(|n| n.to_string()).collect();
+        texts.push(texts[0].clone());
+
+        let error = embed_all(vault.path(), &endpoint, None, "test", &texts, 64)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("422"), "{error}");
+        assert_eq!(*batches.lock().unwrap(), vec![64]);
+
+        let vectors = embed_all(vault.path(), &endpoint, None, "test", &texts, 8)
+            .await
+            .unwrap();
+        let expected: Vec<Vec<f32>> = texts
+            .iter()
+            .map(|text| vec![text.parse().unwrap(), 1.0])
+            .collect();
+        assert_eq!(vectors, expected);
+        assert_eq!(
+            *batches.lock().unwrap(),
+            vec![64, 8, 8, 8, 8, 8, 8, 8, 8, 1]
+        );
+
+        // Changing the limit must keep existing vectors usable without a server.
+        server.abort();
+        let cached = embed_all(vault.path(), &endpoint, None, "test", &texts, 64)
+            .await
+            .unwrap();
+        assert_eq!(cached, expected);
+    }
 
     #[test]
     fn weights_favor_recent_and_sum_to_one() {

--- a/src-tauri/src/features/paper/discovery/recommend/mod.rs
+++ b/src-tauri/src/features/paper/discovery/recommend/mod.rs
@@ -766,7 +766,6 @@ mod tests {
             vec![64, 8, 8, 8, 8, 8, 8, 8, 8, 1]
         );
 
-        // Changing the limit must keep existing vectors usable without a server.
         server.abort();
         let cached = embed_all(vault.path(), &endpoint, None, "test", &texts, 64)
             .await

--- a/src-tauri/src/features/system/settings/mod.rs
+++ b/src-tauri/src/features/system/settings/mod.rs
@@ -200,7 +200,7 @@ pub struct PdfAskSettings {
 
 /// Embedding endpoint: the built-in provider, or a custom OpenAI-compatible
 /// one (BYOK). Custom with all-empty fields = feature disabled.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, specta::Type)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct EmbeddingSettings {
     /// `builtin` | `custom`; empty = unset and inferred from the fields below.
@@ -212,6 +212,25 @@ pub struct EmbeddingSettings {
     pub api_key: String,
     #[serde(default)]
     pub model: String,
+    /// Maximum inputs per embedding request.
+    #[serde(default = "default_embedding_batch_size")]
+    pub batch_size: usize,
+}
+
+fn default_embedding_batch_size() -> usize {
+    64
+}
+
+impl Default for EmbeddingSettings {
+    fn default() -> Self {
+        Self {
+            source: String::new(),
+            base_url: String::new(),
+            api_key: String::new(),
+            model: String::new(),
+            batch_size: default_embedding_batch_size(),
+        }
+    }
 }
 
 /// One column in the papers Library table: array order = display order.
@@ -733,10 +752,10 @@ impl AppSettingsStore {
             .is_ok_and(|guard| embedding_uses_builtin(&guard.embedding))
     }
 
-    /// Resolve the embedding endpoint (base URL, API key, model): the built-in
+    /// Resolve the embedding endpoint (base URL, API key, model, batch size): the built-in
     /// gateway unless the source is custom. None when a custom endpoint is
     /// incomplete, which is what disables arXiv recommendations.
-    pub fn embedding_config(&self) -> Option<(String, Option<String>, String)> {
+    pub fn embedding_config(&self) -> Option<(String, Option<String>, String, usize)> {
         let guard = self.inner.lock().ok()?;
         if embedding_uses_builtin(&guard.embedding) {
             let status = builtin::status();
@@ -744,6 +763,7 @@ impl AppSettingsStore {
                 status.base_url,
                 builtin::api_key().map(str::to_string),
                 status.embedding_model,
+                guard.embedding.batch_size,
             ));
         }
         let base_url = guard.embedding.base_url.trim();
@@ -757,7 +777,12 @@ impl AppSettingsStore {
         } else {
             Some(api_key.to_string())
         };
-        Some((base_url.to_string(), key, model.to_string()))
+        Some((
+            base_url.to_string(),
+            key,
+            model.to_string(),
+            guard.embedding.batch_size,
+        ))
     }
 
     /// Raw `(tunnel_id, api_key)` for the built-in ChatGPT tunnel supervisor.
@@ -1054,6 +1079,9 @@ fn normalize(s: &mut AppSettings) {
     s.embedding.api_key = s.embedding.api_key.trim().to_string();
     s.embedding.model = s.embedding.model.trim().to_string();
     s.embedding.source = resolve_embedding_source(&s.embedding);
+    if s.embedding.batch_size == 0 {
+        s.embedding.batch_size = default_embedding_batch_size();
+    }
 
     normalize_translate_provider_configs(&mut s.translate.provider_configs);
     s.translate.agent_id = s.translate.agent_id.trim().to_string();
@@ -1600,6 +1628,7 @@ mod tests {
         let mut fresh = AppSettings::default();
         normalize(&mut fresh);
         assert_eq!(fresh.embedding.source, "builtin");
+        assert_eq!(fresh.embedding.batch_size, 64);
 
         // Legacy file: BYOK fields populated, no `source` key at all.
         let mut legacy: AppSettings = serde_json::from_str(
@@ -1609,6 +1638,7 @@ mod tests {
         assert_eq!(legacy.embedding.source, "");
         normalize(&mut legacy);
         assert_eq!(legacy.embedding.source, "custom");
+        assert_eq!(legacy.embedding.batch_size, 64);
 
         // An explicit choice wins over inference from the other fields.
         let mut explicit = AppSettings::default();
@@ -1631,14 +1661,31 @@ mod tests {
     }
 
     #[test]
+    fn embedding_batch_size_roundtrips_and_rejects_zero() {
+        let mut settings: AppSettings =
+            serde_json::from_str(r#"{"embedding":{"batchSize":8}}"#).expect("deserialize");
+        normalize(&mut settings);
+        assert_eq!(settings.embedding.source, "builtin");
+        assert_eq!(settings.embedding.batch_size, 8);
+        let json = serde_json::to_string(&settings).expect("serialize");
+        let restored: AppSettings = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(restored.embedding.batch_size, 8);
+
+        settings.embedding.batch_size = 0;
+        normalize(&mut settings);
+        assert_eq!(settings.embedding.batch_size, 64);
+    }
+
+    #[test]
     fn embedding_config_prefers_builtin_unless_custom() {
         let status = builtin::status();
         let store = AppSettingsStore::for_tests(AppSettings::default());
         match store.embedding_config() {
-            Some((base_url, api_key, model)) => {
+            Some((base_url, api_key, model, batch_size)) => {
                 assert!(builtin::available(), "no key compiled in → no config");
                 assert_eq!(base_url, status.base_url);
                 assert_eq!(model, status.embedding_model);
+                assert_eq!(batch_size, 64);
                 assert!(api_key.is_some());
             }
             None => {
@@ -1652,6 +1699,7 @@ mod tests {
                 base_url: "https://embed.test/v1".into(),
                 api_key: "sk-custom-test".into(),
                 model: "bge-m3".into(),
+                batch_size: 8,
             },
             ..AppSettings::default()
         });
@@ -1660,7 +1708,8 @@ mod tests {
             Some((
                 "https://embed.test/v1".into(),
                 Some("sk-custom-test".into()),
-                "bge-m3".into()
+                "bge-m3".into(),
+                8
             ))
         );
     }
@@ -1678,12 +1727,13 @@ mod tests {
                 base_url: "https://embed.test/v1".into(),
                 api_key: "sk-custom-test".into(),
                 model: "bge-m3".into(),
+                ..EmbeddingSettings::default()
             },
             ..AppSettings::default()
         });
         assert!(!custom.embedding_is_builtin());
         assert_eq!(
-            custom.embedding_config().map(|(base, _, _)| base),
+            custom.embedding_config().map(|(base, _, _, _)| base),
             Some("https://embed.test/v1".into())
         );
     }

--- a/src-tauri/src/features/system/settings/mod.rs
+++ b/src-tauri/src/features/system/settings/mod.rs
@@ -212,13 +212,8 @@ pub struct EmbeddingSettings {
     pub api_key: String,
     #[serde(default)]
     pub model: String,
-    /// Maximum inputs per embedding request.
     #[serde(default = "default_embedding_batch_size")]
     pub batch_size: usize,
-}
-
-fn default_embedding_batch_size() -> usize {
-    64
 }
 
 impl Default for EmbeddingSettings {
@@ -470,6 +465,9 @@ fn default_mcp_port() -> u16 {
 }
 fn default_batch_import_concurrency() -> u32 {
     5
+}
+fn default_embedding_batch_size() -> usize {
+    64
 }
 fn default_translate_target() -> String {
     "ui".into()

--- a/src/components/settings/panes/agent/agent-embedding-block.tsx
+++ b/src/components/settings/panes/agent/agent-embedding-block.tsx
@@ -280,6 +280,33 @@ export function AgentEmbeddingBlock({
 						</SettingsRow>
 					</>
 				) : null}
+				<SettingsRow
+					label={t("agent.embedding.batchSize.label")}
+					htmlFor="agent-embedding-batch-size"
+				>
+					<Input
+						key={embedding.batchSize}
+						id="agent-embedding-batch-size"
+						type="number"
+						min={1}
+						step={1}
+						defaultValue={embedding.batchSize}
+						onBlur={(e) => {
+							const batchSize = e.currentTarget.valueAsNumber;
+							if (!Number.isSafeInteger(batchSize) || batchSize < 1) {
+								e.currentTarget.value = String(embedding.batchSize);
+								return;
+							}
+							if (batchSize !== embedding.batchSize) {
+								commitEmbedding({ batchSize });
+							}
+						}}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") e.currentTarget.blur();
+						}}
+						className="h-8 w-28"
+					/>
+				</SettingsRow>
 			</SettingsGroup>
 		</>
 	);

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -255,6 +255,9 @@
 			"model": {
 				"label": "Model"
 			},
+			"batchSize": {
+				"label": "Batch size"
+			},
 			"test": "Test connection",
 			"testing": "Testing…",
 			"probeStatus": {

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -255,6 +255,9 @@
 			"model": {
 				"label": "模型"
 			},
+			"batchSize": {
+				"label": "批次大小"
+			},
 			"test": "测试连接",
 			"testing": "测试中…",
 			"probeStatus": {

--- a/src/lib/core/bindings.ts
+++ b/src/lib/core/bindings.ts
@@ -2333,7 +2333,6 @@ export type EmbeddingSettings = {
 	baseUrl?: string,
 	apiKey?: string,
 	model?: string,
-	/**  Maximum inputs per embedding request. */
 	batchSize?: number,
 };
 

--- a/src/lib/core/bindings.ts
+++ b/src/lib/core/bindings.ts
@@ -2333,6 +2333,8 @@ export type EmbeddingSettings = {
 	baseUrl?: string,
 	apiKey?: string,
 	model?: string,
+	/**  Maximum inputs per embedding request. */
+	batchSize?: number,
 };
 
 export type EnabledResponse = {

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -18,6 +18,7 @@ export const DEFAULT_EMBEDDING_SETTINGS: EmbeddingSettings = {
 	baseUrl: "",
 	apiKey: "",
 	model: "",
+	batchSize: 64,
 };
 
 /** Default Translator Runtime endpoint (overridable in Settings). */

--- a/src/lib/settings/store.ts
+++ b/src/lib/settings/store.ts
@@ -586,6 +586,13 @@ function normalizeEmbeddingSettings(
 	if (typeof raw.baseUrl === "string") base.baseUrl = raw.baseUrl.trim();
 	if (typeof raw.apiKey === "string") base.apiKey = raw.apiKey.trim();
 	if (typeof raw.model === "string") base.model = raw.model.trim();
+	if (
+		typeof raw.batchSize === "number" &&
+		Number.isSafeInteger(raw.batchSize) &&
+		raw.batchSize > 0
+	) {
+		base.batchSize = raw.batchSize;
+	}
 	// Wire `source` is a plain string (empty on a fresh install); narrow it here.
 	base.source = resolveEmbeddingSource(
 		(raw as { source?: unknown }).source,

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -319,6 +319,5 @@ export type EmbeddingSettings = {
 	apiKey: string;
 	/** Embedding model id, e.g. `text-embedding-3-small`, `BAAI/bge-m3`. */
 	model: string;
-	/** Maximum inputs per embedding request. */
 	batchSize: number;
 };

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -319,4 +319,6 @@ export type EmbeddingSettings = {
 	apiKey: string;
 	/** Embedding model id, e.g. `text-embedding-3-small`, `BAAI/bge-m3`. */
 	model: string;
+	/** Maximum inputs per embedding request. */
+	batchSize: number;
 };

--- a/test/settings-builtin-provider.test.ts
+++ b/test/settings-builtin-provider.test.ts
@@ -138,3 +138,31 @@ describe("embedding source migration", () => {
 		expect(next.model).toBe("text-embedding-3-small");
 	});
 });
+
+describe("embedding batch size", () => {
+	it("keeps the default for fresh installs and legacy settings", () => {
+		expect(DEFAULT_SETTINGS.embedding.batchSize).toBe(64);
+		expect(normalizeEmbedding({ model: "bge-m3" }).batchSize).toBe(64);
+	});
+
+	it.each([
+		"builtin",
+		"custom",
+	])("preserves a manual limit for %s", (source) => {
+		const next = normalizeEmbedding({ source, batchSize: 8 });
+		expect(next.batchSize).toBe(8);
+		expect(next.source).toBe(source);
+	});
+
+	it.each([
+		0,
+		-1,
+		1.5,
+		Number.NaN,
+		Number.POSITIVE_INFINITY,
+		"8",
+		null,
+	])("falls back to 64 for invalid input %s", (batchSize) => {
+		expect(normalizeEmbedding({ batchSize }).batchSize).toBe(64);
+	});
+});


### PR DESCRIPTION
arXiv Daily 原先固定每批发送 64 条 embedding 输入，遇到单批上限为 8 的服务时会返回 422。

  在「设置 → Agent → Embedding 模型」中新增批次大小设置，允许用户按服务限制手动调整。

  - 默认保持 64，兼容旧配置，内置和自定义来源均生效。
  - 论文库摘要和 arXiv 候选按配置分批，继续复用向量缓存。
  - 支持正整数输入，失焦或按 Enter 保存，无效输入恢复为已保存值。
  - 补充相关测试、中英文设置文案和文档。

  已完成验证：
  - 前端设置测试、TypeScript 类型检查及相关 Rust 测试通过。
  - 验证默认值、旧配置兼容、输入校验、请求分批及缓存复用。
  - 使用 bge-m3 实测：批次 64 复现 422；改为 8 后正常生成 20 条推荐。
